### PR TITLE
Gjør `WithRequiredIf` litt strengere.

### DIFF
--- a/components/src/types/utils.ts
+++ b/components/src/types/utils.ts
@@ -9,4 +9,4 @@ export type WithRequiredIf<
   Condition extends boolean,
   T,
   K extends keyof T
-> = Omit<T, K> & Pick<Condition extends true ? Required<T> : T, K>;
+> = Omit<T, K> & Pick<true extends Condition ? Required<T> : T, K>;


### PR DESCRIPTION
I noen tilfeller gjorde TS sin typesammenslåing slik at `Condition` ble
`boolean` istedenfor `true` eller `false`, som førte til at
`WithRequiredIf` sin `Condition` da alltid valgte feil grein. Hvis
man isteden flipper fra `Condition extends true` til
`true extends Condition` fungerer det fint.