### PR TITLE
Fjerner Modify typen

### DIFF
--- a/components/src/components/Datepicker/Datepicker.tsx
+++ b/components/src/components/Datepicker/Datepicker.tsx
@@ -63,13 +63,10 @@ const StyledInput = styled(StatefulInput)`
 
 type DatepickerType = 'date' | 'datetime-local';
 
-export type DatepickerProps = Modify<
-  InputProps,
-  {
-    /** Angi dato-input med eller uten klokkeslett. */
-    type?: DatepickerType;
-  }
->;
+export type DatepickerProps = Omit<InputProps, 'type'> & {
+  /** Angi dato-input med eller uten klokkeslett. */
+  type?: DatepickerType;
+};
 
 export const Datepicker = forwardRef<HTMLInputElement, DatepickerProps>(
   (

--- a/components/typings/globals.d.ts
+++ b/components/typings/globals.d.ts
@@ -1,3 +1,2 @@
 type Nullable<T> = T | null;
 type Callback<T> = (e: T) => void;
-type Modify<T, R> = Omit<T, keyof R> & R;


### PR DESCRIPTION
Storybook addon docs som genererer dokumentasjon over tilgjengelige props klarer ikke å hente ut noe dersom `Modify`-typen brukes. Hvis man bruker de underliggende typene direkte vises API-dokumentasjonen som normalt.

Forventet resultat:

<img width="1173" alt="Screenshot 2022-09-12 at 12 45 38" src="https://user-images.githubusercontent.com/8463735/189634989-4258f90b-3338-4d11-8663-5dfec3e0583b.png">

Resultat med `Modify`:

![image](https://user-images.githubusercontent.com/8463735/189635063-f6c70d3a-e0d5-426f-9856-a191cf51ccb3.png)
