### PR TITLE
Begrenser årstall til å være 4 siffer som standard

### DIFF
--- a/components/src/components/Datepicker/Datepicker.tsx
+++ b/components/src/components/Datepicker/Datepicker.tsx
@@ -84,6 +84,7 @@ export const Datepicker = forwardRef<HTMLInputElement, DatepickerProps>(
       tip,
       style,
       className,
+      max,
       'aria-describedby': ariaDescribedby,
       ...rest
     },
@@ -120,6 +121,7 @@ export const Datepicker = forwardRef<HTMLInputElement, DatepickerProps>(
         ariaDescribedby
       ]),
       'aria-invalid': hasErrorMessage ? true : undefined,
+      max: max || '9999-12-31', // Limit the year-part to only four digits by default
       ...rest
     };
 


### PR DESCRIPTION
Forslag om å begrense årstall til kun 4 tegn som standard i `Datepicker` - i stedet for å tillate 6 siffer som det er i dag.