### PR TITLE
Ny komponent: SplitButton

### DIFF
--- a/components/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/components/src/components/OverflowMenu/OverflowMenu.tsx
@@ -61,6 +61,7 @@ export const OverflowMenu = forwardRef<HTMLDivElement, OverflowMenuProps>(
     const {
       anchorRef,
       onClose,
+      onToggle,
       isOpen = false,
       placement = 'bottom-end',
       items,
@@ -87,19 +88,26 @@ export const OverflowMenu = forwardRef<HTMLDivElement, OverflowMenuProps>(
     useOnClickOutside(
       [refs?.floating?.current, refs?.reference?.current as HTMLElement | null],
       () => {
-        if (isOpen) onClose && onClose();
+        if (isOpen) {
+          onClose && onClose();
+          onToggle && onToggle();
+        }
       }
     );
 
     useOnKeyDown(['Esc', 'Escape'], () => {
       if (isOpen) {
         onClose && onClose();
+        onToggle && onToggle();
         anchorRef && anchorRef.current?.focus();
       }
     });
 
     useOnKeyDown(['Tab'], () => {
-      if (isOpen) onClose && onClose();
+      if (isOpen) {
+        onClose && onClose();
+        onToggle && onToggle();
+      }
     });
 
     const interactiveItems: (OverflowMenuContextItem | OverflowMenuNavItem)[] =
@@ -139,6 +147,7 @@ export const OverflowMenu = forwardRef<HTMLDivElement, OverflowMenuProps>(
                   React.MouseEvent<HTMLButtonElement, MouseEvent>
               ) => {
                 item.onClick && item.onClick(e);
+                onToggle && onToggle();
                 onClose && onClose();
               }}
             />

--- a/components/src/components/OverflowMenu/OverflowMenu.types.tsx
+++ b/components/src/components/OverflowMenu/OverflowMenu.types.tsx
@@ -4,17 +4,22 @@ import { BaseComponentProps } from '../../types';
 
 import { SvgIcon } from '../../icons/utils';
 
-export type OverflowMenuContextItem = {
+type OverflowMenuItemBase = {
   title: string;
   icon?: SvgIcon;
-} & (
-  | AnchorHTMLAttributes<HTMLAnchorElement>
-  | ButtonHTMLAttributes<HTMLButtonElement>
-);
-export type OverflowMenuNavItem = {
-  title: string;
-  icon?: SvgIcon;
-} & AnchorHTMLAttributes<HTMLAnchorElement>;
+};
+
+export type OverflowMenuButtonItem = OverflowMenuItemBase &
+  ButtonHTMLAttributes<HTMLButtonElement>;
+
+export type OverflowMenuLinkItem = OverflowMenuItemBase &
+  AnchorHTMLAttributes<HTMLAnchorElement>;
+
+export type OverflowMenuContextItem =
+  | OverflowMenuButtonItem
+  | OverflowMenuLinkItem;
+
+export type OverflowMenuNavItem = OverflowMenuLinkItem;
 
 type UserProps = {
   name: string;
@@ -37,6 +42,8 @@ export type OverflowMenuProps = BaseComponentProps<
     isOpen?: boolean;
     /**Callback for å lukke menyen. **OBS!** nødvendig kun hvis `<OverflowMenuGroup />` ikke brukes.  */
     onClose?: () => void;
+    /**Callback for å toggle menyen. **OBS!** nødvendig kun hvis `<OverflowMenuGroup />` ikke brukes.  */
+    onToggle?: () => void;
     /**Ref til elementet som styrer menyen. **OBS!** nødvendig kun hvis ``<OverflowMenuGroup />` ikke brukes.  */
     anchorRef?: RefObject<HTMLButtonElement>;
     /**Plassering av menyen i forhold til anchor-elementet. */

--- a/components/src/components/OverflowMenu/OverflowMenuGroup.tsx
+++ b/components/src/components/OverflowMenu/OverflowMenuGroup.tsx
@@ -64,6 +64,7 @@ export const OverflowMenuGroup = ({
             isOpen: isOpen,
             id: uniqueOverflowMenuId,
             onClose: handleClose,
+            onToggle: handleToggle,
             anchorRef: buttonRef,
           }))
     );

--- a/components/src/components/SplitButton/SplitButton.spec.tsx
+++ b/components/src/components/SplitButton/SplitButton.spec.tsx
@@ -1,0 +1,86 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { SplitButton } from '.';
+
+const primaryText = 'primaryText';
+const primary = { label: primaryText, onClick: () => {} };
+const itemText = 'text';
+const item = { title: itemText, onClick: () => {} };
+
+type props = {
+  primaryAction: { label: string; onClick?: () => void };
+  secondaryActions: { title: string; onClick?: () => void };
+};
+
+function TestComponent({ primaryAction, secondaryActions }: props) {
+  return (
+    <SplitButton
+      primaryAction={primaryAction}
+      secondaryActions={[secondaryActions]}
+    />
+  );
+}
+
+describe('<OverflowMenu />', () => {
+  it('should show OverflowMenu on menu button click', () => {
+    render(<TestComponent secondaryActions={item} primaryAction={primary} />);
+    const menu = screen.queryByRole('menu');
+    expect(menu).not.toBeInTheDocument();
+    const menuButton = screen.getByLabelText('Åpne liste med flere valg');
+
+    act(() => {
+      fireEvent.click(menuButton!);
+    });
+
+    const menuOpened = screen.getByRole('menu');
+    expect(menuOpened).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('should run onclick event from primary action button', () => {
+    const event = jest.fn();
+    render(
+      <TestComponent
+        secondaryActions={item}
+        primaryAction={{ label: primaryText, onClick: event }}
+      />
+    );
+
+    const button = screen.getByText(primaryText);
+    act(() => {
+      fireEvent.click(button!);
+    });
+
+    expect(event).toHaveBeenCalled();
+  });
+
+  it('should run onclick event from context menu', () => {
+    const event = jest.fn();
+    render(
+      <TestComponent
+        secondaryActions={{ title: itemText, onClick: event }}
+        primaryAction={primary}
+      />
+    );
+
+    const item = screen.getByText(itemText);
+    act(() => {
+      fireEvent.click(item!);
+    });
+
+    expect(event).toHaveBeenCalled();
+  });
+
+  it('should hide menu after Esc keydown', () => {
+    render(<TestComponent secondaryActions={item} primaryAction={primary} />);
+    const menuButton = screen.getByLabelText('Åpne liste med flere valg');
+    fireEvent.click(menuButton!);
+    const menuOpened = screen.getByRole('menu');
+    expect(menuOpened).toHaveAttribute('aria-hidden', 'false');
+
+    act(() => {
+      fireEvent.keyDown(menuOpened, { key: 'Escape', code: 'Escape' });
+    });
+
+    const elQuery = screen.queryByRole('menu');
+    expect(elQuery).not.toBeInTheDocument();
+  });
+});

--- a/components/src/components/SplitButton/SplitButton.stories.mdx
+++ b/components/src/components/SplitButton/SplitButton.stories.mdx
@@ -1,0 +1,59 @@
+import {
+  Story,
+  Canvas,
+  Meta,
+  ArgsTable,
+  PRIMARY_STORY,
+} from '@storybook/addon-docs';
+import { SplitButton } from '.';
+import {
+  Source,
+  ComponentLinkRow,
+  SB_DESIGNSYSTEM_URL,
+  LinkToInteractiveStory,
+} from '../../storybook';
+
+<Meta title="Design system/SplitButton/API" component={SplitButton} />
+
+# SplitButton
+
+<ComponentLinkRow
+  docsHref="https://design.domstol.no/987b33f71/p/1868a2-splitbutton"
+  githubHref="https://github.com/domstolene/designsystem/tree/master/components/src/components/SplitButton"
+  figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/DDS-Komponenter?node-id=155%3A37"
+/>
+
+## Demo
+
+<Canvas>
+  <Story id="design-system-splitbutton--default" height="380px" />
+</Canvas>
+
+<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}-splitbutton`} />
+
+## Oversikt
+
+`<SplitButton />` er en todelt knapp som skal brukes ved flere relaterte handlinger, der den ene er mest vanlig.
+Komponenten består av to knapper: én for den primære handlingen, og én for å åpne en meny med sekundære handlinger.
+Når menyen åpnes og en handling velges blir den umiddelbart gjennomført.
+`<SplitButton />` er dermed en fusjon med en knapp og meny.
+
+## Bruk i koden
+
+<Source code={`import { SplitButton } from '@norges-domstoler/dds-components';
+
+const items = [{
+title: 'Sekundær handling',
+onClick: () => {},
+}];
+
+<SplitButton
+  primaryAction={{ label: 'Label', onClick: () => {} }}
+  secondaryActions={items}
+/>
+`} />
+
+## API
+
+<ArgsTable story={PRIMARY_STORY} />
+I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/components/src/components/SplitButton/SplitButton.stories.tsx
+++ b/components/src/components/SplitButton/SplitButton.stories.tsx
@@ -1,0 +1,116 @@
+import { SplitButton, SplitButtonProps } from '.';
+import { PlusCircledIcon } from '../../icons/tsx';
+import { StoryTemplate } from '../../storybook';
+
+export default {
+  title: 'design system/SplitButton',
+  component: SplitButton,
+};
+
+const items = [
+  {
+    title: 'Sekundær handling',
+    onClick: () => {},
+  },
+  {
+    title: 'Sekundær handling 2',
+    onClick: () => {},
+    icon: PlusCircledIcon,
+  },
+];
+
+export const Overview = (args: SplitButtonProps) => (
+  <StoryTemplate title="SplitButton - overview" display="grid">
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst' }}
+      secondaryActions={items}
+      size="large"
+    />
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst', icon: PlusCircledIcon }}
+      secondaryActions={items}
+      size="large"
+    />
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst', loading: true }}
+      secondaryActions={items}
+      size="large"
+    />
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst' }}
+      secondaryActions={items}
+      size="medium"
+    />
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst', icon: PlusCircledIcon }}
+      secondaryActions={items}
+      size="medium"
+    />
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst', loading: true }}
+      secondaryActions={items}
+      size="medium"
+    />
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst' }}
+      secondaryActions={items}
+      size="small"
+    />
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst', icon: PlusCircledIcon }}
+      secondaryActions={items}
+      size="small"
+    />
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst', loading: true }}
+      secondaryActions={items}
+      size="small"
+    />
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst' }}
+      secondaryActions={items}
+      size="tiny"
+    />
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst', icon: PlusCircledIcon }}
+      secondaryActions={items}
+      size="tiny"
+    />
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst', loading: true }}
+      secondaryActions={items}
+      size="tiny"
+    />
+  </StoryTemplate>
+);
+
+export const Default = (args: SplitButtonProps) => (
+  <StoryTemplate title="SplitButton - default" display="block">
+    <SplitButton
+      {...args}
+      primaryAction={{ label: 'Tekst' }}
+      secondaryActions={items}
+    />
+  </StoryTemplate>
+);
+
+export const FullWidth = () => (
+  <StoryTemplate title="SplitButton - full width" display="block">
+    <SplitButton
+      primaryAction={{ label: 'Tekst', fullWidth: true }}
+      secondaryActions={items}
+    />
+  </StoryTemplate>
+);

--- a/components/src/components/SplitButton/SplitButton.tsx
+++ b/components/src/components/SplitButton/SplitButton.tsx
@@ -1,0 +1,70 @@
+import { forwardRef, useState } from 'react';
+import styled from 'styled-components';
+import { ChevronDownIcon, ChevronUpIcon } from '../../icons/tsx';
+import { Button, ButtonProps, ButtonSize } from '../Button';
+import {
+  OverflowMenu,
+  OverflowMenuButtonItem,
+  OverflowMenuGroup,
+} from '../OverflowMenu';
+
+const Container = styled.div`
+  display: flex;
+`;
+
+const MainButton = styled(Button)`
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: none;
+  &:focus {
+    position: relative;
+    z-index: 0;
+  }
+`;
+const OptionButton = styled(Button)`
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  &:focus {
+    position: relative;
+    z-index: 0;
+  }
+`;
+
+export type SplitButtonProps = {
+  /**Størrelse på komponenten. */
+  size?: ButtonSize;
+  /**Props for primær handling. Samme props som for `<Button />` unntatt `size`, `purpose`, og `appearance`. */
+  primaryAction: Omit<ButtonProps, 'size' | 'apperance' | 'purpose'>;
+  /**Props for sekunære handlinger. */
+  secondaryActions: OverflowMenuButtonItem[];
+};
+export const SplitButton = forwardRef<HTMLDivElement, SplitButtonProps>(
+  (props, ref) => {
+    const { size, primaryAction, secondaryActions, ...rest } = props;
+
+    const [isOpen, setIsOpen] = useState(false);
+    const buttonStyleProps: ButtonProps = {
+      appearance: 'filled',
+      purpose: 'secondary',
+      size,
+    };
+
+    return (
+      <Container ref={ref}>
+        <MainButton
+          {...buttonStyleProps}
+          {...primaryAction}
+          iconPosition="left"
+        />
+        <OverflowMenuGroup onToggle={() => setIsOpen(!isOpen)}>
+          <OptionButton
+            {...buttonStyleProps}
+            icon={isOpen ? ChevronUpIcon : ChevronDownIcon}
+            aria-label="Åpne liste med flere valg"
+          />
+          <OverflowMenu items={secondaryActions} placement="bottom-end" />
+        </OverflowMenuGroup>
+      </Container>
+    );
+  }
+);

--- a/components/src/components/SplitButton/index.ts
+++ b/components/src/components/SplitButton/index.ts
@@ -1,0 +1,1 @@
+export * from './SplitButton';

--- a/components/src/index.ts
+++ b/components/src/index.ts
@@ -40,3 +40,4 @@ export * from './components/Grid';
 export * from './components/ProgressTracker';
 export * from './hooks';
 export * from './components/TextArea';
+export * from './components/SplitButton';


### PR DESCRIPTION
`<SplitButton>` er en todelt knapp som skal brukes ved flere relaterte handlinger, der den ene er mest vanlig.
Komponenten består av to knapper: én for den primære handlingen, og én for å åpne en meny med sekundære handlinger.
Når menyen åpnes og en handling velges blir den umiddelbart gjennomført.
Komponenten brukes for å redusere unødvendig kognitiv belastning.

Annet:
- forbedret typings i OverflowMenu.
- fix: `onToggle` var ikke ordentlig støttet i OverflowMenu. La til propen i `<OverflowMenuGroup>`. `onToggle()` kalles ved lukking av menyen.
