### PR TITLE
Endrer select sin value verdi til å være på samme formatet som output

### DIFF
--- a/components/src/components/Select/Select.stories.tsx
+++ b/components/src/components/Select/Select.stories.tsx
@@ -48,8 +48,8 @@ export const Overview = (args: SelectProps) => {
     <DDSSelect {...args} label={args.label || 'Label'} errorMessage='Dette er en feilmelding' items={items} />
     <DDSSelect {...args} label={args.label || 'Label'} tip='Dette er en hjelpetekst' items={items} />
     <DDSSelect {...args} label={args.label || 'Label'} placeholder='Annerledes placeholder' items={items} />
-    <DDSSelect {...args} label={args.label || 'Label'} defaultValue='Alternativ 4' items={items} />
-    <DDSSelect {...args} label={args.label || 'Label'} value='Alternativ 2' items={items} />
+    <DDSSelect {...args} label={args.label || 'Label'} defaultValue= 'Alternativ 4' items={items} />
+    <DDSSelect {...args} label={args.label || 'Label'} value={{value: 'Alternativ 4', label: 'Alternativ 4'}} items={items} />
     </>,
     '25px',
     2

--- a/components/src/components/Select/Select.tsx
+++ b/components/src/components/Select/Select.tsx
@@ -225,7 +225,7 @@ export type SelectProps = {
     tip?: string;
     width?: string;
     loading?: boolean,
-    value?: string,
+    value?: {value: string, label: string},
     defaultValue?: string,
     className?: string;
     style?: React.CSSProperties;
@@ -257,8 +257,8 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
             options,
             placeholder,
             required,
-            value: value ? { value: value, label: value } : undefined,
-            defaultValue: { value: defaultValue, label: defaultValue },
+            value: value,
+            defaultValue: {value: defaultValue, label: defaultValue},
             isDisabled: disabled || readOnly,
             isClearable: true,
             inputId: uniqueId,


### PR DESCRIPTION
Forrige PR la til muligheten for å legge til value som prop til Select komponenten. Når man wrapper Select komponenten i en controller i react-hook-form, sendes value som en av flere props inn til child komponenten. React-hook-form går ut i fra at formatet i value er det samme som komponenten returnerer, i dette tilfellet stemmet ikke det, da Select returner et objekt på formen {value: string, label: string}, men tok inn en string. Når hook-form prøvde å gi inn objektet som value, resulterte det i en slik feil:

`Uncaught Error: Objects are not valid as a React child (found: object with keys {value, label}). If you meant to render a collection of children, use an array instead.`

Denne PRen endre value slik at den er på samme form som Select returnerer.