### PR TITLE
Fikser typefeil for `RadioButtonGroup`

### DIFF
--- a/components/src/components/RadioButton/RadioButtonGroup.stories.tsx
+++ b/components/src/components/RadioButton/RadioButtonGroup.stories.tsx
@@ -1,6 +1,6 @@
 import { RadioButton, RadioButtonGroup, RadioButtonGroupProps } from '.';
 import { StoryTemplate } from '../../storybook';
-import { ChangeEvent, useState } from 'react';
+import { useState } from 'react';
 
 export default {
   title: 'Design system/RadioButton/RadioButtonGroup',
@@ -20,7 +20,7 @@ export default {
   }
 };
 
-export const Overview = (args: RadioButtonGroupProps) => {
+export const Overview = (args: RadioButtonGroupProps<string>) => {
   return (
     <StoryTemplate
       title="Radio button group - overview"
@@ -103,7 +103,7 @@ export const Overview = (args: RadioButtonGroupProps) => {
   );
 };
 
-export const Default = (args: RadioButtonGroupProps) => {
+export const Default = (args: RadioButtonGroupProps<number>) => {
   const [value, setValue] = useState<number | undefined>();
   return (
     <StoryTemplate title="Radio button group - default">
@@ -111,10 +111,7 @@ export const Default = (args: RadioButtonGroupProps) => {
         {...args}
         label={args.label || 'Label'}
         value={value}
-        onChange={(
-          _event: ChangeEvent<HTMLInputElement>,
-          value: number | undefined
-        ) => {
+        onChange={(_event, value) => {
           setValue(value);
         }}
       >
@@ -126,15 +123,15 @@ export const Default = (args: RadioButtonGroupProps) => {
   );
 };
 
-export const WithDefaultValue = (args: RadioButtonGroupProps) => {
-  const [value, setValue] = useState<number>(2);
+export const WithDefaultValue = (args: RadioButtonGroupProps<number>) => {
+  const [value, setValue] = useState<number | undefined>(2);
   return (
     <StoryTemplate title="Radio button group - default value">
       <RadioButtonGroup
         {...args}
         label="Label"
         value={value}
-        onChange={(_event: ChangeEvent<HTMLInputElement>, value: number) => {
+        onChange={(_event, value) => {
           setValue(value);
         }}
       >

--- a/components/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/components/src/components/RadioButton/RadioButtonGroup.tsx
@@ -27,13 +27,16 @@ const Label = styled(Typography)`
 
 type Direction = 'column' | 'row';
 
-export type RadioButtonGroupProps = {
+export type RadioButtonGroupProps<T extends string | number> = {
   /** Gir alle barna `name` prop.*/
   name?: string;
   /**Ledetekst for hele gruppen. */
   label?: string;
   /**Funksjonen for onChange-event for barna. */
-  onChange?: (event: ChangeEvent<HTMLInputElement>, value: unknown) => void;
+  onChange?: (
+    event: ChangeEvent<HTMLInputElement>,
+    value: T | undefined
+  ) => void;
   /**Legger en markør (*) bak label som indikerer at input er påkrevd. Gjør alle barna påkrevd ved å gi dem `required` prop. */
   required?: boolean;
   /**Meldingen som vises ved valideringsfeil. Gir alle barna error prop. */
@@ -47,14 +50,14 @@ export type RadioButtonGroupProps = {
   /**Retningen radioknappene skal gjengis i. */
   direction?: Direction;
   /**Default verdi - en `<RadioButton />` blir forhåndsvalgt. **OBS!** brukes kun når brukeren ikke skal fylle ut selv. */
-  value?: string | number;
+  value?: T | undefined;
   /**custom id for for gruppen, knytter `label` til gruppen via `aria-label`. */
   groupId?: string;
 } & Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>;
 
 let nextUniqueGroupId = 0;
 
-export const RadioButtonGroup = ({
+export const RadioButtonGroup = <T extends string | number = string>({
   name,
   label,
   groupId,
@@ -70,10 +73,9 @@ export const RadioButtonGroup = ({
   className,
   style,
   ...rest
-}: RadioButtonGroupProps) => {
-  const [groupValue, setGroupValue] = useState<
-    string | number | null | undefined
-  >(value);
+}: RadioButtonGroupProps<T>) => {
+  const [groupValue, setGroupValue] =
+    useState<string | number | null | undefined>(value);
 
   const [uniqueGroupId] = useState<string>(
     groupId ?? `radioButtonGroup-${nextUniqueGroupId++}`
@@ -81,7 +83,7 @@ export const RadioButtonGroup = ({
 
   const handleChange = combineHandlers(
     (e: ChangeEvent<HTMLInputElement>) => setGroupValue(e.target.value),
-    e => onChange && onChange(e, e.target.value)
+    e => onChange && onChange(e, e.target.value as T)
   );
 
   const hasErrorMessage = !!errorMessage;


### PR DESCRIPTION
Gjør `RadioButtonGroup` generisk basert på verdien som sendes inn. Hvis
det ikke angis noen verdi får den standard verditype `string`. Fikser
typesjekkingsfeil i `RadioButtonGroup.stories`.