### PR TITLE
Strengere typings for `purpose` i `<SplitButton>`

### DIFF
--- a/components/src/components/SplitButton/SplitButton.tsx
+++ b/components/src/components/SplitButton/SplitButton.tsx
@@ -1,6 +1,7 @@
 import { forwardRef, useState } from 'react';
 import styled from 'styled-components';
 import { ChevronDownIcon, ChevronUpIcon } from '../../icons/tsx';
+import { ExtractStrict } from '../../types';
 import { Button, ButtonProps, ButtonPurpose, ButtonSize } from '../Button';
 import {
   OverflowMenu,
@@ -23,7 +24,7 @@ const MainButton = styled(Button)`
   }
 `;
 
-export type SplitButtonPurpose = Extract<
+export type SplitButtonPurpose = ExtractStrict<
   ButtonPurpose,
   'primary' | 'secondary'
 >;

--- a/components/src/types/index.ts
+++ b/components/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './Direction';
 export * from './BaseComponentProps';
 export * from './CheckboxPickedHTMLAttributes';
+export * from './utils';

--- a/components/src/types/utils.ts
+++ b/components/src/types/utils.ts
@@ -10,3 +10,12 @@ export type WithRequiredIf<
   T,
   K extends keyof T
 > = Omit<T, K> & Pick<true extends Condition ? Required<T> : T, K>;
+
+/**
+ * Gir tilbake typer fra `T` som matcher `U`
+ *
+ * @template T en union type
+ * @template U delmengde av `T`
+ */
+
+export type ExtractStrict<T, U extends T> = U;


### PR DESCRIPTION
- legger til `ExtractStrict` utility type
- bruker den i `<SplitButton>`