### PR TITLE
Støtte for 'aria-required' i inputkomponenter

### DIFF
--- a/components/src/components/Checkbox/CheckboxGroup.tsx
+++ b/components/src/components/Checkbox/CheckboxGroup.tsx
@@ -43,22 +43,28 @@ export type CheckboxGroupProps = BaseComponentPropsWithChildren<
   }
 >;
 
-export const CheckboxGroup = ({
-  label,
-  direction = 'row',
-  errorMessage,
-  tip,
-  required,
-  groupId,
-  children,
-  id,
-  className,
-  htmlProps,
-  ...rest
-}: CheckboxGroupProps) => {
+export const CheckboxGroup = (props: CheckboxGroupProps) => {
+  const {
+    label,
+    direction = 'row',
+    errorMessage,
+    tip,
+    required,
+    groupId,
+    children,
+    id,
+    className,
+    htmlProps = {},
+    ...rest
+  } = props;
+
+  const { 'aria-required': ariaRequired } = htmlProps;
+
   const generatedId = useId();
   const uniqueGroupId = groupId ?? `${generatedId}-checkboxGroup`;
   const hasErrorMessage = !!errorMessage;
+  const showRequiredMarker = required || ariaRequired;
+
   const errorMessageId = derivativeIdGenerator(
     uniqueGroupId,
     'errorMessage',
@@ -74,13 +80,20 @@ export const CheckboxGroup = ({
   };
 
   return (
-    <Container {...getBaseHTMLProps(id, className, htmlProps, rest)}>
+    <Container
+      {...getBaseHTMLProps(
+        id,
+        className,
+        { ...htmlProps, 'aria-required': ariaRequired },
+        rest
+      )}
+    >
       <Typography
         as="span"
         typographyType="supportingStyleLabel01"
         id={uniqueGroupId}
       >
-        {label} {required && <RequiredMarker />}
+        {label} {showRequiredMarker && <RequiredMarker />}
       </Typography>
       {tip && <InputMessage messageType="tip" message={tip} id={tipId} />}
       <CheckboxGroupContext.Provider value={{ ...contextProps }}>

--- a/components/src/components/Datepicker/Datepicker.tsx
+++ b/components/src/components/Datepicker/Datepicker.tsx
@@ -87,6 +87,7 @@ export const Datepicker = forwardRef<HTMLInputElement, DatepickerProps>(
       className,
       componentSize = 'medium',
       max,
+      'aria-required': ariaRequired,
       'aria-describedby': ariaDescribedby,
       ...rest
     },
@@ -98,6 +99,8 @@ export const Datepicker = forwardRef<HTMLInputElement, DatepickerProps>(
     const componentWidth = width ? width : getWidth(type, componentSize);
     const hasLabel = !!label;
     const hasErrorMessage = !!errorMessage;
+    const showRequiredMarker = required || ariaRequired;
+
     const errorMessageId = derivativeIdGenerator(
       uniqueId,
       'errorMessage',
@@ -120,6 +123,7 @@ export const Datepicker = forwardRef<HTMLInputElement, DatepickerProps>(
         errorMessageId,
         ariaDescribedby,
       ]),
+      'aria-required': ariaRequired,
       'aria-invalid': hasErrorMessage ? true : undefined,
       max: getMax(type, max),
       ...rest,
@@ -135,7 +139,7 @@ export const Datepicker = forwardRef<HTMLInputElement, DatepickerProps>(
       <OuterInputContainer {...outerinputContainerProps}>
         {hasLabel && (
           <Label htmlFor={uniqueId}>
-            {label} {required && <RequiredMarker />}
+            {label} {showRequiredMarker && <RequiredMarker />}
           </Label>
         )}
         <StyledInput {...inputProps} />

--- a/components/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/components/src/components/RadioButton/RadioButtonGroup.tsx
@@ -84,9 +84,11 @@ const RadioButtonGroupInner = <T extends string | number = string>(
     onChange,
     id,
     className,
-    htmlProps,
+    htmlProps = {},
     ...rest
   } = props;
+
+  const { 'aria-required': ariaRequired } = htmlProps;
 
   const [groupValue, setGroupValue] = useState<
     string | number | null | undefined
@@ -102,6 +104,7 @@ const RadioButtonGroupInner = <T extends string | number = string>(
 
   const hasErrorMessage = !!errorMessage;
   const hasTip = !!tip;
+  const showRequiredMarker = required || ariaRequired;
 
   const tipId = tip && `${uniqueGroupId}-tip`;
   const errorMessageId = errorMessage && `${uniqueGroupId}-errorMessage`;
@@ -118,13 +121,21 @@ const RadioButtonGroupInner = <T extends string | number = string>(
   };
 
   return (
-    <Container {...getBaseHTMLProps(id, className, htmlProps, rest)} ref={ref}>
+    <Container
+      {...getBaseHTMLProps(
+        id,
+        className,
+        { ...htmlProps, 'aria-required': ariaRequired },
+        rest
+      )}
+      ref={ref}
+    >
       <Typography
         as="span"
         typographyType="supportingStyleLabel01"
         id={uniqueGroupId}
       >
-        {label} {required && <RequiredMarker />}
+        {label} {showRequiredMarker && <RequiredMarker />}
       </Typography>
       {hasTip && <InputMessage message={tip} messageType="tip" id={tipId} />}
       <RadioButtonGroupContext.Provider value={{ ...contextProps }}>

--- a/components/src/components/Select/Select.tsx
+++ b/components/src/components/Select/Select.tsx
@@ -1,5 +1,5 @@
 import { Property } from 'csstype';
-import React, { ReactNode, useId } from 'react';
+import React, { HTMLAttributes, ReactNode, useId } from 'react';
 import {
   ClearIndicatorProps,
   components,
@@ -206,7 +206,8 @@ export type SelectProps<
   customSingleValueElement?: (
     props: SingleValueProps<TOption, IsMulti, GroupBase<TOption>>
   ) => JSX.Element;
-} & WrappedReactSelectProps<TOption, IsMulti, GroupBase<TOption>>;
+} & Pick<HTMLAttributes<HTMLInputElement>, 'aria-required'> &
+  WrappedReactSelectProps<TOption, IsMulti, GroupBase<TOption>>;
 
 type ForwardRefType<TOption, IsMulti extends boolean> = React.ForwardedRef<
   SelectInstance<TOption, IsMulti, GroupBase<TOption>>
@@ -216,13 +217,17 @@ const SelectInner = <
   TOption extends Record<string, unknown>,
   IsMulti extends boolean = false
 >(
-  {
+  props: SelectProps<TOption, IsMulti>,
+  ref: ForwardRefType<TOption, IsMulti>
+) => {
+  const {
     id,
     label,
     componentSize = 'medium',
     errorMessage,
     tip,
     required,
+    'aria-required': ariaRequired,
     readOnly,
     options,
     isMulti,
@@ -239,15 +244,16 @@ const SelectInner = <
     customOptionElement,
     customSingleValueElement,
     ...rest
-  }: SelectProps<TOption, IsMulti>,
-  ref: ForwardRefType<TOption, IsMulti>
-) => {
+  } = props;
+
   const generatedId = useId();
   const uniqueId = id ?? `${generatedId}-select`;
 
   const singleValueId = !isMulti ? `${uniqueId}-singleValue` : undefined;
   const hasLabel = !!label;
   const hasErrorMessage = !!errorMessage;
+  const showRequiredMarker = required || ariaRequired;
+
   const tipId = derivativeIdGenerator(uniqueId, 'tip', tip);
   const errorMessageId = derivativeIdGenerator(
     uniqueId,
@@ -298,7 +304,7 @@ const SelectInner = <
       NoOptionsMessage: DDSNoOptionsMessage,
       Input: props =>
         DDSInput(
-          props,
+          { ...props, required, 'aria-required': ariaRequired },
           hasErrorMessage,
           spaceSeparatedIdListGenerator([singleValueId, tipId, errorMessageId])
         ),
@@ -317,7 +323,7 @@ const SelectInner = <
     <Container {...containerProps}>
       {hasLabel && (
         <Label htmlFor={uniqueId}>
-          {label} {required && <RequiredMarker />}
+          {label} {showRequiredMarker && <RequiredMarker />}
         </Label>
       )}
       <ReactSelect {...reactSelectProps} ref={ref} />

--- a/components/src/components/TextInput/TextInput.stories.tsx
+++ b/components/src/components/TextInput/TextInput.stories.tsx
@@ -35,9 +35,16 @@ export const TextInputOverview = (args: TextInputProps) => {
         {...args}
         label={args.label ?? 'Label'}
         required
+        aria-required
         value="Påkrevd inputfelt"
       />
       <TextInput {...args} required value="Påkrevd inputfelt" />
+      <TextInput
+        {...args}
+        aria-required
+        label={args.label ?? 'Label'}
+        value="Påkrevd inputfelt med aria-required"
+      />
       <TextInput
         {...args}
         label={args.label ?? 'Label'}

--- a/components/src/components/TextInput/TextInput.tsx
+++ b/components/src/components/TextInput/TextInput.tsx
@@ -57,6 +57,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       style,
       value,
       defaultValue,
+      'aria-required': ariaRequired,
       'aria-describedby': ariaDescribedby,
       icon,
       ...rest
@@ -128,6 +129,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       maxLength,
       value,
       defaultValue,
+      'aria-required': ariaRequired,
       'aria-describedby': spaceSeparatedIdListGenerator([
         tipId,
         errorMessageId,
@@ -145,12 +147,14 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       width: getWidth(componentSize, width),
     };
 
+    const showRequiredMarker = required || ariaRequired;
+
     return (
       <OuterInputContainer {...outerInputContainerProps}>
         {hasLabel && (
           <Label htmlFor={uniqueId}>
             {label}
-            {required && <RequiredMarker />}
+            {showRequiredMarker && <RequiredMarker />}
           </Label>
         )}
         {multiline ? (


### PR DESCRIPTION
I enkelte tilfeller hvor man f.eks bruker et skjemabibliotek sammen med inputkomponenter gir det mening å ikke sette `required` direkte på komponenter, men heller la et eksternt bibliotek ta av seg validering. I disse tilfellene kan konsumenter sette 'aria-required' og så vil komponenten fungere som før untatt at html-validering ikke gjøres. Legger til støtte for dette i `CheckboxGroup`, `Datepicker`, `RadioButtonGroup`, `Select` og `TextInput`.