### PR TITLE
ELSA1-111 Bytter ut alle toBeDefined med toBeInTheDocument

### DIFF
--- a/components/src/components/Button/Button.spec.tsx
+++ b/components/src/components/Button/Button.spec.tsx
@@ -5,7 +5,7 @@ describe('<Button />', () => {
   it('should have a label', () => {
     const label = 'button label';
     render(<Button label={label} />);
-    expect(screen.queryByText(label)).toBeDefined;
+    expect(screen.queryByText(label)).toBeInTheDocument();
   });
   it('renders an anchor element if href prop is provided', () => {
     render(<Button href="/" />);

--- a/components/src/components/Card/Card.spec.tsx
+++ b/components/src/components/Card/Card.spec.tsx
@@ -5,7 +5,7 @@ describe('<Card />', () => {
   it('should render content text', () => {
     const text = 'text';
     render(<Card cardType="info">{text}</Card>);
-    expect(screen.queryByText(text)).toBeDefined;
+    expect(screen.queryByText(text)).toBeInTheDocument();
   });
   it('should render an anchor element when cardType is navigation and href is provided', () => {
     render(

--- a/components/src/components/Checkbox/Checkbox.spec.tsx
+++ b/components/src/components/Checkbox/Checkbox.spec.tsx
@@ -6,7 +6,7 @@ describe('<Checkbox />', () => {
     const label = 'Select me';
     render(<Checkbox label={label} />);
     const labelElement = screen.getByText(label);
-    expect(labelElement).toBeDefined();
+    expect(labelElement).toBeInTheDocument();
   });
   it('should be selectable', () => {
     render(<Checkbox id="test" label="Test" />);

--- a/components/src/components/Datepicker/Datepicker.spec.tsx
+++ b/components/src/components/Datepicker/Datepicker.spec.tsx
@@ -5,24 +5,24 @@ describe('<Datepicker />', () => {
   it('should have a label', () => {
     const label = 'label';
     render(<Datepicker label={label} />);
-    expect(screen.queryByText(label)).toBeDefined;
+    expect(screen.queryByText(label)).toBeInTheDocument();
   });
   it('renders provided error message', () => {
     const errorMessage = 'this is an error';
     render(<Datepicker errorMessage={errorMessage} />);
-    expect(screen.queryByText(errorMessage)).toBeDefined;
+    expect(screen.queryByText(errorMessage)).toBeInTheDocument();
   });
   it('renders provided tip', () => {
     const tip = 'this is a tip';
     render(<Datepicker tip={tip} />);
-    expect(screen.queryByText(tip)).toBeDefined;
+    expect(screen.queryByText(tip)).toBeInTheDocument();
   });
   it('renders error message instead of tip when both are provided', () => {
     const tip = 'this is a tip';
     const errorMessage = 'this is an error';
     render(<Datepicker tip={tip} errorMessage={errorMessage} />);
-    expect(screen.queryByText(errorMessage)).toBeDefined;
-    expect(screen.queryByText(tip)).not.toBeDefined;
+    expect(screen.queryByText(errorMessage)).toBeInTheDocument();
+    expect(screen.queryByText(tip)).not.toBeInTheDocument();
   });
   it('should have aria-describedby when tip provided', () => {
     const id = 'id';

--- a/components/src/components/DescriptionList/DescriptionList.spec.tsx
+++ b/components/src/components/DescriptionList/DescriptionList.spec.tsx
@@ -10,7 +10,7 @@ describe('<DescriptionList />', () => {
         <DescriptionListDesc>desc</DescriptionListDesc>
       </DescriptionList>
     );
-    expect(screen.queryByText(termText)).toBeDefined();
+    expect(screen.queryByText(termText)).toBeInTheDocument();
   });
   it('should render description', () => {
     const descText = 'desc';
@@ -22,6 +22,6 @@ describe('<DescriptionList />', () => {
     );
     const desc = screen.getByRole('definition');
     expect(desc).toBeInTheDocument();
-    expect(screen.queryByText(descText)).toBeDefined();
+    expect(screen.queryByText(descText)).toBeInTheDocument();
   });
 });

--- a/components/src/components/GlobalMessage/GlobalMessage.spec.tsx
+++ b/components/src/components/GlobalMessage/GlobalMessage.spec.tsx
@@ -6,7 +6,7 @@ describe('<GlobalMessage />', () => {
     const message = 'This is a message';
     render(<GlobalMessage message={message} />);
     const messageElement = screen.getByText(message);
-    expect(messageElement).toBeDefined();
+    expect(messageElement).toBeInTheDocument();
   });
 
   it('should call onClose event', () => {

--- a/components/src/components/InternalHeader/InternalHeader.spec.tsx
+++ b/components/src/components/InternalHeader/InternalHeader.spec.tsx
@@ -6,7 +6,7 @@ describe('<InternalHeader />', () => {
     const appName = 'appName';
     render(<InternalHeader applicationName={appName} />);
     const appNameElement = screen.getByText(appName);
-    expect(appNameElement).toBeDefined();
+    expect(appNameElement).toBeInTheDocument();
   });
 
   it('should run onclick event from context menu', () => {

--- a/components/src/components/List/List.spec.tsx
+++ b/components/src/components/List/List.spec.tsx
@@ -39,6 +39,6 @@ describe('<List />', () => {
       </List>
     );
     const listItemText = screen.getByText(text);
-    expect(listItemText).toBeDefined();
+    expect(listItemText).toBeInTheDocument();
   });
 });

--- a/components/src/components/LocalMessage/LocalMessage.spec.tsx
+++ b/components/src/components/LocalMessage/LocalMessage.spec.tsx
@@ -6,7 +6,7 @@ describe('<LocalMessage />', () => {
     const message = 'This is a message';
     render(<LocalMessage message={message} />);
     const messageElement = screen.getByText(message);
-    expect(messageElement).toBeDefined();
+    expect(messageElement).toBeInTheDocument();
   });
 
   it('should call onClose event', () => {

--- a/components/src/components/Popover/Popover.spec.tsx
+++ b/components/src/components/Popover/Popover.spec.tsx
@@ -34,7 +34,7 @@ describe('<Popover />', () => {
       </PopoverGroup>
     );
     const titleElement = screen.getByText(title);
-    expect(titleElement).toBeDefined();
+    expect(titleElement).toBeInTheDocument();
   });
 
   it('should render content', () => {
@@ -46,7 +46,7 @@ describe('<Popover />', () => {
       </PopoverGroup>
     );
     const contentElement = screen.getByText(content);
-    expect(contentElement).toBeDefined();
+    expect(contentElement).toBeInTheDocument();
   });
 
   //må fikse disse testene

--- a/components/src/components/Search/Search.spec.tsx
+++ b/components/src/components/Search/Search.spec.tsx
@@ -12,12 +12,12 @@ describe('<Search />', () => {
     render(<Search buttonProps={{ onClick: e => {}, label: label }} />);
     const button = screen.getByRole('button');
     expect(button).toBeInTheDocument();
-    expect(screen.queryByText(label)).toBeDefined;
+    expect(screen.queryByText(label)).toBeInTheDocument();
   });
   it('renders provided tip', () => {
     const tip = 'tip';
     render(<Search tip={tip} />);
-    expect(screen.queryByText(tip)).toBeDefined;
+    expect(screen.queryByText(tip)).toBeInTheDocument();
   });
   it('should have aria-dsecribedby when tip provided', () => {
     const tip = 'tip';

--- a/components/src/components/Select/Select.spec.tsx
+++ b/components/src/components/Select/Select.spec.tsx
@@ -8,7 +8,7 @@ describe('<Select />', () => {
       <Select options={[{ label: 'label', value: 'item' }]} label={label} />
     );
     const labelElement = screen.getByText(label);
-    expect(labelElement).toBeDefined();
+    expect(labelElement).toBeInTheDocument();
   });
   it('should have aria-describedby when tip provided', () => {
     const id = 'id';

--- a/components/src/components/SkipToContent/SkipToContent.spec.tsx
+++ b/components/src/components/SkipToContent/SkipToContent.spec.tsx
@@ -12,6 +12,6 @@ describe('<SkipToContent />', () => {
     const text = 'text';
     render(<SkipToContent href="#" text={text} />);
     const labelElement = screen.getByText(text);
-    expect(labelElement).toBeDefined();
+    expect(labelElement).toBeInTheDocument();
   });
 });

--- a/components/src/components/Table/Table.spec.tsx
+++ b/components/src/components/Table/Table.spec.tsx
@@ -34,8 +34,8 @@ describe('<Table />', () => {
     );
     const headerTextNode = screen.getByText(headerText);
     const bodyTextNode = screen.getByText(bodyText);
-    expect(headerTextNode).toBeDefined();
-    expect(bodyTextNode).toBeDefined();
+    expect(headerTextNode).toBeInTheDocument();
+    expect(bodyTextNode).toBeInTheDocument();
   });
   it('renders a header cell', () => {
     const headerText = 'header';

--- a/components/src/components/TextInput/TextInput.spec.tsx
+++ b/components/src/components/TextInput/TextInput.spec.tsx
@@ -5,17 +5,17 @@ describe('<TextInput />', () => {
   it('should have a label', () => {
     const label = 'button label';
     render(<TextInput label={label} />);
-    expect(screen.queryByText(label)).toBeDefined;
+    expect(screen.queryByText(label)).toBeInTheDocument();
   });
   it('renders provided error message', () => {
     const errorMessage = 'this is an error';
     render(<TextInput errorMessage={errorMessage} />);
-    expect(screen.queryByText(errorMessage)).toBeDefined;
+    expect(screen.queryByText(errorMessage)).toBeInTheDocument();
   });
   it('renders provided tip', () => {
     const tip = 'this is a tip';
     render(<TextInput tip={tip} />);
-    expect(screen.queryByText(tip)).toBeDefined;
+    expect(screen.queryByText(tip)).toBeInTheDocument();
   });
   it('should have aria-describedby when tip provided', () => {
     const id = 'id';
@@ -44,7 +44,7 @@ describe('<TextInput />', () => {
       'aria-describedby',
       `${id}-characterCounter`
     );
-    expect(screen.queryByText(`0/${length}`)).toBeDefined;
+    expect(screen.queryByText(`0/${length}`)).toBeInTheDocument();
   });
   it('should not have character counter when both maxLength and withCharacterCounter=false provided', () => {
     const id = 'id';
@@ -56,14 +56,14 @@ describe('<TextInput />', () => {
       'aria-describedby',
       `${id}-characterCounter`
     );
-    expect(screen.queryByText(`0/${length}`)).not.toBeDefined;
+    expect(screen.queryByText(`0/${length}`)).not.toBeInTheDocument();
   });
   it('renders error message instead of tip when both are provided', () => {
     const tip = 'this is a tip';
     const errorMessage = 'this is an error';
     render(<TextInput tip={tip} errorMessage={errorMessage} />);
-    expect(screen.queryByText(errorMessage)).toBeDefined;
-    expect(screen.queryByText(tip)).not.toBeDefined;
+    expect(screen.queryByText(errorMessage)).toBeInTheDocument();
+    expect(screen.queryByText(tip)).not.toBeInTheDocument();
   });
   it('should render correct number of characters when both maxLength and value are provided', () => {
     const value = 'Test';

--- a/components/src/components/Tooltip/Tooltip.spec.tsx
+++ b/components/src/components/Tooltip/Tooltip.spec.tsx
@@ -37,7 +37,7 @@ describe('<Tooltip />', () => {
     );
     const textElement = screen.getByText(text);
     await waitFor(() => {
-      expect(textElement).toBeDefined();
+      expect(textElement).toBeInTheDocument();
     });
   });
   it('anchor element should have tooltip id as aria-describedby', async () => {

--- a/components/src/components/Typography/Typography.spec.tsx
+++ b/components/src/components/Typography/Typography.spec.tsx
@@ -5,6 +5,6 @@ describe('<Typography />', () => {
   it('should have text', () => {
     const text = 'text';
     render(<Typography>{text}</Typography>);
-    expect(screen.queryByText(text)).toBeDefined;
+    expect(screen.queryByText(text)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Ref.: https://github.com/domstolene/designsystem/pull/191#discussion_r937701496

Det ble oppdaget en feil med noen tester som ikke kalte `toBeDefined`-metoden, og dermed evaluerte ikke sjekken riktig. I tillegg benytter man seg ellers av `testing-library`-biblioteket som medfører at `toBeInTheDocument` kanskje er et mer naturlig valg enn `toBeDefined` i disse tilfellene.