### PR TITLE
Legger til 'className' som toppnivå-prop overalt

### DIFF
--- a/components/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/components/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -36,7 +36,7 @@ export type BreadcrumbsProps = BaseComponentPropsWithChildren<
 
 export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
   (props, ref) => {
-    const { smallScreen, children, id, htmlProps, ...rest } = props;
+    const { smallScreen, children, id, className, htmlProps, ...rest } = props;
 
     const breadcrumbIconSize = tokens.icon.size as IconSize;
 
@@ -71,7 +71,7 @@ export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
 
     return (
       <nav
-        {...getBaseHTMLProps(id, htmlProps, rest)}
+        {...getBaseHTMLProps(id, className, htmlProps, rest)}
         ref={ref}
         aria-label="brødsmulesti"
       >

--- a/components/src/components/Button/Button.tsx
+++ b/components/src/components/Button/Button.tsx
@@ -23,6 +23,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       onFocus,
       onBlur,
       id,
+      className,
       htmlProps,
       ...rest
     } = props;
@@ -33,7 +34,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     const hasIcon = !!Icon;
 
     const wrapperProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(id, className, htmlProps, rest),
       href,
       label,
       as,

--- a/components/src/components/Card/Card.tsx
+++ b/components/src/components/Card/Card.tsx
@@ -86,6 +86,7 @@ export const Card = (props: CardProps) => {
     cardRef,
     children,
     id,
+    className,
     htmlProps,
     ...rest
   } = props;
@@ -95,7 +96,7 @@ export const Card = (props: CardProps) => {
 
     return (
       <Container
-        {...getBaseHTMLProps(id, htmlProps, rest)}
+        {...getBaseHTMLProps(id, className, htmlProps, rest)}
         cardType={cardType}
         color={color}
         as="a"
@@ -110,7 +111,7 @@ export const Card = (props: CardProps) => {
 
   return (
     <Container
-      {...getBaseHTMLProps(id, htmlProps, rest)}
+      {...getBaseHTMLProps(id, className, htmlProps, rest)}
       cardType={cardType}
       color={color}
       as="div"

--- a/components/src/components/Card/CardAccordion/CardAccordion.tsx
+++ b/components/src/components/Card/CardAccordion/CardAccordion.tsx
@@ -27,7 +27,14 @@ let nextUniqueId = 0;
 
 export const CardAccordion = forwardRef<HTMLDivElement, CardAccordionProps>(
   (props, ref) => {
-    const { isExpanded = false, id, children, htmlProps, ...rest } = props;
+    const {
+      isExpanded = false,
+      id,
+      children,
+      className,
+      htmlProps,
+      ...rest
+    } = props;
 
     const [expanded, setExpanded] = useState(isExpanded);
 
@@ -64,7 +71,7 @@ export const CardAccordion = forwardRef<HTMLDivElement, CardAccordionProps>(
     });
 
     const wrapperProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(id, className, htmlProps, rest),
       ref
     };
     return <Wrapper {...wrapperProps}>{Children}</Wrapper>;

--- a/components/src/components/Card/CardAccordion/CardAccordionBody.tsx
+++ b/components/src/components/Card/CardAccordion/CardAccordionBody.tsx
@@ -61,7 +61,8 @@ export const CardAccordionBody = forwardRef<
   HTMLDivElement,
   CardAccordionBodyProps
 >((props, ref) => {
-  const { children, isExpanded, headerId, id, htmlProps, ...rest } = props;
+  const { children, isExpanded, headerId, id, className, htmlProps, ...rest } =
+    props;
 
   const bodyRef = useRef<HTMLDivElement>(null);
 
@@ -76,7 +77,7 @@ export const CardAccordionBody = forwardRef<
   }, [isExpanded]);
 
   const bodyProps = {
-    ...getBaseHTMLProps(id, htmlProps, rest),
+    ...getBaseHTMLProps(id, className, htmlProps, rest),
     ref,
     isExpanded,
     role: 'region'

--- a/components/src/components/Card/CardAccordion/CardAccordionHeader.tsx
+++ b/components/src/components/Card/CardAccordion/CardAccordionHeader.tsx
@@ -68,6 +68,7 @@ export const CardAccordionHeader = forwardRef<
     toggleExpanded,
     bodyId,
     id,
+    className,
     htmlProps,
     ...rest
   } = props;
@@ -79,7 +80,7 @@ export const CardAccordionHeader = forwardRef<
   };
 
   const headerWrapperProps = {
-    ...getBaseHTMLProps(id, htmlProps, rest),
+    ...getBaseHTMLProps(id, className, htmlProps, rest),
     'aria-expanded': isExpanded,
     'aria-controls': bodyId,
     ref,

--- a/components/src/components/Checkbox/Checkbox.tsx
+++ b/components/src/components/Checkbox/Checkbox.tsx
@@ -4,7 +4,7 @@ import { CustomCheckbox, Input, Container } from './Checkbox.styles';
 import { CheckboxProps } from './Checkbox.types';
 import { useCheckboxGroup } from './CheckboxGroupContext';
 import { spaceSeparatedIdListGenerator } from '../../utils';
-import { getBaseHTMLProps } from '../../types';
+import { getBaseHTMLProps, joinClassNames } from '../../types';
 
 let nextUniqueId = 0;
 
@@ -19,6 +19,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       readOnly,
       indeterminate,
       'aria-describedby': ariaDescribedby,
+      className,
       htmlProps = {},
       ...rest
     } = props;
@@ -26,7 +27,11 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     const [uniqueId] = useState<string>(id ?? `checkbox-${nextUniqueId++}`);
     const checkboxGroup = useCheckboxGroup();
 
-    const { className, style, ...restHtmlProps } = htmlProps;
+    const {
+      style,
+      className: htmlPropsClassName,
+      ...restHtmlProps
+    } = htmlProps;
 
     const containerProps = {
       error: error || checkboxGroup?.error,
@@ -35,15 +40,14 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       readOnly,
       htmlFor: uniqueId,
       label,
-      className,
+      className: joinClassNames(className, htmlPropsClassName),
       style
     };
     type AriaChecked = 'mixed' | boolean | undefined;
 
     const inputProps = {
-      ...getBaseHTMLProps(id, restHtmlProps, rest),
+      ...getBaseHTMLProps(uniqueId, restHtmlProps, rest),
       ref,
-      id: uniqueId,
       name,
       indeterminate,
       disabled: disabled || readOnly,

--- a/components/src/components/Checkbox/CheckboxGroup.tsx
+++ b/components/src/components/Checkbox/CheckboxGroup.tsx
@@ -56,6 +56,7 @@ export const CheckboxGroup = ({
   groupId,
   children,
   id,
+  className,
   htmlProps,
   ...rest
 }: CheckboxGroupProps) => {
@@ -78,7 +79,7 @@ export const CheckboxGroup = ({
   };
 
   return (
-    <Container {...getBaseHTMLProps(id, htmlProps, rest)}>
+    <Container {...getBaseHTMLProps(id, className, htmlProps, rest)}>
       <Label
         forwardedAs="span"
         typographyType="supportingStyleLabel01"

--- a/components/src/components/Chip/Chip.tsx
+++ b/components/src/components/Chip/Chip.tsx
@@ -24,9 +24,9 @@ export type ChipProps = BaseComponentProps<
 >;
 
 export const Chip = forwardRef<HTMLDivElement, ChipProps>((props, ref) => {
-  const { text, onClose, id, htmlProps = {}, ...rest } = props;
+  const { text, onClose, id, className, htmlProps = {}, ...rest } = props;
 
-  const { 'aria-label': ariaLabel } = htmlProps;
+  const { 'aria-label': ariaLabel, ...restHTMLprops } = htmlProps;
 
   const [isOpen, setIsOpen] = useState(true);
 
@@ -36,7 +36,10 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>((props, ref) => {
   };
 
   return isOpen ? (
-    <Container {...getBaseHTMLProps(id, htmlProps, rest)} ref={ref}>
+    <Container
+      {...getBaseHTMLProps(id, className, restHTMLprops, rest)}
+      ref={ref}
+    >
       <TextWrapper>{text}</TextWrapper>
       <Button
         size="tiny"

--- a/components/src/components/DescriptionList/DescriptionList.tsx
+++ b/components/src/components/DescriptionList/DescriptionList.tsx
@@ -43,10 +43,17 @@ export const DescriptionList = forwardRef<
   HTMLDListElement,
   DescriptionListProps
 >((props, ref) => {
-  const { appearance = 'bold', children, id, htmlProps, ...rest } = props;
+  const {
+    appearance = 'bold',
+    children,
+    id,
+    className,
+    htmlProps,
+    ...rest
+  } = props;
 
   const dListProps = {
-    ...getBaseHTMLProps(id, htmlProps, rest),
+    ...getBaseHTMLProps(id, className, htmlProps, rest),
     appearance,
     ref
   };

--- a/components/src/components/DescriptionList/DescriptionListDesc.tsx
+++ b/components/src/components/DescriptionList/DescriptionListDesc.tsx
@@ -29,10 +29,10 @@ export const DescriptionListDesc = forwardRef<
   HTMLElement,
   DescriptionListDescProps
 >((props, ref) => {
-  const { children, Icon, id, htmlProps, ...rest } = props;
+  const { children, Icon, id, className, htmlProps, ...rest } = props;
 
   const dListDescProps = {
-    ...getBaseHTMLProps(id, htmlProps, rest),
+    ...getBaseHTMLProps(id, className, htmlProps, rest),
     children,
     ref
   };

--- a/components/src/components/DescriptionList/DescriptionListGroup.tsx
+++ b/components/src/components/DescriptionList/DescriptionListGroup.tsx
@@ -27,10 +27,10 @@ export const DescriptionListGroup = forwardRef<
   HTMLDivElement,
   DescriptionListGroupProps
 >((props, ref) => {
-  const { children, margin, id, htmlProps, ...rest } = props;
+  const { children, margin, id, className, htmlProps, ...rest } = props;
 
   const dListGroupProps = {
-    ...getBaseHTMLProps(id, htmlProps, rest),
+    ...getBaseHTMLProps(id, className, htmlProps, rest),
     children,
     ref,
     margin

--- a/components/src/components/Divider/Divider.tsx
+++ b/components/src/components/Divider/Divider.tsx
@@ -23,10 +23,10 @@ export type DividerProps = BaseComponentProps<
 >;
 
 export const Divider = forwardRef<HTMLHRElement, DividerProps>((props, ref) => {
-  const { color = 'primary', id, htmlProps, ...rest } = props;
+  const { color = 'primary', id, className, htmlProps, ...rest } = props;
 
   const lineProps = {
-    ...getBaseHTMLProps(id, htmlProps, rest),
+    ...getBaseHTMLProps(id, className, htmlProps, rest),
     color
   };
 

--- a/components/src/components/Drawer/Drawer.tsx
+++ b/components/src/components/Drawer/Drawer.tsx
@@ -118,6 +118,7 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
     size = 'small',
     triggerRef,
     id,
+    className,
     htmlProps,
     ...rest
   } = props;
@@ -144,13 +145,12 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
   const hasTransitionedIn = useMountTransition(isOpen, 500);
 
   const containerProps = {
-    ...getBaseHTMLProps(id, htmlProps, rest),
+    ...getBaseHTMLProps(uniqueId, className, htmlProps, rest),
     placement,
     ref: combinedRef,
     isOpen: hasTransitionedIn && isOpen,
     tabIndex: -1,
     role: 'dialog',
-    id: uniqueId,
     'aria-labelledby': headerId,
     size
   };

--- a/components/src/components/GlobalMessage/GlobalMessage.tsx
+++ b/components/src/components/GlobalMessage/GlobalMessage.tsx
@@ -69,6 +69,7 @@ export const GlobalMessage = forwardRef<HTMLDivElement, GlobalMessageProps>(
       onClose,
       children,
       id,
+      className,
       htmlProps,
       ...rest
     } = props;
@@ -77,7 +78,7 @@ export const GlobalMessage = forwardRef<HTMLDivElement, GlobalMessageProps>(
     const buttonPurpose = tokens.button[purpose].purpose as ButtonPurpose;
 
     const containerProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(id, className, htmlProps, rest),
       ref,
       purpose
     };

--- a/components/src/components/InputMessage/InputMessage.tsx
+++ b/components/src/components/InputMessage/InputMessage.tsx
@@ -41,10 +41,10 @@ export type InputMessageProps = BaseComponentProps<
 
 export const InputMessage = forwardRef<HTMLDivElement, InputMessageProps>(
   (props, ref) => {
-    const { message, messageType, id, htmlProps, ...rest } = props;
+    const { message, messageType, id, className, htmlProps, ...rest } = props;
 
     const wrapperProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(id, className, htmlProps, rest),
       ref,
       messageType
     };

--- a/components/src/components/InternalHeader/InternalHeader.tsx
+++ b/components/src/components/InternalHeader/InternalHeader.tsx
@@ -29,6 +29,7 @@ export const InternalHeader = (props: InternalHeaderProps) => {
     userProps,
     onCurrentPageChange,
     id,
+    className,
     htmlProps,
     ...rest
   } = props;
@@ -82,7 +83,7 @@ export const InternalHeader = (props: InternalHeaderProps) => {
   const hasContextMenu =
     hasContextMenuElements || !!userProps || hasNavInContextMenu;
   return (
-    <Wrapper {...getBaseHTMLProps(id, htmlProps, rest)}>
+    <Wrapper {...getBaseHTMLProps(id, className, htmlProps, rest)}>
       <BannerWrapper hasContextMenu={hasContextMenu}>
         <BannerLeftWrapper>
           <LovisaWrapper>

--- a/components/src/components/List/List.tsx
+++ b/components/src/components/List/List.tsx
@@ -99,6 +99,7 @@ export const List = forwardRef<HTMLUListElement | HTMLOListElement, ListProps>(
       typographyType = 'inherit',
       children,
       id,
+      className,
       htmlProps,
       ...rest
     } = props;
@@ -106,7 +107,7 @@ export const List = forwardRef<HTMLUListElement | HTMLOListElement, ListProps>(
     const as: ElementType = listType === 'ordered' ? 'ol' : 'ul';
 
     const listProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(id, className, htmlProps, rest),
       listType,
       typographyType,
       as,

--- a/components/src/components/LocalMessage/LocalMessage.tsx
+++ b/components/src/components/LocalMessage/LocalMessage.tsx
@@ -111,6 +111,7 @@ export const LocalMessage = forwardRef<HTMLDivElement, LocalMessageProps>(
       layout = 'horisontal',
       children,
       id,
+      className,
       htmlProps,
       ...rest
     } = props;
@@ -119,7 +120,7 @@ export const LocalMessage = forwardRef<HTMLDivElement, LocalMessageProps>(
     const buttonPurpose = tokens.button[purpose].purpose as ButtonPurpose;
 
     const containerProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(id, className, htmlProps, rest),
       purpose,
       width,
       layout,

--- a/components/src/components/Modal/Modal.tsx
+++ b/components/src/components/Modal/Modal.tsx
@@ -68,6 +68,7 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>((props, ref) => {
     onClose,
     id,
     triggerRef,
+    className,
     htmlProps,
     ...rest
   } = props;
@@ -104,7 +105,7 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>((props, ref) => {
   };
 
   const containerProps = {
-    ...getBaseHTMLProps(id, htmlProps, rest),
+    ...getBaseHTMLProps(id, className, htmlProps, rest),
     ref: combinedRef,
     role: 'dialog',
     'aria-modal': true,

--- a/components/src/components/Modal/ModalBody.tsx
+++ b/components/src/components/Modal/ModalBody.tsx
@@ -34,10 +34,10 @@ export type ModalBodyProps = BaseComponentPropsWithChildren<
 
 export const ModalBody = forwardRef<HTMLDivElement, ModalBodyProps>(
   (props, ref) => {
-    const { children, scrollable, id, htmlProps, ...rest } = props;
+    const { children, scrollable, id, className, htmlProps, ...rest } = props;
 
     const containerProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(id, className, htmlProps, rest),
       ref,
       tabIndex: scrollable ? 0 : undefined,
       scrollable

--- a/components/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/components/src/components/OverflowMenu/OverflowMenu.tsx
@@ -61,11 +61,10 @@ export const OverflowMenu = forwardRef<HTMLDivElement, OverflowMenuProps>(
       userProps,
       id,
       offset = tokens.offset,
+      className,
       htmlProps = {},
       ...rest
     } = props;
-
-    const { style = {} } = htmlProps;
 
     const { reference, floating, refs, styles } = useFloatPosition(
       null,
@@ -188,8 +187,10 @@ export const OverflowMenu = forwardRef<HTMLDivElement, OverflowMenuProps>(
       }
     };
 
+    const { style = {}, ...restHTMLProps } = htmlProps;
+
     const containerProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(id, className, restHTMLProps, rest),
       ref: combinedRef,
       id: id ?? useId('overflowMenu'),
       isOpen,

--- a/components/src/components/OverflowMenu/OverflowMenuItem.tsx
+++ b/components/src/components/OverflowMenu/OverflowMenuItem.tsx
@@ -108,6 +108,7 @@ export const OverflowMenuItem = forwardRef<
     setFocus,
     index,
     id,
+    className,
     htmlProps = {},
     ...rest
   } = props;
@@ -162,7 +163,7 @@ export const OverflowMenuItem = forwardRef<
 
   if (!href && !onClick) {
     return (
-      <Span {...{ ...getBaseHTMLProps(id, htmlProps, rest), ref }}>
+      <Span {...{ ...getBaseHTMLProps(id, className, htmlProps, rest), ref }}>
         {icon}
         {title}
       </Span>
@@ -172,7 +173,7 @@ export const OverflowMenuItem = forwardRef<
   if (!href) {
     return (
       <Link
-        {...getBaseHTMLProps(id, htmlProps, rest)}
+        {...getBaseHTMLProps(id, className, htmlProps, rest)}
         {...linkProps}
         as="button"
         ref={combinedRef as React.ForwardedRef<HTMLButtonElement>}
@@ -185,7 +186,7 @@ export const OverflowMenuItem = forwardRef<
 
   return (
     <Link
-      {...getBaseHTMLProps(id, htmlProps, rest)}
+      {...getBaseHTMLProps(id, className, htmlProps, rest)}
       {...linkProps}
       as="a"
       ref={combinedRef as React.ForwardedRef<HTMLAnchorElement>}

--- a/components/src/components/Pagination/Pagination.tsx
+++ b/components/src/components/Pagination/Pagination.tsx
@@ -118,6 +118,7 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
       onChange,
       onSelectOptionChange,
       id,
+      className,
       htmlProps,
       ...rest
     } = props;
@@ -203,11 +204,11 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
 
     const navProps = !withSelect &&
       !withCounter && {
-        ...getBaseHTMLProps(id, htmlProps, rest)
+        ...getBaseHTMLProps(id, className, htmlProps, rest)
       };
 
     const containerProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(id, className, htmlProps, rest),
       smallScreen
     };
 

--- a/components/src/components/Popover/Popover.tsx
+++ b/components/src/components/Popover/Popover.tsx
@@ -99,6 +99,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       placement = 'bottom',
       offset = Spacing.SizesDdsSpacingLocalX05NumberPx,
       id,
+      className,
       htmlProps = {},
       ...rest
     } = props;
@@ -116,7 +117,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
     }, [anchorElement, isOpen]);
 
     const wrapperProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(id, className, htmlProps, rest),
       ref: multiRef,
       isOpen,
       style: { ...htmlProps.style, ...styles.floating },

--- a/components/src/components/RadioButton/RadioButton.tsx
+++ b/components/src/components/RadioButton/RadioButton.tsx
@@ -6,7 +6,7 @@ import {
   useRadioButtonGroup
 } from './RadioButtonGroupContext';
 import { CustomRadioButton, Input, Container } from './RadioButton.styles';
-import { getBaseHTMLProps } from '../../types';
+import { getBaseHTMLProps, joinClassNames } from '../../types';
 
 let nextUniqueId = 0;
 
@@ -38,11 +38,16 @@ export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
       required,
       onChange,
       'aria-describedby': ariaDescribedby,
+      className,
       htmlProps = {},
       ...rest
     } = props;
 
-    const { className, style, ...restHtmlProps } = htmlProps;
+    const {
+      className: htmlPropsClassName,
+      style,
+      ...restHtmlProps
+    } = htmlProps;
 
     const [uniqueId] = useState<string>(id ?? `radioButton-${nextUniqueId++}`);
 
@@ -59,8 +64,7 @@ export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
     if (ariaDescribedby) describedByIds.push(ariaDescribedby);
 
     const inputProps = {
-      ...getBaseHTMLProps(id, restHtmlProps, rest),
-      id: uniqueId,
+      ...getBaseHTMLProps(uniqueId, restHtmlProps, rest),
       name: name ?? radioButtonGroup?.name,
       disabled:
         disabled ||
@@ -84,7 +88,7 @@ export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
       disabled: disabled || radioButtonGroup?.disabled,
       readOnly: readOnly || radioButtonGroup?.readOnly,
       style,
-      className
+      className: joinClassNames(className, htmlPropsClassName)
     };
 
     return (

--- a/components/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/components/src/components/RadioButton/RadioButtonGroup.tsx
@@ -77,6 +77,7 @@ export const RadioButtonGroup = <T extends string | number = string>({
   required,
   onChange,
   id,
+  className,
   htmlProps,
   ...rest
 }: RadioButtonGroupProps<T>) => {
@@ -113,7 +114,7 @@ export const RadioButtonGroup = <T extends string | number = string>({
   };
 
   return (
-    <Container {...getBaseHTMLProps(id, htmlProps, rest)}>
+    <Container {...getBaseHTMLProps(id, className, htmlProps, rest)}>
       <Label
         forwardedAs="span"
         typographyType="supportingStyleLabel01"

--- a/components/src/components/SkipToContent/SkipToContent.tsx
+++ b/components/src/components/SkipToContent/SkipToContent.tsx
@@ -3,7 +3,11 @@ import styled from 'styled-components';
 import { skipToContentTokens as tokens } from './SkipToContent.tokens';
 import { Property } from 'csstype';
 import { focusVisibleTransitionValue } from '../../helpers/styling';
-import { BaseComponentProps, getBaseHTMLProps } from '../../types';
+import {
+  BaseComponentProps,
+  getBaseHTMLProps,
+  joinClassNames
+} from '../../types';
 
 type WrapperProps = {
   top: Property.Top<string | number>;
@@ -62,15 +66,20 @@ export const SkipToContent = forwardRef<HTMLAnchorElement, SkipToContentProps>(
       text = 'Til hovedinnhold',
       top = 0,
       id,
+      className,
       htmlProps = {},
       ...rest
     } = props;
 
-    const { className, style, ...restHtmlProps } = htmlProps;
+    const {
+      className: htmlPropsClassName,
+      style,
+      ...restHtmlProps
+    } = htmlProps;
 
     const wrapperProps = {
       top,
-      className,
+      className: joinClassNames(className, htmlPropsClassName),
       style
     };
 

--- a/components/src/components/Spinner/Spinner.tsx
+++ b/components/src/components/Spinner/Spinner.tsx
@@ -67,6 +67,7 @@ export function Spinner(props: SpinnerProps) {
     size = ddsBaseTokens.iconSizes.DdsIconsizeMedium,
     color = 'interactive',
     id,
+    className,
     htmlProps,
     ...rest
   } = props;
@@ -78,7 +79,7 @@ export function Spinner(props: SpinnerProps) {
   const [uniqueId] = useState<string>(`spinnerTitle-${nextUniqueId++}`);
 
   const spinnerProps = {
-    ...getBaseHTMLProps(id, htmlProps, rest),
+    ...getBaseHTMLProps(id, className, htmlProps, rest),
     outerAnimationDelay,
     size
   };

--- a/components/src/components/Tabs/Tab.tsx
+++ b/components/src/components/Tabs/Tab.tsx
@@ -84,6 +84,7 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
     onClick,
     onKeyDown,
     id,
+    className,
     htmlProps,
     ...rest
   } = props;
@@ -130,7 +131,7 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
   };
 
   const buttonProps = {
-    ...getBaseHTMLProps(id, htmlProps, rest),
+    ...getBaseHTMLProps(id, className, htmlProps, rest),
     ref: combinedRef,
     'aria-selected': active,
     role: 'tab',

--- a/components/src/components/Tabs/TabPanel.tsx
+++ b/components/src/components/Tabs/TabPanel.tsx
@@ -30,9 +30,9 @@ export type TabPanelProps = BaseComponentPropsWithChildren<
 >;
 
 export const TabPanel = forwardRef<HTMLDivElement, TabPanelProps>(
-  ({ active = false, children, id, htmlProps, ...rest }, ref) => {
+  ({ active = false, children, id, className, htmlProps, ...rest }, ref) => {
     const panelProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(id, className, htmlProps, rest),
       ref,
       tabIndex: 0,
       role: 'tabpanel',

--- a/components/src/components/Tabs/Tabs.tsx
+++ b/components/src/components/Tabs/Tabs.tsx
@@ -35,6 +35,7 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
     tabContentDirection = 'row',
     tabWidth = '150px',
     children,
+    className,
     htmlProps,
     ...rest
   } = props;
@@ -52,9 +53,8 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
   };
 
   const containerProps = {
-    ...getBaseHTMLProps(id, htmlProps, rest),
-    ref,
-    id: uniqueId
+    ...getBaseHTMLProps(uniqueId, className, htmlProps, rest),
+    ref
   };
   return (
     <TabsContext.Provider

--- a/components/src/components/Tag/Tag.tsx
+++ b/components/src/components/Tag/Tag.tsx
@@ -32,11 +32,18 @@ export type TagProps = BaseComponentProps<
 >;
 
 export const Tag = forwardRef<HTMLSpanElement, TagProps>((props, ref) => {
-  const { text, purpose = 'default', id, htmlProps, ...rest } = props;
+  const {
+    text,
+    purpose = 'default',
+    id,
+    className,
+    htmlProps,
+    ...rest
+  } = props;
 
   return (
     <Wrapper
-      {...getBaseHTMLProps(id, htmlProps, rest)}
+      {...getBaseHTMLProps(id, className, htmlProps, rest)}
       forwardedAs="span"
       typographyType="bodySans01"
       ref={ref}

--- a/components/src/components/TextInput/CharCounter.tsx
+++ b/components/src/components/TextInput/CharCounter.tsx
@@ -20,7 +20,7 @@ type Props = BaseComponentProps<
 let nextUniqueId = 0;
 
 function CharCounter(props: Props) {
-  const { current, max, id, htmlProps, ...rest } = props;
+  const { current, max, id, className, htmlProps, ...rest } = props;
 
   const [uniqueId] = useState<string>(
     id ?? `characterCounter-${nextUniqueId++}`
@@ -28,10 +28,9 @@ function CharCounter(props: Props) {
 
   return (
     <Wrapper
-      {...getBaseHTMLProps(id, htmlProps, rest)}
+      {...getBaseHTMLProps(uniqueId, className, htmlProps, rest)}
       forwardedAs="div"
       typographyType="supportingStyleHelperText01"
-      id={uniqueId}
       aria-label={`${current} av ${max} tegn skrevet`}
     >
       {current}/{max}

--- a/components/src/components/ToggleButton/ToggleButton.tsx
+++ b/components/src/components/ToggleButton/ToggleButton.tsx
@@ -62,13 +62,12 @@ export type ToggleButtonProps = BaseComponentProps<
 >;
 
 export const ToggleButton = forwardRef<HTMLInputElement, ToggleButtonProps>(
-  ({ id, label, Icon, htmlProps, ...rest }, ref) => {
+  ({ id, label, Icon, className, htmlProps, ...rest }, ref) => {
     const [uniqueId] = useState<string>(id ?? `toggleButton-${nextUniqueId++}`);
 
     const inputProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(uniqueId, className, htmlProps, rest),
       ref,
-      id: uniqueId,
       type: 'checkbox'
     };
 

--- a/components/src/components/ToggleButton/ToggleButtonGroup.tsx
+++ b/components/src/components/ToggleButton/ToggleButtonGroup.tsx
@@ -41,6 +41,7 @@ export const ToggleButtonGroup = (props: ToggleButtonGroupProps) => {
     label,
     labelId,
     id,
+    className,
     htmlProps,
     ...rest
   } = props;
@@ -54,7 +55,7 @@ export const ToggleButtonGroup = (props: ToggleButtonGroupProps) => {
   };
 
   const containerProps = {
-    ...getBaseHTMLProps(id, htmlProps, rest),
+    ...getBaseHTMLProps(id, className, htmlProps, rest),
     role: 'group',
     'aria-labelledby': label ? uniqueLabelId : undefined
   };

--- a/components/src/components/Tooltip/Tooltip.tsx
+++ b/components/src/components/Tooltip/Tooltip.tsx
@@ -27,7 +27,7 @@ type AnchorElement = React.ReactElement & React.RefAttributes<HTMLElement>;
 
 type PickedHTMLAttributes = Pick<
   HTMLAttributes<HTMLDivElement>,
-  'style' | 'onMouseLeave' | 'onMouseOver' | 'className'
+  'style' | 'onMouseLeave' | 'onMouseOver'
 >;
 
 export type TooltipProps = BaseComponentProps<
@@ -60,8 +60,8 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       style,
       onMouseLeave,
       onMouseOver,
-      className,
       id,
+      className,
       htmlProps,
       ...rest
     } = props;
@@ -115,9 +115,8 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     );
 
     const containerProps = {
-      ...getBaseHTMLProps(id, htmlProps, rest),
+      ...getBaseHTMLProps(id, className, htmlProps, rest),
       style,
-      className,
       onMouseLeave: combineHandlers(closeTooltip, onMouseLeave),
       onMouseOver: combineHandlers(openTooltip, onMouseOver)
     };

--- a/components/src/types/BaseComponentsProps.spec.tsx
+++ b/components/src/types/BaseComponentsProps.spec.tsx
@@ -1,0 +1,150 @@
+import { BaseComponentProps, getBaseHTMLProps } from './BaseComponentProps';
+
+type BCP = BaseComponentProps<HTMLElement> & {};
+
+describe('getBaseHTMLProps', () => {
+  it('returns empty object if not receiving any non-undefined arguments', () => {
+    const baseHTMLProps = getBaseHTMLProps(undefined, undefined, undefined, {});
+
+    expect(baseHTMLProps).toStrictEqual({});
+  });
+  it('returns id from base argument', () => {
+    const props: BCP = { id: 'foo' };
+
+    const { id, className, htmlProps, testProp, ...rest } = props;
+
+    const baseHTMLProps = getBaseHTMLProps(id, className, htmlProps, rest);
+
+    expect(baseHTMLProps).toStrictEqual({
+      id: 'foo'
+    });
+  });
+  it('returns id from htmlProps if base id is not set', () => {
+    const props: BCP = { htmlProps: { id: 'fewa' } };
+
+    const { id, className, htmlProps, testProp, ...rest } = props;
+
+    const baseHTMLProps = getBaseHTMLProps(id, className, htmlProps, rest);
+
+    expect(baseHTMLProps).toStrictEqual({
+      id: 'fewa'
+    });
+  });
+  it('returns className from base argument', () => {
+    const props: BCP = { className: 'foo' };
+
+    const { id, className, htmlProps, testProp, ...rest } = props;
+
+    const baseHTMLProps = getBaseHTMLProps(id, className, htmlProps, rest);
+
+    expect(baseHTMLProps).toStrictEqual({
+      className: 'foo'
+    });
+  });
+  it('returns className from htmlProps if base className is not set', () => {
+    const props: BCP = { htmlProps: { className: 'fewa' } };
+
+    const { id, className, htmlProps, testProp, ...rest } = props;
+
+    const baseHTMLProps = getBaseHTMLProps(id, className, htmlProps, rest);
+
+    expect(baseHTMLProps).toStrictEqual({
+      className: 'fewa'
+    });
+  });
+  it('returns className from both base and htmlProps if both are set', () => {
+    const props: BCP = {
+      className: 'foobar',
+      htmlProps: { className: 'fewa' }
+    };
+
+    const { id, className, htmlProps, testProp, ...rest } = props;
+
+    const baseHTMLProps = getBaseHTMLProps(id, className, htmlProps, rest);
+
+    expect(baseHTMLProps).toStrictEqual({
+      className: 'foobar fewa'
+    });
+  });
+  it('returns htmlProps from base argument without id and with joined className', () => {
+    const props: BCP = {
+      id: 'fooid',
+      className: 'baseclassName',
+      htmlProps: {
+        id: 'htmlPropsId',
+        'aria-activedescendant': 'fewa',
+        title: 'fewafewa',
+        className: 'htmlPropsClassName'
+      }
+    };
+
+    const { id, className, htmlProps, testProp, ...rest } = props;
+
+    const baseHTMLProps = getBaseHTMLProps(id, className, htmlProps, rest);
+
+    expect(baseHTMLProps).toStrictEqual({
+      id: 'fooid',
+      'aria-activedescendant': 'fewa',
+      title: 'fewafewa',
+      className: 'baseclassName htmlPropsClassName'
+    });
+  });
+  it('returns unknownProps from base argument "rest"', () => {
+    const props: BCP = {
+      id: 'fooid',
+      htmlProps: {
+        'aria-label': 'arialabel'
+      },
+      'data-unknownProp': 'lol',
+      'data-unknownProp2': 'lol2'
+    };
+
+    const { id, className, htmlProps, testProp, ...rest } = props;
+
+    const baseHTMLProps = getBaseHTMLProps(id, className, htmlProps, rest);
+
+    expect(baseHTMLProps).toStrictEqual({
+      id: 'fooid',
+      'aria-label': 'arialabel',
+      'data-unknownProp': 'lol',
+      'data-unknownProp2': 'lol2'
+    });
+  });
+  it('overwrites aria-attributes that are set on the root if they are set on htmlprops', () => {
+    const props: BCP = {
+      'aria-label': 'foobar',
+      'aria-describedby': 'other',
+      htmlProps: { 'aria-label': 'arialabelfromhtmlprops' }
+    };
+
+    const { id, className, htmlProps, testProp, ...rest } = props;
+
+    const baseHTMLProps = getBaseHTMLProps(id, htmlProps, rest);
+
+    expect(baseHTMLProps).toStrictEqual({
+      'aria-label': 'arialabelfromhtmlprops',
+      'aria-describedby': 'other'
+    });
+  });
+  it('works without className argument', () => {
+    const props: BCP = {
+      id: 'foo',
+      htmlProps: {
+        className: 'fewa',
+        'aria-label': 'arialabl'
+      },
+      'data-unknownProp': 'foo'
+    };
+
+    const { id, className, htmlProps, testProp, ...rest } = props;
+
+    const baseHTMLProps = getBaseHTMLProps(id, htmlProps, rest);
+
+    expect(baseHTMLProps).toStrictEqual({
+      id: 'foo',
+      className: 'fewa',
+      'aria-label': 'arialabl',
+      'data-unknownProp': 'foo'
+    });
+  });
+});


### PR DESCRIPTION
Etter overgang til `htmlProps` ble det litt kronglete å bruke
`className` siden den måtte settes i `htmlProps`. Flytter den opp til
toppnivå for alle komponenter, og slår sammen med `className`
spesifisert i `htmlProps` dersom den er spesifisert begge steder.

Utvider også `getBaseHTMLProps` med className-argument, samt overload
slik at den kan brukes både med og uten `className`-parameter.

Legger også til tester for `getBaseHTMLProps` som forhåpentligvis
belyser forventet oppførsel.

Et par steder hvor `id` for komponenten var satt til `uniqueId` etter
å ha spreadet `getBaseHTMLProps` endres det også til å bare sende
`uniqueId` rett inn til `getBaseHTMLProps` for å slippe en linje.