### PR TITLE
Sentrerer ikon med første linje med tekst i OveflowMenu

### DIFF
--- a/components/src/components/OverflowMenu/OverflowMenu.tokens.tsx
+++ b/components/src/components/OverflowMenu/OverflowMenu.tokens.tsx
@@ -1,4 +1,5 @@
 import { ddsBaseTokens } from '@norges-domstoler/dds-design-tokens';
+import { calculateHeightWithLineHeight } from '../../utils';
 import { StaticTypographyType } from '../Typography';
 
 const { border, borderRadius, colors, spacing, fontPackages } = ddsBaseTokens;
@@ -15,7 +16,15 @@ const element = {
   },
 };
 
+const iconHeight = calculateHeightWithLineHeight(
+  fontPackages.body_sans_01.numbers.lineHeightNumber,
+  fontPackages.body_sans_01.numbers.fontSizeNumber
+);
+
 const link = {
+  iconWrapper: {
+    height: `${iconHeight}px`,
+  },
   hover: {
     backgroundColor: colors.DdsColorInteractiveLightest,
   },

--- a/components/src/components/OverflowMenu/OverflowMenuItem.tsx
+++ b/components/src/components/OverflowMenu/OverflowMenuItem.tsx
@@ -27,7 +27,6 @@ const { element, link } = tokens;
 
 const elementBaseCSS = css`
   display: flex;
-  align-items: center;
   box-sizing: border-box;
   color: ${element.base.color};
   text-decoration: ${element.base.textDecoration};
@@ -42,6 +41,7 @@ export const Span = styled.span`
 `;
 
 export const Link = styled.a`
+  text-align: left;
   user-select: text;
   border: none;
   cursor: pointer;
@@ -61,6 +61,12 @@ export const Link = styled.a`
   &.focus-visible {
     ${focusVisibleLink}
   }
+`;
+
+const IconWrapper = styled.span`
+  display: flex;
+  align-items: center;
+  height: ${link.iconWrapper.height};
 `;
 
 type BaseOverflowMenuItemProps = {
@@ -174,7 +180,7 @@ export const OverflowMenuItem = forwardRef<
   if (!href && !onClick) {
     return (
       <Span {...{ ...getBaseHTMLProps(id, className, htmlProps, rest), ref }}>
-        {iconElement}
+        <IconWrapper>{iconElement}</IconWrapper>
         {title}
       </Span>
     );
@@ -188,7 +194,7 @@ export const OverflowMenuItem = forwardRef<
         as="button"
         ref={combinedRef as ForwardedRef<HTMLButtonElement>}
       >
-        {iconElement}
+        <IconWrapper>{iconElement}</IconWrapper>
         {title}
       </Link>
     );
@@ -201,7 +207,7 @@ export const OverflowMenuItem = forwardRef<
       as="a"
       ref={combinedRef as ForwardedRef<HTMLAnchorElement>}
     >
-      {iconElement}
+      <IconWrapper>{iconElement}</IconWrapper>
       {title}
     </Link>
   );


### PR DESCRIPTION
### Før:

![image](https://user-images.githubusercontent.com/71430829/200002769-572cf64c-3fa7-4a24-a66b-a10f70c782c2.png)


### Nå:
![image](https://user-images.githubusercontent.com/71430829/200002481-b87923dd-2b0c-4320-8d49-b3edc978839c.png)
