### PR TITLE
UU-forbedring i SortCell

### DIFF
--- a/components/src/components/Table/SortCell.spec.tsx
+++ b/components/src/components/Table/SortCell.spec.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render } from '@testing-library/react';
+import { Table, Row, Head, SortCell } from '.';
+
+describe('<SortCell />', () => {
+  it('should run onclick event', () => {
+    const event = jest.fn();
+    const { container } = render(
+      <Table>
+        <Head>
+          <Row>
+            <SortCell onClick={event}></SortCell>
+          </Row>
+        </Head>
+      </Table>
+    );
+    const sortButton = container.querySelector('th')?.querySelector('button');
+    fireEvent.click(sortButton!);
+    expect(event).toHaveBeenCalled();
+  });
+
+  it('should have aria-sort', () => {
+    const { container } = render(
+      <Table>
+        <Head>
+          <Row>
+            <SortCell sortOrder="ascending" onClick={() => {}}></SortCell>
+          </Row>
+        </Head>
+      </Table>
+    );
+    const sortCell = container.querySelector('th');
+    expect(sortCell!.getAttribute('aria-sort')).toBe('ascending');
+  });
+});

--- a/components/src/components/Table/SortCell.tsx
+++ b/components/src/components/Table/SortCell.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, MouseEvent } from 'react';
 import { Cell, TableCellProps } from './Cell';
 import { cellTokens as tokens } from './Cell.tokens';
 import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
@@ -13,8 +13,14 @@ const SortIconWrapper = styled(IconWrapper)`
   ${tokens.head.sortCell.icon.base}
 `;
 
-const StyledCell = styled(Cell)`
+const StyledButton = styled.button`
+  background: none;
+  color: inherit;
+  border: none;
+  padding: 0;
+  font: inherit;
   cursor: pointer;
+  outline: inherit;
 `;
 
 export type SortOrder = 'ascending' | 'descending' | 'none';
@@ -22,10 +28,11 @@ export type SortOrder = 'ascending' | 'descending' | 'none';
 export type SortCellProps = {
   isSorted?: boolean;
   sortOrder?: SortOrder;
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
 } & Omit<TableCellProps, 'type'>;
 
 export const SortCell = forwardRef<HTMLTableHeaderCellElement, SortCellProps>(
-  ({ isSorted, sortOrder, children, ...rest }, ref) => {
+  ({ isSorted, sortOrder, onClick, children, ...rest }, ref) => {
     const IconRenderer = (isSorted?: boolean, sortOrder?: SortOrder) => {
       const Wrapper = (
         Icon: OverridableComponent<
@@ -42,9 +49,16 @@ export const SortCell = forwardRef<HTMLTableHeaderCellElement, SortCellProps>(
     };
 
     return (
-      <StyledCell ref={ref} type="head" {...rest}>
-        {children} {IconRenderer(isSorted, sortOrder)}
-      </StyledCell>
+      <Cell
+        ref={ref}
+        type="head"
+        aria-sort={sortOrder !== 'none' ? sortOrder : undefined}
+        {...rest}
+      >
+        <StyledButton onClick={onClick}>
+          {children} {IconRenderer(isSorted, sortOrder)}
+        </StyledButton>
+      </Cell>
     );
   }
 );


### PR DESCRIPTION
`onClick`-events bør være lagt på `buttons`. Wrapper derfor innholdet i `SortCell` i en `button`. Gjør samtidig `onClick` påkrevd.

Legger også på en `aria-sort` på cell-en som viser at kolonnen er sortert.