### PR TITLE
Opprydding og småfiks i SortCell

### DIFF
--- a/components/src/components/Table/SortCell.spec.tsx
+++ b/components/src/components/Table/SortCell.spec.tsx
@@ -24,7 +24,11 @@ describe('<SortCell />', () => {
       <Table>
         <Head>
           <Row>
-            <SortCell sortOrder="ascending" onClick={() => {}}></SortCell>
+            <SortCell
+              isSorted={true}
+              sortOrder="ascending"
+              onClick={() => {}}
+            ></SortCell>
           </Row>
         </Head>
       </Table>

--- a/components/src/components/Table/SortCell.tsx
+++ b/components/src/components/Table/SortCell.tsx
@@ -5,8 +5,6 @@ import KeyboardArrowDownIcon from '@material-ui/icons/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
 import UnfoldMoreIcon from '@material-ui/icons/UnfoldMore';
 import { IconWrapper } from '../../helpers/IconWrapper';
-import { OverridableComponent } from '@material-ui/core/OverridableComponent';
-import { SvgIconTypeMap } from '@material-ui/core/SvgIcon';
 import styled from 'styled-components';
 
 const SortIconWrapper = styled(IconWrapper)`
@@ -23,7 +21,7 @@ const StyledButton = styled.button`
   outline: inherit;
 `;
 
-export type SortOrder = 'ascending' | 'descending' | 'none';
+export type SortOrder = 'ascending' | 'descending';
 
 export type SortCellProps = {
   isSorted?: boolean;
@@ -31,34 +29,29 @@ export type SortCellProps = {
   onClick: (event: MouseEvent<HTMLButtonElement>) => void;
 } & Omit<TableCellProps, 'type'>;
 
-export const SortCell = forwardRef<HTMLTableHeaderCellElement, SortCellProps>(
-  ({ isSorted, sortOrder, onClick, children, ...rest }, ref) => {
-    const IconRenderer = (isSorted?: boolean, sortOrder?: SortOrder) => {
-      const Wrapper = (
-        Icon: OverridableComponent<
-          SvgIconTypeMap<Record<string, unknown>, 'svg'>
-        >
-      ) => <SortIconWrapper Icon={Icon} iconSize="inline" />;
-      return !isSorted
-        ? Wrapper(UnfoldMoreIcon)
-        : sortOrder === 'ascending'
-        ? Wrapper(KeyboardArrowDownIcon)
-        : sortOrder === 'descending'
-        ? Wrapper(KeyboardArrowUpIcon)
-        : '';
-    };
-
-    return (
-      <Cell
-        ref={ref}
-        type="head"
-        aria-sort={sortOrder !== 'none' ? sortOrder : undefined}
-        {...rest}
-      >
-        <StyledButton onClick={onClick}>
-          {children} {IconRenderer(isSorted, sortOrder)}
-        </StyledButton>
-      </Cell>
-    );
+const makeSortIcon = (isSorted?: boolean, sortOrder?: SortOrder) => {
+  if (!isSorted || !sortOrder) {
+    return <SortIconWrapper Icon={UnfoldMoreIcon} iconSize="inline" />;
   }
+
+  return sortOrder === 'ascending' ? (
+    <SortIconWrapper Icon={KeyboardArrowDownIcon} iconSize="inline" />
+  ) : (
+    <SortIconWrapper Icon={KeyboardArrowUpIcon} iconSize="inline" />
+  );
+};
+
+export const SortCell = forwardRef<HTMLTableCellElement, SortCellProps>(
+  ({ isSorted, sortOrder, onClick, children, ...rest }, ref) => (
+    <Cell
+      ref={ref}
+      type="head"
+      aria-sort={isSorted && sortOrder ? sortOrder : undefined}
+      {...rest}
+    >
+      <StyledButton onClick={onClick}>
+        {children} {makeSortIcon(isSorted, sortOrder)}
+      </StyledButton>
+    </Cell>
+  )
 );

--- a/components/src/components/Table/Table.stories.tsx
+++ b/components/src/components/Table/Table.stories.tsx
@@ -458,32 +458,25 @@ export const Sortable = (args: TableProps) => {
   }, [headerSortCells]);
 
   const onClickSort = (sortHeaderCell: HeaderCellToSort) => {
-    const updateSortInfo = headerSortCells.map(headerCell => {
-      if (sortHeaderCell.dataName === headerCell.dataName) {
-        let sortOrder: SortOrder = 'none';
-        switch (sortHeaderCell.sortOrder) {
-          case 'descending':
-            sortOrder = 'ascending';
-            break;
-          case 'ascending':
-            sortOrder = 'descending';
-            break;
-          default:
-            sortOrder = 'ascending';
-            break;
+    const updateSortInfo = headerSortCells.map(
+      (headerCell): HeaderCellToSort => {
+        if (sortHeaderCell.dataName === headerCell.dataName) {
+          return {
+            ...sortHeaderCell,
+            isSorted: true,
+            sortOrder:
+              sortHeaderCell.sortOrder === 'ascending'
+                ? 'descending'
+                : 'ascending'
+          };
         }
         return {
-          ...sortHeaderCell,
-          isSorted: true,
-          sortOrder
+          ...headerCell,
+          isSorted: false,
+          sortOrder: headerCell.sortOrder ? ('none' as SortOrder) : undefined
         };
       }
-      return {
-        ...headerCell,
-        isSorted: false,
-        sortOrder: headerCell.sortOrder ? ('none' as SortOrder) : undefined
-      };
-    });
+    );
     setHeaderSortCells(updateSortInfo);
   };
 
@@ -519,7 +512,11 @@ export const Sortable = (args: TableProps) => {
                     key={`head-${headerCell.dataName}`}
                     onClick={() => onClickSort(headerCell)}
                     isSorted={headerCell.isSorted}
-                    sortOrder={headerCell.sortOrder}
+                    sortOrder={
+                      headerCell.sortOrder === 'none'
+                        ? undefined
+                        : headerCell.sortOrder
+                    }
                   >
                     {headerCell.name}
                   </SortCell>

--- a/components/src/components/Table/tableData.tsx
+++ b/components/src/components/Table/tableData.tsx
@@ -3,7 +3,7 @@ import { SortOrder } from './SortCell';
 export type HeaderCellToSort = {
   name: string;
   dataName: string;
-  sortOrder?: SortOrder;
+  sortOrder?: SortOrder | 'none';
   isSorted?: boolean;
 };
 


### PR DESCRIPTION
1) Tar bort alternativet 'none' på SortOrder.
Synes det var litt forvirrende at man både kunne sette `isSorted=false` og `sortOrder=none` i tillegg til at de begge ikke trenger å være satt. Sjekket bruk av denne på Github, og ser ut til å beholde kompatibilitet med andre løsninger ved å rydde dette på denne måten.

2) Lar `aria-sort` også ta hensyn til `isSorted`.
Liten bug her hvor `aria-sort` kunne vært satt selv om tabellen ikke var sortert på den kolonnen.

3) Refaktorering av kode.
Synes det var noe logikk som var litt komplisert å lese, så jeg har skrevet om noe av det.

4) Tilpassing i koden for stories / tester for å støtte de andre endringnene over.