### PR TITLE
Fikser typing på Select komponenten

### DIFF
--- a/components/src/components/Pagination/Pagination.tsx
+++ b/components/src/components/Pagination/Pagination.tsx
@@ -7,7 +7,7 @@ import FirstPageOutlinedIcon from '@material-ui/icons/FirstPageOutlined';
 import LastPageOutlinedIcon from '@material-ui/icons/LastPageOutlined';
 import { Typography } from '../../components/Typography';
 import { Button } from '../../components/Button';
-import { Select, SelectOption } from '../Select';
+import { Select } from '../Select';
 import { PaginationGenerator } from './paginationGenerator';
 import { IconWrapper } from '../../helpers/IconWrapper';
 import { paginationTokens as tokens } from './Pagination.tokens';
@@ -54,6 +54,11 @@ const IndicatorsContainer = styled.div`
   gap: ${tokens.indicatorsContainer.spacing};
 `;
 
+export type PaginationOption = {
+  label: string;
+  value: number;
+};
+
 export type PaginationProps = {
   itemsAmount: number;
   defaultItemsPerPage?: number;
@@ -61,8 +66,8 @@ export type PaginationProps = {
   withPagination?: boolean;
   withCounter?: boolean;
   withSelect?: boolean;
-  selectOptions?: SelectOption[];
-  onSelectOptionChange?: (option: SelectOption | null) => void;
+  selectOptions?: PaginationOption[];
+  onSelectOptionChange?: (option: PaginationOption | null) => void;
   smallScreen?: boolean;
   onChange?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
@@ -108,7 +113,7 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
       }
     };
 
-    const handleSelectChange = (option: SelectOption | null) => {
+    const handleSelectChange = (option: PaginationOption | null) => {
       setItemsPerPage(option?.value as number);
       if (onSelectOptionChange) {
         onSelectOptionChange(option);
@@ -262,7 +267,7 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
               width="76px"
               defaultValue={{
                 label: itemsPerPage.toString(),
-                value: itemsPerPage.toString()
+                value: itemsPerPage
               }}
               isClearable={false}
               onChange={handleSelectChange}

--- a/components/src/components/Select/Select.stories.tsx
+++ b/components/src/components/Select/Select.stories.tsx
@@ -24,7 +24,12 @@ export default {
   }
 };
 
-const options = [
+type Option = {
+  label: string;
+  value: string;
+};
+
+const options: Option[] = [
   'Alternativ 1',
   'Alternativ 2',
   'Veldig langt alternativ her veldig langt alternativ her',
@@ -32,7 +37,7 @@ const options = [
   'Alternativ 4'
 ].map(s => ({ label: s, value: s }));
 
-const optionsLong = [
+const optionsLong: Option[] = [
   'Alternativ 1',
   'Alternativ 2',
   'Veldig langt alternativ her veldig langt alternativ her',
@@ -43,7 +48,7 @@ const optionsLong = [
   'Alternativ 7'
 ].map(s => ({ label: s, value: s }));
 
-type SingleSelectProps = SelectProps<false>;
+type SingleSelectProps = SelectProps<Option, false>;
 
 export const Overview = (args: SingleSelectProps) => {
   return (

--- a/components/src/components/Select/Select.styles.ts
+++ b/components/src/components/Select/Select.styles.ts
@@ -4,7 +4,6 @@ import { IconWrapper } from '../../helpers/IconWrapper';
 import scrollbarStyling from '../../helpers/scrollbarStyling';
 import { Typography } from '../Typography';
 import { typographyTokens } from '../Typography/Typography.tokens';
-import { SelectOption } from './Select';
 import { selectTokens as tokens } from './Select.tokens';
 
 export const prefix = 'dds-select';
@@ -150,9 +149,9 @@ export const SelectedIconWrapper = styled(IconWrapper)`
   margin: ${tokens.option.selected.icon.margin};
 `;
 
-export const CustomStyles: Partial<
-  StylesConfig<SelectOption, boolean, GroupBase<SelectOption>>
-> = {
+export const getCustomStyles = <TOption>(): Partial<
+  StylesConfig<TOption, boolean, GroupBase<TOption>>
+> => ({
   control: () => ({
     position: 'relative',
     display: 'flex',
@@ -255,4 +254,4 @@ export const CustomStyles: Partial<
     ...provided,
     ...tokens.loadingIndicator.base
   })
-};
+});

--- a/components/src/components/Select/Select.tsx
+++ b/components/src/components/Select/Select.tsx
@@ -19,7 +19,7 @@ import {
 } from '../../utils';
 import {
   Container,
-  CustomStyles,
+  getCustomStyles,
   Label,
   prefix,
   SelectedIconWrapper,
@@ -56,13 +56,7 @@ export function searchFilter(text: string, search: string): boolean {
   return searchFilterRegex.test(text.toLowerCase());
 }
 
-export type SelectOption = {
-  label: string;
-  value: string | number;
-  data?: unknown;
-};
-
-export type SelectProps<IsMulti extends boolean> = {
+export type SelectProps<TOption, IsMulti extends boolean> = {
   label?: string;
   required?: boolean;
   readOnly?: boolean;
@@ -71,15 +65,15 @@ export type SelectProps<IsMulti extends boolean> = {
   width?: CSS.WidthProperty<string>;
   className?: string;
   style?: React.CSSProperties;
-} & ReactSelectProps<SelectOption, IsMulti, GroupBase<SelectOption>>;
+} & ReactSelectProps<TOption, IsMulti, GroupBase<TOption>>;
 
 let nextUniqueId = 0;
 
-type ForwardRefType<IsMulti extends boolean> = React.ForwardedRef<
-  SelectInstance<SelectOption, IsMulti, GroupBase<SelectOption>>
+type ForwardRefType<TOption, IsMulti extends boolean> = React.ForwardedRef<
+  SelectInstance<TOption, IsMulti, GroupBase<TOption>>
 >;
 
-const SelectInner = <IsMulti extends boolean = false>(
+const SelectInner = <TOption, IsMulti extends boolean = false>(
   {
     id,
     label,
@@ -99,8 +93,8 @@ const SelectInner = <IsMulti extends boolean = false>(
     isClearable = true,
     placeholder = '-- Velg fra listen --',
     ...rest
-  }: SelectProps<IsMulti>,
-  ref: ForwardRefType<IsMulti>
+  }: SelectProps<TOption, IsMulti>,
+  ref: ForwardRefType<TOption, IsMulti>
 ) => {
   const [uniqueId] = useState<string>(id ?? `select-${nextUniqueId++}`);
 
@@ -135,9 +129,9 @@ const SelectInner = <IsMulti extends boolean = false>(
   };
 
   const reactSelectProps: ReactSelectProps<
-    SelectOption,
+    TOption,
     IsMulti,
-    GroupBase<SelectOption>
+    GroupBase<TOption>
   > = {
     options,
     value,
@@ -154,8 +148,8 @@ const SelectInner = <IsMulti extends boolean = false>(
     inputId: uniqueId,
     name: uniqueId,
     classNamePrefix: prefix,
-    styles: CustomStyles,
-    filterOption: (option: SelectOption, inputValue: string) => {
+    styles: getCustomStyles<TOption>(),
+    filterOption: (option, inputValue: string) => {
       const { label } = option;
       return searchFilter(label, inputValue) || inputValue === '';
     },


### PR DESCRIPTION
Bruker en generisk `TOption` istedenfor å spikre options til å være av typen `SelectOption`.

Dette gjør det mere fleksibelt med tanke på hvilke options som kan sendes inn, og man kan definere getOptionLabel/getOptionValue istedenfor å konvertere options til `SelectOption[]` før man sender inn options

For eksempel kan man bruke det slik.

```
type Embete = {
  id: string;
  name: string;
};

const embeter: Embete[] = [
  {
    id: '1',
    name: 'Domstoladministrasjonen'
  }
];

  <Select
    options={embeter}
    onChange={embete => {
      handleOnChange(embete)
    }}
    getOptionLabel={embete => embete.name}
    getOptionValue={embete => embete.id}
  />
```

Og sende inn embeter som options idag gir typefeil, og krever formatering til `SelectOption` noe som føles ugunstig