### PR TITLE
Fikser markering av tekst i knapper i Firefox

### DIFF
--- a/components/src/components/Button/Button.styles.tsx
+++ b/components/src/components/Button/Button.styles.tsx
@@ -21,6 +21,7 @@ type ButtonWrapperProps = {
 
 export const ButtonWrapper = styled.button<ButtonWrapperProps>`
   ${tokens.base}
+  user-select: text;
   display: inline-flex;
   align-items: center;
   justify-content: center;

--- a/components/src/components/Card/CardAccordion/CardAccordionHeader.tsx
+++ b/components/src/components/Card/CardAccordion/CardAccordionHeader.tsx
@@ -23,6 +23,7 @@ const HeaderContainer = styled.div`
 `;
 
 const HeaderWrapper = styled.button`
+  user-select: text;
   position: relative;
   cursor: pointer;
   @media (prefers-reduced-motion: no-preference) {

--- a/components/src/components/OverflowMenu/OverflowMenuItem.tsx
+++ b/components/src/components/OverflowMenu/OverflowMenuItem.tsx
@@ -38,6 +38,7 @@ export const Span = styled.span`
 `;
 
 export const Link = styled.a`
+  user-select: text;
   border: none;
   cursor: pointer;
   outline: inherit;

--- a/components/src/components/Popover/Popover.stories.tsx
+++ b/components/src/components/Popover/Popover.stories.tsx
@@ -162,6 +162,7 @@ export const Overflow = (args: PopoverProps) => {
 export const InlineExample = (args: PopoverProps) => {
   const Trigger = styled.button`
     ${removeButtonStyling}
+    user-select: text;
     text-decoration: underline;
     color: ${ddsBaseTokens.colors.DdsColorInteractiveBase};
     &:hover {

--- a/components/src/components/Table/SortCell.tsx
+++ b/components/src/components/Table/SortCell.tsx
@@ -13,6 +13,7 @@ import { focusVisible, removeButtonStyling } from '../../helpers/styling';
 const { cell } = tableTokens;
 
 const StyledButton = styled.button`
+  user-select: text;
   ${removeButtonStyling}
   display: flex;
   align-items: center;

--- a/components/src/components/Tabs/Tab.tsx
+++ b/components/src/components/Tabs/Tab.tsx
@@ -28,6 +28,7 @@ type ButtonProps = {
 };
 
 const Button = styled.button<ButtonProps>`
+  user-select: text;
   @media (prefers-reduced-motion: no-preference) {
     transition: box-shadow 0.2s, border-bottom 0.2s, color 0.2s,
       ${focusVisibleTransitionValue};

--- a/components/src/components/Typography/Typography/Typography.tsx
+++ b/components/src/components/Typography/Typography/Typography.tsx
@@ -39,6 +39,7 @@ type StyledTypographyProps = {
 };
 
 const StyledTypography = styled.p<StyledTypographyProps>`
+  user-select: text;
   &::selection,
   *::selection {
     ${selection}


### PR DESCRIPTION
Firefox har ikke user-select satt i CSS for knapper.
Legger inn user-select: text; for alle komponenter som bruker <button>.