### PR TITLE
Fixups for CardAccordion

### DIFF
--- a/components/src/components/Card/Card.stories.tsx
+++ b/components/src/components/Card/Card.stories.tsx
@@ -16,6 +16,7 @@ import {
 import { Typography } from '../Typography';
 import styled from 'styled-components';
 import { ddsBaseTokens } from '@norges-domstoler/dds-design-tokens';
+import { useState } from 'react';
 
 export default {
   title: 'Design system/Card',
@@ -188,6 +189,24 @@ export const Accordion = (args: ExpandableCardProps) => {
       </Card>
       <Card {...args} cardType="expandable">
         <CardAccordion>
+          <CardAccordionHeader>Header</CardAccordionHeader>
+          <CardAccordionBody>Content</CardAccordionBody>
+        </CardAccordion>
+      </Card>
+    </StoryTemplate>
+  );
+};
+
+export const AccordionControlled = (args: ExpandableCardProps) => {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  return (
+    <StoryTemplate title="Card - accordion" gap="0">
+      <Card {...args} cardType="expandable">
+        <CardAccordion
+          isExpanded={isExpanded}
+          onChange={() => setIsExpanded(!isExpanded)}
+        >
           <CardAccordionHeader>Header</CardAccordionHeader>
           <CardAccordionBody>Content</CardAccordionBody>
         </CardAccordion>

--- a/components/src/components/Card/CardAccordion/CardAccordion.tsx
+++ b/components/src/components/Card/CardAccordion/CardAccordion.tsx
@@ -7,6 +7,7 @@ import {
   cloneElement,
   isValidElement,
   useId,
+  useCallback,
 } from 'react';
 import styled from 'styled-components';
 import {
@@ -21,6 +22,8 @@ export type CardAccordionProps = BaseComponentPropsWithChildren<
   {
     /**Spesifiserer om body skal være utvidet ved innlastning. */
     isExpanded?: boolean;
+    /**For å lytte til endringer i expanded-state. */
+    onChange?: (expanded: boolean) => void;
   }
 >;
 
@@ -28,6 +31,7 @@ export const CardAccordion = forwardRef<HTMLDivElement, CardAccordionProps>(
   (props, ref) => {
     const {
       isExpanded = false,
+      onChange,
       id,
       children,
       className,
@@ -44,9 +48,15 @@ export const CardAccordion = forwardRef<HTMLDivElement, CardAccordionProps>(
       setExpanded(isExpanded);
     }, [isExpanded]);
 
-    const toggleExpanded = () => {
-      setExpanded(!expanded);
-    };
+    const toggleExpanded = useCallback(() => {
+      const newExpanded = !expanded;
+
+      setExpanded(newExpanded);
+
+      if (onChange) {
+        onChange(newExpanded);
+      }
+    }, [expanded, onChange]);
 
     const Children = ReactChildren.map(children, (child, childIndex) => {
       const headerId = `${accordionId}-header`;

--- a/components/src/hooks/useIsMounted.ts
+++ b/components/src/hooks/useIsMounted.ts
@@ -1,0 +1,16 @@
+import { useRef, useEffect, useCallback } from 'react';
+
+const useIsMounted = () => {
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  return useCallback(() => isMounted.current, []);
+};
+
+export default useIsMounted;


### PR DESCRIPTION
* Legger til `onChange` prop for å la `isExpanded` være styrt fra konsument.
* Fikser initiell "flash" av animasjon dersom man ønsker å starte med accordion expanded.
* Legger til `useIsMounted`-hook for å fikse forrige punkt.