### PR TITLE
Fikser initiell visning av tegnteller

### DIFF
--- a/components/src/components/TextInput/TextInput.spec.tsx
+++ b/components/src/components/TextInput/TextInput.spec.tsx
@@ -65,4 +65,14 @@ describe('<TextInput />', () => {
     expect(screen.queryByText(errorMessage)).toBeDefined;
     expect(screen.queryByText(tip)).not.toBeDefined;
   });
+  it('should render correct number of characters when both maxLength and value are provided', () => {
+    const value = 'Test';
+    const valueLength = value.length;
+    const maxLength = 10;
+
+    render(<TextInput maxLength={maxLength} value={value} />);
+
+    const textElement = screen.getByText(`${valueLength}/${maxLength}`);
+    expect(textElement).toBeInTheDocument();
+  });
 });

--- a/components/src/components/TextInput/TextInput.tsx
+++ b/components/src/components/TextInput/TextInput.tsx
@@ -35,13 +35,17 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       withCharacterCounter = true,
       className,
       style,
+      value,
+      defaultValue,
       'aria-describedby': ariaDescribedby,
       ...rest
     },
     ref
   ) => {
     const textAreaRef = useRef<HTMLTextAreaElement>(null);
-    const [text, setText] = useState('');
+    const [text, setText] = useState<string>(
+      getDefaultText(value, defaultValue)
+    );
 
     useEffect(() => {
       if (textAreaRef && textAreaRef.current) {
@@ -101,6 +105,8 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       readOnly,
       tabIndex: readOnly ? -1 : 0,
       maxLength,
+      value,
+      defaultValue,
       'aria-describedby': spaceSeparatedIdListGenerator([
         tipId,
         errorMessageId,
@@ -185,3 +191,18 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     );
   }
 );
+
+function getDefaultText(
+  value?: string | number | readonly string[],
+  defaultValue?: string | number | readonly string[]
+): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof defaultValue === 'string') {
+    return defaultValue;
+  }
+
+  return '';
+}


### PR DESCRIPTION
Tegnteller viste alltid 0 for gjeldende antall tegn dersom `value` var satt initielt på `TextInput`.

Før:

![Screenshot 2022-08-03 at 07 48 25](https://user-images.githubusercontent.com/8463735/182533974-335fb916-9c7d-45f8-a207-389a4723455a.png)

Etter:

![Screenshot 2022-08-03 at 07 48 48](https://user-images.githubusercontent.com/8463735/182533999-c83267bb-d600-4028-bc5a-92b371dabc7f.png)
