### PR TITLE
Legger til workflow for publisering av prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,21 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build
-        working-directory: ${{ env.working-directory }}        
+        working-directory: ${{ env.working-directory }}
         run: npm run build
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to npm
+        if: ${{ github.event.release.prerelease == false }}
         working-directory: ${{ env.working-directory }}
         run: npm publish --tag latest
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish next to npm
+        if: ${{ github.event.release.prerelease == true }}
+        working-directory: ${{ env.working-directory }}
+        run: npm publish --tag next
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/components/README.md
+++ b/components/README.md
@@ -70,6 +70,12 @@ Det brukes en egen workflow for release av ny versjon av `@norges-domstoler/dds-
 
 For versjonering brukes [_semantisk versjonering_](https://semver.org/) for å holde ting organisert og for å enkelt kommunisere utviklingsløpet til pakken.
 
+### Pre-release versjoner
+
+Hvis man ønsker å publisere en pre-release kan man følge samme flyt som vanlig release, men markere releasen som "pre-release" på Github. Da vil det publiseres en ny versjon til `next`-taggen på NPM istedenfor `latest` som i normal flyt. Pre-releases kan brukes for å publisere innhold som er ment til å være med i neste versjon, men som kan testes av konsumenter før neste release er klar.
+
+Versjonsnummerering for pre-releases skal følge `-beta.x`, eksempelvis `5.0.0-beta.1` osv.
+
 ## ⌨️ For bidragsytere
 
 Sjekk ut [guiden for bidragsytere](https://design.domstol.no/987b33f71/p/34c962-bidra/b/3611d5).


### PR DESCRIPTION
Hvis man trigger en publish med en GH prerelease blir det nå publisert
til `next` taggen på NPM.