### PR TITLE
Dra TextArea ut av TextInput til egen komponent

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -69,6 +69,7 @@ Tilgjengelige komponenter:
 - Tabs
 - Tag
 - TextInput
+- TextArea
 - ToggleBar
 - ToggleButton
 - Tooltip

--- a/components/src/components/Checkbox/CheckboxGroup.tsx
+++ b/components/src/components/Checkbox/CheckboxGroup.tsx
@@ -1,7 +1,6 @@
 import { useId } from 'react';
 import styled, { css } from 'styled-components';
-import { RequiredMarker } from '../../helpers';
-import { InputMessage } from '../InputMessage';
+import { renderInputMessage, RequiredMarker } from '../../helpers';
 import { checkboxGroupTokens as tokens } from './CheckboxGroup.tokens';
 import { CheckboxGroupContext } from './CheckboxGroupContext';
 import { Typography } from '../Typography';
@@ -95,7 +94,7 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
       >
         {label} {showRequiredMarker && <RequiredMarker />}
       </Typography>
-      {tip && <InputMessage messageType="tip" message={tip} id={tipId} />}
+      {renderInputMessage(tip, tipId)}
       <CheckboxGroupContext.Provider value={{ ...contextProps }}>
         <GroupContainer
           role="group"
@@ -106,13 +105,7 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
           {children}
         </GroupContainer>
       </CheckboxGroupContext.Provider>
-      {errorMessage && (
-        <InputMessage
-          messageType="error"
-          message={errorMessage}
-          id={errorMessageId}
-        />
-      )}
+      {renderInputMessage(undefined, undefined, errorMessage, errorMessageId)}
     </Container>
   );
 };

--- a/components/src/components/Datepicker/Datepicker.tsx
+++ b/components/src/components/Datepicker/Datepicker.tsx
@@ -1,6 +1,5 @@
 import { forwardRef, useId } from 'react';
-import { InputMessage } from '../InputMessage';
-import { InputSize } from '../../helpers';
+import { InputSize, renderInputMessage } from '../../helpers';
 import { StatefulInput, OuterInputContainer, InputProps } from '../../helpers';
 import { Property } from 'csstype';
 import styled, { css } from 'styled-components';
@@ -143,16 +142,7 @@ export const Datepicker = forwardRef<HTMLInputElement, DatepickerProps>(
           </Label>
         )}
         <StyledInput {...inputProps} />
-        {hasErrorMessage && (
-          <InputMessage
-            message={errorMessage}
-            id={errorMessageId}
-            messageType="error"
-          />
-        )}
-        {tip && !hasErrorMessage && (
-          <InputMessage message={tip} id={tipId} messageType="tip" />
-        )}
+        {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
       </OuterInputContainer>
     );
   }

--- a/components/src/components/RadioButton/RadioButtonGroup.tsx
+++ b/components/src/components/RadioButton/RadioButtonGroup.tsx
@@ -8,8 +8,7 @@ import {
   useState,
 } from 'react';
 import styled, { css } from 'styled-components';
-import { RequiredMarker } from '../../helpers';
-import { InputMessage } from '../InputMessage';
+import { renderInputMessage, RequiredMarker } from '../../helpers';
 import { radioButtonGroupTokens as tokens } from './RadioButtonGroup.tokens';
 import { RadioButtonGroupContext } from './RadioButtonGroupContext';
 import { Typography } from '../Typography';
@@ -137,7 +136,7 @@ const RadioButtonGroupInner = <T extends string | number = string>(
       >
         {label} {showRequiredMarker && <RequiredMarker />}
       </Typography>
-      {hasTip && <InputMessage message={tip} messageType="tip" id={tipId} />}
+      {renderInputMessage(tip, tipId)}
       <RadioButtonGroupContext.Provider value={{ ...contextProps }}>
         <GroupContainer
           role="radiogroup"
@@ -149,13 +148,7 @@ const RadioButtonGroupInner = <T extends string | number = string>(
           {children}
         </GroupContainer>
       </RadioButtonGroupContext.Provider>
-      {hasErrorMessage && (
-        <InputMessage
-          message={errorMessage}
-          messageType="error"
-          id={errorMessageId}
-        />
-      )}
+      {renderInputMessage(undefined, undefined, errorMessage, errorMessageId)}
     </Container>
   );
 };

--- a/components/src/components/Search/Search.tsx
+++ b/components/src/components/Search/Search.tsx
@@ -11,8 +11,8 @@ import { searchTokens as tokens } from './Search.tokens';
 import {
   Input as BaseInput,
   InputProps as BaseInputProps,
+  renderInputMessage,
 } from '../../helpers';
-import { InputMessage } from '../InputMessage';
 import {
   derivativeIdGenerator,
   spaceSeparatedIdListGenerator,
@@ -166,9 +166,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
               />
             )}
           </HorisontalContainer>
-          {hasTip && (
-            <InputMessage id={tipId} messageType="tip" message={tip} />
-          )}
+          {renderInputMessage(tip, tipId)}
         </div>
       </OuterContainer>
     );

--- a/components/src/components/Select/Select.tsx
+++ b/components/src/components/Select/Select.tsx
@@ -23,7 +23,6 @@ import {
   spaceSeparatedIdListGenerator,
 } from '../../utils';
 import { Icon } from '../Icon';
-import { InputMessage } from '../InputMessage';
 import {
   Container,
   getCustomStyles,
@@ -33,7 +32,10 @@ import {
 } from './Select.styles';
 import { Label } from '../Typography';
 import { SvgIcon } from '../../icons/utils';
-import { getFormInputIconSize } from '../../helpers/Input/Input.utils';
+import {
+  getFormInputIconSize,
+  renderInputMessage,
+} from '../../helpers/Input/Input.utils';
 
 const {
   Option,
@@ -327,18 +329,7 @@ const SelectInner = <
         </Label>
       )}
       <ReactSelect {...reactSelectProps} ref={ref} />
-
-      {errorMessage && (
-        <InputMessage
-          messageType="error"
-          id={errorMessageId}
-          message={errorMessage}
-        />
-      )}
-
-      {tip && !errorMessage && (
-        <InputMessage messageType="tip" id={tipId} message={tip} />
-      )}
+      {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
     </Container>
   );
 };

--- a/components/src/components/TextArea/TextArea.spec.tsx
+++ b/components/src/components/TextArea/TextArea.spec.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react';
+import { TextArea } from '.';
+
+describe('<TeaxtArea />', () => {
+  it('should have a label', () => {
+    const label = 'button label';
+    const id = 'id';
+    render(<TextArea label={label} id={id} />);
+    expect(screen.queryByText(label)).toBeInTheDocument();
+    expect(screen.getByText(label)).toHaveAttribute('for', id);
+  });
+  it('renders provided error message', () => {
+    const errorMessage = 'this is an error';
+    render(<TextArea errorMessage={errorMessage} />);
+    expect(screen.queryByText(errorMessage)).toBeInTheDocument();
+  });
+  it('renders provided tip', () => {
+    const tip = 'this is a tip';
+    render(<TextArea tip={tip} />);
+    expect(screen.queryByText(tip)).toBeInTheDocument();
+  });
+  it('should have aria-describedby when tip provided', () => {
+    const id = 'id';
+    const tip = 'this is a tip';
+    render(<TextArea id={id} tip={tip} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'aria-describedby',
+      `${id}-tip`
+    );
+  });
+  it('should have aria-describedby and aria-invalid when errorMessage provided', () => {
+    const id = 'id';
+    const errorMessage = 'this is an errorMessage';
+    render(<TextArea id={id} errorMessage={errorMessage} />);
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'aria-describedby',
+      `${id}-errorMessage`
+    );
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+  });
+  it('renders error message instead of tip when both are provided', () => {
+    const tip = 'this is a tip';
+    const errorMessage = 'this is an error';
+    render(<TextArea tip={tip} errorMessage={errorMessage} />);
+    expect(screen.queryByText(errorMessage)).toBeInTheDocument();
+    expect(screen.queryByText(tip)).not.toBeInTheDocument();
+  });
+});

--- a/components/src/components/TextArea/TextArea.stories.mdx
+++ b/components/src/components/TextArea/TextArea.stories.mdx
@@ -1,0 +1,54 @@
+import {
+  Meta,
+  ArgsTable,
+  PRIMARY_STORY,
+  Story,
+  Canvas,
+} from '@storybook/addon-docs';
+import { TextArea } from '.';
+import {
+  Source,
+  ComponentLinkRow,
+  SB_DESIGNSYSTEM_URL,
+  LinkToInteractiveStory,
+} from '../../storybook';
+
+<Meta title="Design system/TextArea/API" component={TextArea} />
+
+# TextArea
+
+<ComponentLinkRow
+  docsHref="https://design.domstol.no/987b33f71/p/39f89e-textarea"
+  figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/?node-id=155%3A38"
+  githubHref="https://github.com/domstolene/designsystem/tree/master/components/src/components/TextArea"
+/>
+
+## Demo
+
+<Canvas>
+  <Story id="design-system-textarea--default" />
+</Canvas>
+<Canvas>
+  <Story id="design-system-textarea--with-label" />
+</Canvas>
+
+<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}-textarea`} />
+
+## Bruk i koden
+
+<Source code={`import { TextArea } from '@norges-domstoler/dds-components';
+
+<TextArea label="Ledetekst" />
+`} />
+
+## API
+
+<ArgsTable story={PRIMARY_STORY} />
+I tillegg støttes alle native HTML-attributter som er en del av `TextareaHTMLAttributes<HTMLTextAreaElement>`-interface.
+
+## Retningslinjer
+
+- Bruk gjerne `autofocus` for å indikere hvor brukeren skal starte.
+- Unngå å bruke `placeholder` - inputfeltet kan se ferdig fylt ut.
+- Bruk `onChange` slik at brukeren kan få umiddelbar tilbakemelding på deres input baser på validering.
+- Det kan være lurt å lagre kladd av input i skjemaet brukeren fyller ut.

--- a/components/src/components/TextArea/TextArea.stories.tsx
+++ b/components/src/components/TextArea/TextArea.stories.tsx
@@ -1,0 +1,86 @@
+import { StoryTemplate } from '../../storybook';
+import { TextArea, TextAreaProps } from '.';
+
+export default {
+  title: 'Design system/TextArea',
+  component: TextArea,
+  argTypes: {
+    label: { control: { type: 'text' } },
+    tip: { control: { type: 'text' } },
+    errorMessage: { control: { type: 'text' } },
+    width: { control: { type: 'text' } },
+    required: { control: { type: 'boolean' } },
+    disabled: { control: { type: 'boolean' } },
+    readOnly: { control: { type: 'boolean' } },
+  },
+  parameters: {
+    controls: {
+      exclude: ['style', 'className'],
+    },
+  },
+};
+
+export const Overview = (args: TextAreaProps) => {
+  return (
+    <StoryTemplate title="Textrea - overview" display="grid" columnsAmount={2}>
+      <TextArea {...args} label={args.label ?? 'Label'} />
+      <TextArea {...args} />
+      <TextArea
+        {...args}
+        label={args.label ?? 'Label'}
+        required
+        value="Påkrevd"
+      />
+      <TextArea {...args} required value="Påkrevd" />
+      <TextArea
+        {...args}
+        label={args.label ?? 'Label'}
+        disabled
+        value="Disabled"
+      />
+      <TextArea {...args} disabled value="Disabled" />
+      <TextArea
+        {...args}
+        label={args.label ?? 'Label'}
+        readOnly
+        value="Readonly"
+      />
+      <TextArea {...args} readOnly value="Readonly" />
+      <TextArea
+        {...args}
+        label={args.label ?? 'Label'}
+        errorMessage={
+          args.errorMessage || 'Dette er en feilmelding ved valideringsfeil'
+        }
+      />
+      <TextArea
+        {...args}
+        errorMessage={
+          args.errorMessage || 'Dette er en feilmelding ved valideringsfeil'
+        }
+      />
+      <TextArea
+        {...args}
+        label={args.label ?? 'Label'}
+        tip={args.tip || 'Dette er en hjelpetekst'}
+      />
+      <TextArea {...args} tip={args.tip || 'Dette er en hjelpetekst'} />
+    </StoryTemplate>
+  );
+};
+
+export const Default = (args: TextAreaProps) => {
+  return (
+    <StoryTemplate title="TextArea - default" display="block">
+      <TextArea {...args} />
+    </StoryTemplate>
+  );
+};
+
+export const WithLabel = (args: TextAreaProps) => {
+  return (
+    <StoryTemplate title="TextArea - with label">
+      <TextArea {...args} label={args.label ?? 'Label'} />
+    </StoryTemplate>
+  );
+};

--- a/components/src/components/TextArea/TextArea.tokens.tsx
+++ b/components/src/components/TextArea/TextArea.tokens.tsx
@@ -1,0 +1,11 @@
+import { ddsBaseTokens } from '@norges-domstoler/dds-design-tokens';
+
+const { spacing } = ddsBaseTokens;
+
+const textarea = {
+  paddingBottom: spacing.SizesDdsSpacingLocalX05,
+};
+
+export const textAreaTokens = {
+  textarea,
+};

--- a/components/src/components/TextArea/TextArea.tsx
+++ b/components/src/components/TextArea/TextArea.tsx
@@ -1,0 +1,140 @@
+import {
+  forwardRef,
+  TextareaHTMLAttributes,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+import styled from 'styled-components';
+import {
+  getDefaultText,
+  OuterInputContainer,
+  inputTokens,
+  StatefulInput,
+  StyledInputProps,
+  CommonInputProps,
+  renderInputMessage,
+} from '../../helpers/Input';
+import { useCombinedRef } from '../../hooks';
+import {
+  derivativeIdGenerator,
+  spaceSeparatedIdListGenerator,
+} from '../../utils';
+import { scrollbarStyling } from '../ScrollableContainer';
+import { Label } from '../Typography';
+import { textAreaTokens } from './TextArea.tokens';
+import { Property } from 'csstype';
+
+const defaultWidth: Property.Width<string> = '320px';
+const { textarea } = textAreaTokens;
+
+export const StyledTextArea = styled(StatefulInput)<StyledInputProps>`
+  ${scrollbarStyling.webkit}
+  ${scrollbarStyling.firefox}
+  height: auto;
+  resize: vertical;
+  vertical-align: bottom;
+  padding-bottom: ${textarea.paddingBottom};
+  ${inputTokens.input.sizes.medium.font}
+`;
+
+export type TextAreaProps = CommonInputProps &
+  TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
+  (props, ref) => {
+    const {
+      id,
+      value,
+      defaultValue,
+      onChange,
+      errorMessage,
+      required,
+      disabled,
+      tip,
+      label,
+      'aria-required': ariaRequired,
+      'aria-describedby': ariaDescribedby,
+      className,
+      style,
+      width = defaultWidth,
+      ...rest
+    } = props;
+
+    const generatedId = useId();
+    const uniqueId = id ?? `${generatedId}-textArea`;
+
+    const textAreaRef = useRef<HTMLTextAreaElement>(null);
+    const multiRef = useCombinedRef(ref, textAreaRef);
+    const [text, setText] = useState<string>(
+      getDefaultText(value, defaultValue)
+    );
+
+    useEffect(() => {
+      if (textAreaRef && textAreaRef.current) {
+        textAreaRef.current.style.height = `${
+          textAreaRef.current.scrollHeight + 2
+        }px`;
+      }
+    }, [text]);
+
+    const onChangeHandler: React.ChangeEventHandler<HTMLTextAreaElement> = (
+      event: React.ChangeEvent<HTMLTextAreaElement>
+    ) => {
+      setText(event.target.value);
+
+      if (onChange) {
+        onChange(event);
+      }
+    };
+
+    const hasErrorMessage = !!errorMessage;
+    const hasLabel = !!label;
+    const tipId = derivativeIdGenerator(uniqueId, 'tip', tip);
+    const errorMessageId = derivativeIdGenerator(
+      uniqueId,
+      'errorMessage',
+      errorMessage
+    );
+
+    const showRequiredStyling = required || !!ariaRequired;
+
+    const containerProps = {
+      width,
+      className,
+      style,
+    };
+
+    const textAreaProps = {
+      ref: multiRef,
+      onChange: onChangeHandler,
+      value,
+      defaultValue,
+      id: uniqueId,
+      disabled,
+      hasErrorMessage,
+      required,
+      'aria-required': ariaRequired,
+      'aria-describedby': spaceSeparatedIdListGenerator([
+        tipId,
+        errorMessageId,
+        ariaDescribedby,
+      ]),
+      'aria-invalid': hasErrorMessage ? true : undefined,
+      ...rest,
+    };
+
+    return (
+      <OuterInputContainer {...containerProps}>
+        {hasLabel && (
+          <Label showRequiredStyling={showRequiredStyling} htmlFor={uniqueId}>
+            {label}
+          </Label>
+        )}
+        <StyledTextArea {...textAreaProps} as="textarea" />
+        {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
+      </OuterInputContainer>
+    );
+  }
+);

--- a/components/src/components/TextArea/index.ts
+++ b/components/src/components/TextArea/index.ts
@@ -1,0 +1,1 @@
+export * from './TextArea';

--- a/components/src/components/TextInput/TextInput.stories.mdx
+++ b/components/src/components/TextInput/TextInput.stories.mdx
@@ -3,14 +3,14 @@ import {
   ArgsTable,
   PRIMARY_STORY,
   Story,
-  Canvas
+  Canvas,
 } from '@storybook/addon-docs';
 import { TextInput } from '.';
 import {
   Source,
   ComponentLinkRow,
   SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory
+  LinkToInteractiveStory,
 } from '../../storybook';
 import { Typography } from '../Typography';
 
@@ -33,13 +33,6 @@ import { Typography } from '../Typography';
   <Story id="design-system-textinput--with-label" />
 </Canvas>
 
-<Canvas>
-  <Story id="design-system-textinput--textarea" />
-</Canvas>
-<Canvas>
-  <Story id="design-system-textinput--textarea-with-label" />
-</Canvas>
-
 <LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}-textinput`} />
 
 ## Bruk i koden
@@ -47,13 +40,12 @@ import { Typography } from '../Typography';
 <Source code={`import { TextInput } from '@norges-domstoler/dds-components';
 
 <TextInput label="Ledetekst" />
-<TextInput label="Ledetekst" multiline />
 `} />
 
 ## API
 
 <ArgsTable story={PRIMARY_STORY} />
-I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLInputElement>` eller `InputHTMLAttributes<HTMLTextAreaElement>`-interface.
+I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLInputElement>`-interface.
 
 ### maxLength
 
@@ -63,7 +55,7 @@ Når native attributtet `maxLength` brukes dukker det opp en tegnteller til høy
   <Story id="design-system-textinput--with-character-count" />
 </Canvas>
 
-For å ikke vise tegntelleren sett ``withCharacterCounter=false`.
+For å ikke vise tegntelleren sett `withCharacterCounter=false`.
 
 ## Retningslinjer
 

--- a/components/src/components/TextInput/TextInput.stories.tsx
+++ b/components/src/components/TextInput/TextInput.stories.tsx
@@ -10,7 +10,6 @@ export default {
     tip: { control: { type: 'text' } },
     errorMessage: { control: { type: 'text' } },
     width: { control: { type: 'text' } },
-    multiline: { control: { type: 'boolean' } },
     required: { control: { type: 'boolean' } },
     disabled: { control: { type: 'boolean' } },
     readOnly: { control: { type: 'boolean' } },
@@ -116,82 +115,6 @@ export const TextInputOverviewSizes = () => (
   </StoryTemplate>
 );
 
-export const TextareaOverview = (args: TextInputProps) => {
-  return (
-    <StoryTemplate
-      title="Textarea (multiline) - overview"
-      display="grid"
-      columnsAmount={2}
-    >
-      <TextInput {...args} multiline label={args.label ?? 'Label'} />
-      <TextInput {...args} multiline />
-      <TextInput
-        {...args}
-        multiline
-        label={args.label ?? 'Label'}
-        required
-        value="Påkrevd textarea"
-      />
-      <TextInput {...args} multiline required value="Påkrevd textarea" />
-      <TextInput
-        {...args}
-        multiline
-        label={args.label ?? 'Label'}
-        disabled
-        value="Disabled textarea"
-      />
-      <TextInput {...args} multiline disabled value="Disabled textarea" />
-      <TextInput
-        {...args}
-        multiline
-        label={args.label ?? 'Label'}
-        readOnly
-        value="Readonly textarea"
-      />
-      <TextInput {...args} multiline readOnly value="Readonly textarea" />
-      <TextInput
-        {...args}
-        multiline
-        label={args.label ?? 'Label'}
-        errorMessage={
-          args.errorMessage || 'Dette er en feilmelding ved valideringsfeil'
-        }
-      />
-      <TextInput
-        {...args}
-        multiline
-        errorMessage={
-          args.errorMessage || 'Dette er en feilmelding ved valideringsfeil'
-        }
-      />
-      <TextInput
-        {...args}
-        multiline
-        label={args.label ?? 'Label'}
-        tip={args.tip || 'Dette er en hjelpetekst'}
-      />
-      <TextInput
-        {...args}
-        multiline
-        tip={args.tip || 'Dette er en hjelpetekst'}
-      />
-      <TextInput
-        {...args}
-        multiline
-        label={args.label ?? 'Label'}
-        tip={args.tip || 'Dette er en hjelpetekst med character count'}
-        maxLength={20}
-      />
-      <TextInput
-        {...args}
-        multiline
-        tip={args.tip || 'Dette er en hjelpetekst med character count'}
-        maxLength={20}
-      />
-    </StoryTemplate>
-  );
-};
-
 export const Default = (args: TextInputProps) => {
   return (
     <StoryTemplate title="TextInput - default">
@@ -212,22 +135,6 @@ export const WithCharacterCount = (args: TextInputProps) => {
   return (
     <StoryTemplate title="TextInput - with character count">
       <TextInput {...args} maxLength={25} label={args.label ?? 'Label'} />
-    </StoryTemplate>
-  );
-};
-
-export const Textarea = (args: TextInputProps) => {
-  return (
-    <StoryTemplate title="Textarea (multiline) - default">
-      <TextInput {...args} multiline />
-    </StoryTemplate>
-  );
-};
-
-export const TextareaWithLabel = (args: TextInputProps) => {
-  return (
-    <StoryTemplate title="Textarea (multiline) - with label">
-      <TextInput {...args} label={args.label ?? 'Label'} multiline />
     </StoryTemplate>
   );
 };

--- a/components/src/components/TextInput/TextInput.styles.tsx
+++ b/components/src/components/TextInput/TextInput.styles.tsx
@@ -8,16 +8,6 @@ import { ddsBaseTokens } from '@norges-domstoler/dds-design-tokens';
 const { iconSizes } = ddsBaseTokens;
 const { input, icon } = tokens;
 
-export const TextArea = styled(StatefulInput)<StyledInputProps>`
-  ${scrollbarStyling.webkit}
-  ${scrollbarStyling.firefox}
-  height: auto;
-  resize: vertical;
-  vertical-align: bottom;
-  padding-bottom: ${input.multiline.paddingBottom};
-  ${inputTokens.input.sizes.medium.font}
-`;
-
 export const MessageContainer = styled.div`
   display: flex;
   justify-content: space-between;

--- a/components/src/components/TextInput/TextInput.tsx
+++ b/components/src/components/TextInput/TextInput.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef, forwardRef, useId } from 'react';
 import { InputSize } from '../../helpers';
-import { InputMessage } from '../InputMessage';
 import CharCounter from './CharCounter';
 import { TextInputProps } from './TextInput.types';
 import {
@@ -8,19 +7,18 @@ import {
   InputContainer,
   OuterInputContainer,
 } from '../../helpers';
-import {
-  MessageContainer,
-  TextArea,
-  StyledIcon,
-  StyledInput,
-} from './TextInput.styles';
+import { MessageContainer, StyledIcon, StyledInput } from './TextInput.styles';
 import { Label } from '../Typography';
 import {
   derivativeIdGenerator,
   spaceSeparatedIdListGenerator,
 } from '../../utils';
 import { Property } from 'csstype';
-import { getFormInputIconSize } from '../../helpers/Input';
+import {
+  getDefaultText,
+  getFormInputIconSize,
+  renderInputMessage,
+} from '../../helpers/Input';
 
 const defaultWidth: Property.Width<string> = '320px';
 const defaultTinyWidth: Property.Width<string> = '210px';
@@ -46,7 +44,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       tip,
       required,
       maxLength,
-      multiline,
       onChange,
       id,
       width,
@@ -64,32 +61,13 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     },
     ref
   ) => {
-    const textAreaRef = useRef<HTMLTextAreaElement>(null);
     const [text, setText] = useState<string>(
       getDefaultText(value, defaultValue)
     );
 
-    useEffect(() => {
-      if (textAreaRef && textAreaRef.current) {
-        textAreaRef.current.style.height = `${
-          textAreaRef.current.scrollHeight + 2
-        }px`;
-      }
-    }, [text]);
-
     const onChangeHandler: React.ChangeEventHandler<HTMLInputElement> = (
       event: React.ChangeEvent<HTMLInputElement>
     ) => {
-      setText(event.target.value);
-
-      if (onChange) {
-        onChange(event);
-      }
-    };
-
-    const onChangeHandlerMultiline: React.ChangeEventHandler<
-      HTMLTextAreaElement
-    > = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
       setText(event.target.value);
 
       if (onChange) {
@@ -141,7 +119,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     };
 
     const outerInputContainerProps = {
-      multiline,
       className,
       style,
       width: getWidth(componentSize, width),
@@ -156,14 +133,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             {label}
           </Label>
         )}
-        {multiline ? (
-          <TextArea
-            ref={textAreaRef}
-            as="textarea"
-            onChange={onChangeHandlerMultiline}
-            {...generalInputProps}
-          />
-        ) : hasIcon ? (
+        {hasIcon ? (
           <InputContainer>
             {
               <StyledIcon
@@ -192,16 +162,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
         )}
         {hasMessage && (
           <MessageContainer>
-            {hasErrorMessage && (
-              <InputMessage
-                message={errorMessage}
-                messageType="error"
-                id={errorMessageId}
-              />
-            )}
-            {hasTip && !errorMessage && (
-              <InputMessage message={tip} messageType="tip" id={tipId} />
-            )}
+            {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
             {maxLength &&
               Number.isInteger(maxLength) &&
               maxLength > 0 &&
@@ -218,18 +179,3 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     );
   }
 );
-
-function getDefaultText(
-  value?: string | number | readonly string[],
-  defaultValue?: string | number | readonly string[]
-): string {
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  if (typeof defaultValue === 'string') {
-    return defaultValue;
-  }
-
-  return '';
-}

--- a/components/src/components/TextInput/TextInput.types.tsx
+++ b/components/src/components/TextInput/TextInput.types.tsx
@@ -1,14 +1,9 @@
-import { InputHTMLAttributes } from 'react';
-
 import { InputProps } from '../../helpers';
 import { SvgIcon } from '../../icons/utils';
 
-export type TextInputProps = {
-  /**Gjør inputfeltet om til `<textarea>`. */
-  multiline?: boolean;
-  /** Spesifiserer om tegntelleren skal vises. */
+export type TextInputProps = InputProps & {
+  /** Spesifiserer om tegntelleren skal vises ved bruk av `maxLength` attributt. */
   withCharacterCounter?: boolean;
   /** Ikonet som vises i komponenten. */
   icon?: SvgIcon;
-} & InputProps &
-  InputHTMLAttributes<HTMLTextAreaElement>;
+};

--- a/components/src/helpers/Input/Input.types.tsx
+++ b/components/src/helpers/Input/Input.types.tsx
@@ -1,24 +1,30 @@
 import { InputHTMLAttributes } from 'react';
 import { Property } from 'csstype';
 
-export type InputSize = 'medium' | 'small' | 'tiny';
-
-export type InputProps = {
+export type CommonInputProps = {
   /**Ledetekst for input. */
   label?: string;
-  /**Størrelse på inputfeltet. */
-  componentSize?: InputSize;
   /**Bredde for inputfeltet. */
   width?: Property.Width<string>;
   /**Hjelpetekst. */
   tip?: string;
   /**Feilmelding. Setter også error state. */
   errorMessage?: string;
+};
+
+export type InputSize = 'medium' | 'small' | 'tiny';
+
+export type InputProps = CommonInputProps & {
+  /**Størrelse på inputfeltet. */
+  componentSize?: InputSize;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-export type StyledInputProps = Pick<
+export type StyledCommonInputProps = Pick<
   InputProps,
-  'readOnly' | 'disabled' | 'componentSize'
+  'readOnly' | 'disabled'
 > & {
   hasErrorMessage: boolean;
 };
+
+export type StyledInputProps = StyledCommonInputProps &
+  Pick<InputProps, 'componentSize'>;

--- a/components/src/helpers/Input/Input.utils.tsx
+++ b/components/src/helpers/Input/Input.utils.tsx
@@ -1,4 +1,5 @@
 import { IconSize } from '../../components/Icon';
+import { InputMessage } from '../../components/InputMessage';
 import { InputSize } from './Input.types';
 
 export const getFormInputIconSize = (componentSize: InputSize): IconSize => {
@@ -11,3 +12,38 @@ export const getFormInputIconSize = (componentSize: InputSize): IconSize => {
       return 'small';
   }
 };
+
+export function getDefaultText(
+  value?: string | number | readonly string[],
+  defaultValue?: string | number | readonly string[]
+): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof defaultValue === 'string') {
+    return defaultValue;
+  }
+
+  return '';
+}
+
+export const renderInputMessage = (
+  tip?: string,
+  tipId?: string,
+  errorMessage?: string,
+  errorMessageId?: string
+) => (
+  <>
+    {errorMessage && errorMessageId && (
+      <InputMessage
+        message={errorMessage}
+        messageType="error"
+        id={errorMessageId}
+      />
+    )}
+    {tip && tipId && !errorMessage && (
+      <InputMessage message={tip} messageType="tip" id={tipId} />
+    )}
+  </>
+);

--- a/components/src/index.ts
+++ b/components/src/index.ts
@@ -39,3 +39,4 @@ export * from './components/ToggleBar';
 export * from './components/Grid';
 export * from './components/ProgressTracker';
 export * from './hooks';
+export * from './components/TextArea';


### PR DESCRIPTION
Grunnet forskjeller i typings mellom `<textarea>` og `<input>` blir TextArea egen komponent.

- Ny komponent: TextArea.
- Fjerner `<textarea>` fra TextInput. Breaking: `multiline` støttes ikke lenger  i TextInput.
- Gjenbrukbare types i `Input.types`
- Flytter `getDefaultText()` til `Input.utils` til bruk på tvers av komponenter.
- Ny util i `Input.utils`:  `renderInputMessage()` for lik rendering av InputMessage. Bruker den i skjemakomponenter.
- Opprydding i `TextInput.types`.