### PR TITLE
Fikser bug i if-sjekk for "activeTab"

### DIFF
--- a/components/src/components/Tabs/Tabs.tsx
+++ b/components/src/components/Tabs/Tabs.tsx
@@ -35,7 +35,7 @@ export type TabsProps = BaseComponentPropsWithChildren<
 export const Tabs = forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
   const {
     id,
-    activeTab = 0,
+    activeTab,
     onChange,
     tabContentDirection = 'row',
     tabWidth = '150px',
@@ -48,7 +48,7 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
   const generatedId = useId();
   const uniqueId = id ?? `${generatedId}-tabs`;
 
-  const [thisActiveTab, setActiveTab] = useState(activeTab);
+  const [thisActiveTab, setActiveTab] = useState(activeTab || 0);
   const [hasTabFocus, setHasTabFocus] = useState(false);
   const tabListRef = useRef<HTMLDivElement>(null);
   const tabPanelsRef = useRef<HTMLDivElement>(null);
@@ -59,7 +59,7 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
   };
 
   useEffect(() => {
-    if (activeTab && activeTab != thisActiveTab) {
+    if (activeTab !== undefined && activeTab !== thisActiveTab) {
       setActiveTab(activeTab);
     }
   }, [activeTab, thisActiveTab]);


### PR DESCRIPTION
0 er gyldig verdi som "activeTab", men vil slå ut som false i if-sjekken. Sjekker heller på "undefined" eksplisitt.