### PR TITLE
Fikser feil med required for Select

### DIFF
--- a/components/src/components/Select/Select.tsx
+++ b/components/src/components/Select/Select.tsx
@@ -302,7 +302,7 @@ const SelectInner = <
       NoOptionsMessage: DDSNoOptionsMessage,
       Input: props =>
         DDSInput(
-          { ...props, required, 'aria-required': ariaRequired },
+          { ...props, 'aria-required': ariaRequired },
           hasErrorMessage,
           spaceSeparatedIdListGenerator([
             singleValueId,


### PR DESCRIPTION
Når `aria-required` ble introdusert i #337 ble input-feltet satt som "required". Dette oppfører seg ikke korrekt siden `react-select` ikke har støtte for required selects. Fjerner `required`-attributten men beholder `aria-required` for å hjelpe skjermlesere.