### PR TITLE
Setter relativ sti til index.ts i components

### DIFF
--- a/components/rollup.config.js
+++ b/components/rollup.config.js
@@ -19,7 +19,7 @@ function isBareModuleId(id) {
 }
 
 export default {
-  input: 'src/index.ts',
+  input: './src/index.ts',
   output: [
     {
       dir: 'dist/cjs',


### PR DESCRIPTION
Etter oppgradering av rollup ble ikke lenger index.ts identifisert som
"internal" i `isBareModuleId` når bygget ble kjørt på CI. Setter relativ
sti isteden slik at `.` blir med i path.