### PR TITLE
Skriver om idGenerator for bedre lesbarhet.

### DIFF
--- a/components/src/components/Checkbox/CheckboxGroup.tsx
+++ b/components/src/components/Checkbox/CheckboxGroup.tsx
@@ -2,7 +2,10 @@ import { useId } from 'react';
 import styled, { css } from 'styled-components';
 import { renderInputMessage, RequiredMarker } from '../../helpers';
 import { checkboxGroupTokens as tokens } from './CheckboxGroup.tokens';
-import { CheckboxGroupContext } from './CheckboxGroupContext';
+import {
+  CheckboxGroupContext,
+  CheckboxGroupContextProps,
+} from './CheckboxGroupContext';
 import { Typography } from '../Typography';
 import { derivativeIdGenerator } from '../../utils';
 import { BaseComponentPropsWithChildren, getBaseHTMLProps } from '../../types';
@@ -64,18 +67,14 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
   const hasErrorMessage = !!errorMessage;
   const showRequiredMarker = required || ariaRequired;
 
-  const errorMessageId = derivativeIdGenerator(
-    uniqueGroupId,
-    'errorMessage',
-    errorMessage
-  );
-  const tipId = derivativeIdGenerator(uniqueGroupId, 'tip', tip);
+  const errorMessageId = derivativeIdGenerator(uniqueGroupId, 'errorMessage');
+  const tipId = derivativeIdGenerator(uniqueGroupId, 'tip');
 
-  const contextProps = {
+  const contextProps: CheckboxGroupContextProps = {
     error: hasErrorMessage,
-    errorMessageId,
+    errorMessageId: errorMessage ? errorMessageId : undefined,
     uniqueGroupId,
-    tipId,
+    tipId: tip ? tipId : undefined,
   };
 
   return (
@@ -99,7 +98,7 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
         <GroupContainer
           role="group"
           aria-labelledby={uniqueGroupId}
-          aria-describedby={tipId}
+          aria-describedby={tip ? tipId : undefined}
           direction={direction}
         >
           {children}

--- a/components/src/components/Checkbox/CheckboxGroupContext.tsx
+++ b/components/src/components/Checkbox/CheckboxGroupContext.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 
-export interface CheckboxGroup {
+export interface CheckboxGroupContextProps {
   error?: boolean;
   errorMessageId?: string;
   uniqueGroupId?: string;
@@ -8,7 +8,7 @@ export interface CheckboxGroup {
 }
 
 export const CheckboxGroupContext =
-  React.createContext<Nullable<CheckboxGroup>>(null);
+  React.createContext<Nullable<CheckboxGroupContextProps>>(null);
 
 export const useCheckboxGroup = () => {
   return useContext(CheckboxGroupContext);

--- a/components/src/components/Datepicker/Datepicker.tsx
+++ b/components/src/components/Datepicker/Datepicker.tsx
@@ -100,12 +100,8 @@ export const Datepicker = forwardRef<HTMLInputElement, DatepickerProps>(
     const hasErrorMessage = !!errorMessage;
     const showRequiredStyling = !!(required || ariaRequired);
 
-    const errorMessageId = derivativeIdGenerator(
-      uniqueId,
-      'errorMessage',
-      errorMessage
-    );
-    const tipId = derivativeIdGenerator(uniqueId, 'tip', tip);
+    const errorMessageId = derivativeIdGenerator(uniqueId, 'errorMessage');
+    const tipId = derivativeIdGenerator(uniqueId, 'tip');
 
     const inputProps = {
       id: uniqueId,
@@ -118,8 +114,8 @@ export const Datepicker = forwardRef<HTMLInputElement, DatepickerProps>(
       componentSize,
       type,
       'aria-describedby': spaceSeparatedIdListGenerator([
-        tipId,
-        errorMessageId,
+        tip ? tipId : undefined,
+        errorMessage ? errorMessageId : undefined,
         ariaDescribedby,
       ]),
       'aria-required': ariaRequired,

--- a/components/src/components/Search/Search.tsx
+++ b/components/src/components/Search/Search.tsx
@@ -118,7 +118,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
     const uniqueId = id ?? `${generatedId}-searchInput`;
     const hasLabel = !!label;
     const hasTip = !!tip;
-    const tipId = derivativeIdGenerator(uniqueId, 'tip', tip);
+    const tipId = derivativeIdGenerator(uniqueId, 'tip');
 
     const containerProps = {
       className,
@@ -133,7 +133,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
       type: 'search',
       id: uniqueId,
       'aria-describedby': spaceSeparatedIdListGenerator([
-        tipId,
+        tip ? tipId : undefined,
         ariaDescribedby,
       ]),
     };

--- a/components/src/components/Select/Select.tsx
+++ b/components/src/components/Select/Select.tsx
@@ -256,12 +256,8 @@ const SelectInner = <
   const hasErrorMessage = !!errorMessage;
   const showRequiredStyling = !!(required || ariaRequired);
 
-  const tipId = derivativeIdGenerator(uniqueId, 'tip', tip);
-  const errorMessageId = derivativeIdGenerator(
-    uniqueId,
-    'errorMessage',
-    errorMessage
-  );
+  const tipId = derivativeIdGenerator(uniqueId, 'tip');
+  const errorMessageId = derivativeIdGenerator(uniqueId, 'errorMessage');
 
   const containerProps = {
     width,
@@ -308,7 +304,11 @@ const SelectInner = <
         DDSInput(
           { ...props, required, 'aria-required': ariaRequired },
           hasErrorMessage,
-          spaceSeparatedIdListGenerator([singleValueId, tipId, errorMessageId])
+          spaceSeparatedIdListGenerator([
+            singleValueId,
+            tip ? tipId : undefined,
+            errorMessage ? errorMessageId : undefined,
+          ])
         ),
       SingleValue: props =>
         CustomSingleValue(props, singleValueId, customSingleValueElement),

--- a/components/src/components/TextArea/TextArea.tsx
+++ b/components/src/components/TextArea/TextArea.tsx
@@ -91,12 +91,8 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
     const hasErrorMessage = !!errorMessage;
     const hasLabel = !!label;
-    const tipId = derivativeIdGenerator(uniqueId, 'tip', tip);
-    const errorMessageId = derivativeIdGenerator(
-      uniqueId,
-      'errorMessage',
-      errorMessage
-    );
+    const tipId = derivativeIdGenerator(uniqueId, 'tip');
+    const errorMessageId = derivativeIdGenerator(uniqueId, 'errorMessage');
 
     const showRequiredStyling = required || !!ariaRequired;
 
@@ -117,8 +113,8 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       required,
       'aria-required': ariaRequired,
       'aria-describedby': spaceSeparatedIdListGenerator([
-        tipId,
-        errorMessageId,
+        tip ? tipId : undefined,
+        errorMessage ? errorMessageId : undefined,
         ariaDescribedby,
       ]),
       'aria-invalid': hasErrorMessage ? true : undefined,

--- a/components/src/components/TextInput/TextInput.tsx
+++ b/components/src/components/TextInput/TextInput.tsx
@@ -86,15 +86,10 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 
     const characterCounterId = derivativeIdGenerator(
       uniqueId,
-      'characterCounter',
-      maxLength && withCharacterCounter
+      'characterCounter'
     );
-    const tipId = derivativeIdGenerator(uniqueId, 'tip', tip);
-    const errorMessageId = derivativeIdGenerator(
-      uniqueId,
-      'errorMessage',
-      errorMessage
-    );
+    const tipId = derivativeIdGenerator(uniqueId, 'tip');
+    const errorMessageId = derivativeIdGenerator(uniqueId, 'errorMessage');
 
     const generalInputProps = {
       id: uniqueId,
@@ -109,9 +104,9 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       defaultValue,
       'aria-required': ariaRequired,
       'aria-describedby': spaceSeparatedIdListGenerator([
-        tipId,
-        errorMessageId,
-        characterCounterId,
+        hasTip ? tipId : undefined,
+        hasErrorMessage ? errorMessageId : undefined,
+        maxLength && withCharacterCounter ? characterCounterId : undefined,
         ariaDescribedby,
       ]),
       'aria-invalid': hasErrorMessage ? true : undefined,

--- a/components/src/utils/idGenerator.tsx
+++ b/components/src/utils/idGenerator.tsx
@@ -1,23 +1,10 @@
-export const derivativeIdGenerator = (
-  prefix: string,
-  suffix: string,
-  value?: string | number | boolean
-) => (value ? `${prefix}-${suffix}` : undefined);
-
-export const idArrayGenerator = (
-  values: (string | undefined)[]
-): string[] | undefined => {
-  const array: string[] = [];
-  values.forEach(e => {
-    if (e) {
-      array.push(e);
-    }
-  });
-  return array.length > 0 ? array : undefined;
-};
+export const derivativeIdGenerator = (prefix: string, suffix: string): string =>
+  `${prefix}-${suffix}`;
 
 export const spaceSeparatedIdListGenerator = (
   values: (string | undefined)[]
 ): string | undefined => {
-  return idArrayGenerator(values)?.join(' ');
+  const filtered = values.filter(Boolean);
+
+  return filtered.length > 0 ? filtered.join(' ') : undefined;
 };


### PR DESCRIPTION
Eksisterende implementasjon hadde et tredje argument i `derivativeIdGenerator()` som lot funksjonen returnere `undefined`. En generator bør ikke gjøre det. Skriver om slik at den alltid returnerer en `string` slik at konsumenter må forholde seg til om den skal brukes eller ikke.

Skriver også om `spaceSeparatedIdListGenerator()` til en mer lesbar implementasjon med samme funksjonalitet.