### PR TITLE
Slår på `@typescript-eslint/no-explicit-any`

### DIFF
--- a/components/.eslintrc.js
+++ b/components/.eslintrc.js
@@ -7,7 +7,11 @@ module.exports = {
   env: {
     es6: true
   },
-  extends: ["plugin:@typescript-eslint/recommended", "prettier", "plugin:storybook/recommended"],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+    'plugin:storybook/recommended'
+  ],
   globals: {
     Atomics: 'readonly',
     SharedArrayBuffer: 'readonly'
@@ -24,7 +28,6 @@ module.exports = {
   },
   plugins: ['react', '@typescript-eslint'],
   rules: {
-    '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-empty-function': 'off'

--- a/components/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/components/src/components/OverflowMenu/OverflowMenu.tsx
@@ -67,8 +67,10 @@ export const OverflowMenu = forwardRef<HTMLDivElement, OverflowMenuProps>(
     },
     ref
   ) => {
-    const [referenceElement, setReferenceElement] = useState(null) as any;
-    const [popperElement, setPopperElement] = useState(null) as any;
+    const [referenceElement, setReferenceElement] =
+      useState<HTMLElement | null>(null);
+    const [popperElement, setPopperElement] =
+      useState<HTMLElement | null>(null);
     const combinedRef = useCombinedRef(ref, setPopperElement);
 
     const { styles, attributes } = useReactPopper(

--- a/components/src/components/Popover/Popover.tsx
+++ b/components/src/components/Popover/Popover.tsx
@@ -98,8 +98,10 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
     },
     ref
   ) => {
-    const [referenceElement, setReferenceElement] = useState(null) as any;
-    const [popperElement, setPopperElement] = useState(null) as any;
+    const [referenceElement, setReferenceElement] =
+      useState<HTMLElement | null>(null);
+    const [popperElement, setPopperElement] =
+      useState<HTMLElement | null>(null);
     const multiRef = useCombinedRef(ref, setPopperElement);
 
     const { styles, attributes } = useReactPopper(
@@ -111,7 +113,9 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
     );
 
     useEffect(() => {
-      isOpen ? setReferenceElement(anchorElement) : setReferenceElement(null);
+      isOpen && anchorElement?.current
+        ? setReferenceElement(anchorElement.current)
+        : setReferenceElement(null);
       return () => setReferenceElement(null);
     }, [anchorElement, isOpen]);
 

--- a/components/src/components/RadioButton/RadioButton.tsx
+++ b/components/src/components/RadioButton/RadioButton.tsx
@@ -10,16 +10,16 @@ import { CustomRadioButton, Input, Container } from './RadioButton.styles';
 let nextUniqueId = 0;
 
 const isValueEqualToGroupValueOrFalsy = (
-  value: any,
+  value: unknown,
   group: Nullable<RadioButtonGroup>
-) => {
+): boolean => {
   if (typeof value !== 'undefined' && value !== null && group) {
     if (typeof value === 'number') {
       return value === Number(group?.value);
     }
     return value === group?.value;
   }
-  return value;
+  return !!value;
 };
 
 export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(

--- a/components/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/components/src/components/RadioButton/RadioButtonGroup.tsx
@@ -39,7 +39,7 @@ export type RadioButtonGroupProps = {
   groupId?: string;
   children?: React.ReactNode;
   required?: boolean;
-  onChange?: (event: ChangeEvent<HTMLInputElement>, value: any) => void;
+  onChange?: (event: ChangeEvent<HTMLInputElement>, value: unknown) => void;
   className?: string;
   style?: React.CSSProperties;
 } & Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>;

--- a/components/src/components/Select/Select.tsx
+++ b/components/src/components/Select/Select.tsx
@@ -29,7 +29,9 @@ import { selectTokens as tokens } from './Select.tokens';
 
 const { Option: DdsOption, NoOptionsMessage, Input } = components;
 
-const IconOption = (props: OptionProps<any, any>) => (
+const IconOption = <TValue, IsMulti extends boolean>(
+  props: OptionProps<TValue, IsMulti>
+) => (
   <DdsOption {...props}>
     {props.isSelected && (
       <SelectedIconWrapper Icon={CheckOutlinedIcon} iconSize="inline" />
@@ -38,9 +40,9 @@ const IconOption = (props: OptionProps<any, any>) => (
   </DdsOption>
 );
 
-const NoOptionsMessageCustom = (props: NoticeProps<any, any>) => (
-  <NoOptionsMessage {...props}>Ingen treff</NoOptionsMessage>
-);
+const NoOptionsMessageCustom = <TValue, IsMulti extends boolean>(
+  props: NoticeProps<TValue, IsMulti>
+) => <NoOptionsMessage {...props}>Ingen treff</NoOptionsMessage>;
 
 function escapeRegexCharacters(text: string) {
   return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
@@ -111,7 +113,7 @@ const SelectInner = <IsMulti extends boolean = false>(
     errorMessage
   );
 
-  const CustomInput = (props: InputProps<any, any>) => (
+  const CustomInput = <TValue,>(props: InputProps<TValue, IsMulti>) => (
     <Input
       {...props}
       aria-describedby={spaceSeparatedIdListGenerator([tipId, errorMessageId])}

--- a/components/src/components/Tooltip/Tooltip.tsx
+++ b/components/src/components/Tooltip/Tooltip.tsx
@@ -56,9 +56,11 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     );
 
     const [open, setOpen] = useState(false);
-    const [popperElement, setPopperElement] = useState(null) as any;
-    const [referenceElement, setReferenceElement] = useState(null) as any;
-    const [arrowElement, setArrowElement] = useState(null) as any;
+    const [popperElement, setPopperElement] =
+      useState<HTMLElement | null>(null);
+    const [referenceElement, setReferenceElement] =
+      useState<HTMLElement | null>(null);
+    const [arrowElement, setArrowElement] = useState<HTMLElement | null>(null);
     const combinedRef = useCombinedRef(ref, setPopperElement);
     let timer: ReturnType<typeof setTimeout>;
 

--- a/components/src/hooks/useReactPopper.tsx
+++ b/components/src/hooks/useReactPopper.tsx
@@ -22,9 +22,9 @@ export type Placement =
   | 'left-end';
 
 export const useReactPopper = (
-  referenceElement: HTMLElement,
-  popperElement: HTMLElement,
-  arrowRef?: HTMLElement | string,
+  referenceElement: HTMLElement | null,
+  popperElement: HTMLElement | null,
+  arrowRef?: HTMLElement | string | null,
   placement = 'auto' as Placement,
   offset = defaultOffset,
   offsetAlong = 0


### PR DESCRIPTION
For å sikre typesikkerhet over tid er det viktig å unngå bruk av `any`,
og heller bruke `unknown` i tilfeller hvor man ikke har mulighet til å
garantere typesikkerhet. Da må konsumenter forholde seg til at typen
er `unknown` og guarde den hvis de er avhengig av å vite typen direkte.