### PR TITLE
fixed issue where bullets in List were not showing

### DIFF
--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@norges-domstoler/dds-components",
-  "version": "0.0.9",
+  "version": "0.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/components/src/components/List/List.tsx
+++ b/components/src/components/List/List.tsx
@@ -48,13 +48,22 @@ const StyledList = styled.ul<StyledListProps>`
               left: 0;
               background-size: contain;
               background-repeat: no-repeat;
-              background-image: url(${bullet});
+              // disable eslint to ensure double quotes in url due to svg data URI in image bundle that requires them, as the attributes use single quotes
+              // eslint-disable-next-line
+              // prettier-ignore
+              background-image: url("${bullet}");
             }
             ul > li:before {
-              background-image: url(${bulletLvl2});
+              // disable eslint to ensure double quotes in url due to svg data URI in image bundle that requires them, as the attributes use single quotes
+              // eslint-disable-next-line
+              // prettier-ignore
+              background-image: url("${bulletLvl2}");
             }
             ul > li > ul > li:before {
-              background-image: url(${bulletLvl3});
+              // disable eslint to ensure double quotes in url due to svg data URI in image bundle that requires them, as the attributes use single quotes
+              // eslint-disable-next-line
+              // prettier-ignore
+              background-image: url("${bulletLvl3}");
             }
           }
         `


### PR DESCRIPTION
due to usage of rollup image plugin svg bullets were bundled as svg data URI. attributes in these use single quotes, making it necessary to wrap them in double quotes.