### PR TITLE
Ny prop `rowGap` i `<Grid>`

### DIFF
--- a/components/src/components/Grid/Grid.tokens.tsx
+++ b/components/src/components/Grid/Grid.tokens.tsx
@@ -15,7 +15,7 @@ export const gridTokens = {
   [ScreenSize.XSmall]: {
     grid: {
       columns: grid.DdsGridXs0599Count,
-      gap: grid.DdsGridXs0599GutterSize,
+      columnGap: grid.DdsGridXs0599GutterSize,
       marginLeft: spacing.SizesDdsSpacingLayoutX1,
       marginRight: spacing.SizesDdsSpacingLayoutX1,
     },
@@ -32,7 +32,7 @@ export const gridTokens = {
   [ScreenSize.Small]: {
     grid: {
       columns: grid.DdsGridSm600959Count,
-      gap: grid.DdsGridSm600959GutterSize,
+      columnGap: grid.DdsGridSm600959GutterSize,
       marginLeft: spacing.SizesDdsSpacingLayoutX2,
       marginRight: spacing.SizesDdsSpacingLayoutX2,
     },
@@ -48,7 +48,7 @@ export const gridTokens = {
   [ScreenSize.Medium]: {
     grid: {
       columns: grid.DdsGridMd9601279Count,
-      gap: grid.DdsGridMd9601279GutterSize,
+      columnGap: grid.DdsGridMd9601279GutterSize,
       marginLeft: spacing.SizesDdsSpacingLayoutX4,
       marginRight: spacing.SizesDdsSpacingLayoutX4,
     },
@@ -64,7 +64,7 @@ export const gridTokens = {
   [ScreenSize.Large]: {
     grid: {
       columns: grid.DdsGridLg12801919Count,
-      gap: grid.DdsGridLg12801919GutterSize,
+      columnGap: grid.DdsGridLg12801919GutterSize,
       marginLeft: spacing.SizesDdsSpacingLayoutX6,
       marginRight: spacing.SizesDdsSpacingLayoutX6,
     },
@@ -80,7 +80,7 @@ export const gridTokens = {
   [ScreenSize.XLarge]: {
     grid: {
       columns: grid.DdsGridXl1920Count,
-      gap: grid.DdsGridXl1920GutterSize,
+      columnGap: grid.DdsGridXl1920GutterSize,
       marginLeft: spacing.SizesDdsSpacingLayoutX10,
       marginRight: spacing.SizesDdsSpacingLayoutX10,
     },

--- a/components/src/components/Grid/Grid.tsx
+++ b/components/src/components/Grid/Grid.tsx
@@ -55,6 +55,7 @@ type MaxWidthGrid = BreakpointBasedProps<'maxWidth'>;
 type BaseGridProps = {
   /**Maksimal bredde. Gjøres per brekkepunkt.  */
   maxWidth?: MaxWidthGrid;
+  /** CSS `row-gap`. Gjøres per brekkepunkt. */
   rowGap?: RowGapGrid;
 } & Pick<HTMLAttributes<HTMLElement>, 'style'>;
 

--- a/components/src/components/Grid/Grid.tsx
+++ b/components/src/components/Grid/Grid.tsx
@@ -3,26 +3,35 @@ import { ScreenSize, useScreenSize } from '../../hooks';
 import { BaseComponentPropsWithChildren, getBaseHTMLProps } from '../../types';
 import { gridTokens } from './Grid.tokens';
 import { GridContext } from './Grid.context';
-import { Property } from 'csstype';
-import { getLiteralScreenSize } from './Grid.utils';
+import { StandardProperties } from 'csstype';
+import { getLiteralScreenSize, ScreenSizeLiteral } from './Grid.utils';
 import { HTMLAttributes } from 'react';
 
 type StyledGridProps = {
   screenSize: ScreenSize;
   maxWidth?: MaxWidthGrid;
+  rowGap?: RowGapGrid;
 };
 
 const getHooksGridStyling = (
   screenSize: ScreenSize,
-  maxWidth?: MaxWidthGrid
+  maxWidth?: MaxWidthGrid,
+  rowGap?: RowGapGrid
 ) => {
   const tokens = gridTokens[screenSize].grid;
   return {
     gridTemplateColumns: `repeat(${tokens.columns}, minmax(0, 1fr))`,
-    gap: tokens.gap,
+    columnGap: tokens.columnGap,
     marginLeft: tokens.marginLeft,
     marginRight: tokens.marginRight,
-    maxWidth: maxWidth && maxWidth[getLiteralScreenSize(screenSize)],
+    rowGap:
+      rowGap && rowGap[getLiteralScreenSize(screenSize)]
+        ? rowGap[getLiteralScreenSize(screenSize)]
+        : tokens.columnGap,
+    maxWidth:
+      maxWidth &&
+      maxWidth[getLiteralScreenSize(screenSize)] &&
+      maxWidth[getLiteralScreenSize(screenSize)],
   };
 };
 
@@ -32,20 +41,21 @@ const StyledGrid = styled.div<StyledGridProps>`
     css`
       max-width: ${maxWidth};
     `}
-  ${({ screenSize, maxWidth }) => getHooksGridStyling(screenSize, maxWidth)}
+  ${({ screenSize, maxWidth, rowGap }) =>
+    getHooksGridStyling(screenSize, maxWidth, rowGap)}
 `;
 
-type MaxWidthGrid = {
-  xs?: Property.MaxWidth;
-  sm?: Property.MaxWidth;
-  md?: Property.MaxWidth;
-  lg?: Property.MaxWidth;
-  xl?: Property.MaxWidth;
+type BreakpointBasedProps<T extends keyof StandardProperties> = {
+  [k in ScreenSizeLiteral]?: StandardProperties[T];
 };
+
+type RowGapGrid = BreakpointBasedProps<'rowGap'>;
+type MaxWidthGrid = BreakpointBasedProps<'maxWidth'>;
 
 type BaseGridProps = {
   /**Maksimal bredde. Gjøres per brekkepunkt.  */
   maxWidth?: MaxWidthGrid;
+  rowGap?: RowGapGrid;
 } & Pick<HTMLAttributes<HTMLElement>, 'style'>;
 
 type GridDivProps = BaseComponentPropsWithChildren<


### PR DESCRIPTION
Det kan nå settes egen CSS `row-gap` basert på brekkpunkter. Som default er den samme som `column-gap`.