### PR TITLE
Autocomplete-funksjonalitet med søkeforslag i `<Search>`

### DIFF
--- a/components/src/components/Search/AutocompleteSearch.context.tsx
+++ b/components/src/components/Search/AutocompleteSearch.context.tsx
@@ -1,0 +1,24 @@
+import {
+  ChangeEvent,
+  createContext,
+  MouseEvent,
+  RefObject,
+  useContext,
+} from 'react';
+
+export type AutocompleteSearchContextType = {
+  onValueChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  onSugggestionClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+  suggestions?: string[];
+  showSuggestions?: boolean;
+  inputValue?: string;
+  inputRef?: RefObject<HTMLInputElement> | null;
+  suggestionsRef?: RefObject<HTMLDivElement> | null;
+};
+
+export const AutocompleteSearchContext =
+  createContext<AutocompleteSearchContextType>({});
+
+export const useAutocompleteSearch = () => {
+  return useContext(AutocompleteSearchContext);
+};

--- a/components/src/components/Search/Search.spec.tsx
+++ b/components/src/components/Search/Search.spec.tsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import { Search } from '.';
+import userEvent from '@testing-library/user-event';
 
 describe('<Search />', () => {
   it('should render a searchbox', () => {
@@ -19,7 +20,7 @@ describe('<Search />', () => {
     render(<Search tip={tip} />);
     expect(screen.queryByText(tip)).toBeInTheDocument();
   });
-  it('should have aria-dsecribedby when tip provided', () => {
+  it('should have aria-describedby when tip provided', () => {
     const tip = 'tip';
     const id = 'id';
     render(<Search tip={tip} id={id} />);
@@ -27,5 +28,107 @@ describe('<Search />', () => {
       'aria-describedby',
       `${id}-tip`
     );
+  });
+  it('should render combobox when using autocomplete version', () => {
+    render(
+      <Search.AutocompleteWrapper data={{ array: [] }}>
+        <Search />
+      </Search.AutocompleteWrapper>
+    );
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('should render search suggestions wrapper', () => {
+    render(
+      <Search.AutocompleteWrapper data={{ array: [] }}>
+        <Search />
+      </Search.AutocompleteWrapper>
+    );
+    expect(screen.getByLabelText('Søkeforslag')).toBeInTheDocument();
+  });
+
+  it('should render specified search suggestion', async () => {
+    const text = 'text';
+    render(
+      <Search.AutocompleteWrapper data={{ array: [text] }}>
+        <Search />
+      </Search.AutocompleteWrapper>
+    );
+
+    const input = screen.getByRole('combobox');
+    await userEvent.type(input, `${text}`);
+    const option = screen.getByRole('option');
+    expect(option).toBeInTheDocument();
+    const { queryByText, queryByRole } = within(option);
+    expect(queryByText(text)).toBeInTheDocument();
+    expect(queryByRole('menuitem')).toBeInTheDocument();
+  });
+
+  it('should not render search suggestion when query is too short', async () => {
+    const text = 'text';
+    const queryLength = 3;
+    render(
+      <Search.AutocompleteWrapper data={{ array: [text] }}>
+        <Search />
+      </Search.AutocompleteWrapper>
+    );
+
+    const input = screen.getByRole('combobox');
+    await userEvent.type(input, `${text.slice(queryLength - 2)}`);
+    const option = screen.queryByRole('option');
+    expect(option).not.toBeInTheDocument();
+  });
+
+  it('Search should have aria-expanded=true when suggestions list present and false when not', async () => {
+    const text = 'text';
+    render(
+      <Search.AutocompleteWrapper data={{ array: [text] }}>
+        <Search />
+      </Search.AutocompleteWrapper>
+    );
+
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.type(input, `${text}`);
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('menuitem should get focus when using arrows to navigate', async () => {
+    const text = 'text';
+    render(
+      <Search.AutocompleteWrapper data={{ array: [text] }}>
+        <Search />
+      </Search.AutocompleteWrapper>
+    );
+
+    const input = screen.getByRole('combobox');
+    await userEvent.type(input, `${text}`);
+    const menuitem = screen.getByRole('menuitem');
+    expect(menuitem).not.toHaveFocus();
+    await userEvent.keyboard('{ArrowDown}');
+    expect(menuitem).toHaveFocus();
+  });
+
+  it('should run function on suggestion click', async () => {
+    const event = jest.fn();
+    const text = 'text';
+    render(
+      <Search.AutocompleteWrapper
+        data={{ array: [text] }}
+        onSuggestionSelection={event}
+      >
+        <Search />
+      </Search.AutocompleteWrapper>
+    );
+
+    const input = screen.getByRole('combobox');
+    await userEvent.type(input, `${text}`);
+    const button = screen.getByText(text);
+
+    act(() => {
+      button.click();
+    });
+
+    expect(event).toHaveBeenCalled();
   });
 });

--- a/components/src/components/Search/Search.stories.mdx
+++ b/components/src/components/Search/Search.stories.mdx
@@ -33,28 +33,60 @@ import {
   <Story id="design-system-search--with-button" />
 </Canvas>
 
+<Canvas>
+  <Story height="470px" id="design-system-search--with-suggestions" />
+</Canvas>
+
 <LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}-search`} />
+
+## Oversikt
+
+`<Search>` er en komponent som tilsvarer `<input type="search">` og kan vise en søkeknapp hvis ønsket.
+I tillegg finnes det følgende subkomponenter:
+
+- **`<Search.AutocompleteWrapper>`** - wrapper for `<Search>` som håndterer autocomplete-funksjonalitet hvis er ønsket.
+  Den rendrer en liste med forslag under søkefeltet basert på brukerens input.
+  Støtter en rekke custom props.
+- **`<Search.Suggestions>`** - selve listen med forslag.
+  Brukes i `<Search.AutocompleteWrapper>`, men kan brukes uten wrapper hvis konsumenten skal håndtere oppførselen selv.
 
 ## Bruk i koden
 
 <Source code={`import { Search } from '@norges-domstoler/dds-components';
-import React from 'react';
 
-const handleKeyPress = (e: React.KeyboardEvent<FormControl>) => {
+const handleSearch = () => {
+${' '}${' '}// code
+}
+
+const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
 ${' '}if( e.key == 'Enter' ){
-${' '}${' '}this.send();
+${' '}${' '}handleSearch();
 ${' '}}
 };
 
 <Search onKeyPress={handleKeyPress} />
+
+<Search
+  onKeyPress={handleKeyPress}
+  buttonProps={{ onClick: () => handleSearch() }}
+/>
+
+<Search.AutocompleteWrapper>
+  <Search onKeyPress={handleKeyPress} />
+</Search.AutocompleteWrapper>
+
 `} />
 
 ## API
 
+### Search
+
+Søkefeltet.
+
 <ArgsTable story={PRIMARY_STORY} />
 I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLInputElement>`-interface.
 
-### Types
+#### Types
 
 <Source
   code={`type ButtonProps = {
@@ -63,6 +95,36 @@ I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttri
   loading?: boolean;
 } & ButtonHTMLAttributes<HTMLButtonElement>;`}
 />
+
+### Search.AutocompleteWrapper
+
+En wrapper som håndterer autocomplete-funksjonalitet.
+
+<ArgsTable of={Search.AutocompleteWrapper} />
+
+#### Types
+
+<Source
+  code={`
+  type WeightedSearchData = {
+  array: {
+    text: string;
+    relevance: number;
+  };
+  sortFunction?: (a: WeightedValue, b: WeightedValue) => number;
+};
+
+type SearchData = {
+${' '}${' '}array: string[];
+${' '}${' '}sortFunction?: (a: string, b: string) => number;
+};`}
+/>
+
+### Search.Suggestions
+
+Liste med forslag. Håndterer tastaturfokus internt.
+
+<ArgsTable of={Search.Suggestions} />
 
 ## Retningslinjer
 

--- a/components/src/components/Search/Search.stories.tsx
+++ b/components/src/components/Search/Search.stories.tsx
@@ -1,5 +1,5 @@
 import { StoryTemplate } from '../../storybook';
-import { Search, SearchProps } from './Search';
+import { Search, SearchProps } from '.';
 
 export default {
   title: 'Design system/Search',
@@ -14,6 +14,23 @@ export default {
     },
   },
 };
+
+const array = [
+  'lala',
+  'ghostbusters',
+  'ghostbusters A',
+  'buardi',
+  'ghost3',
+  'ghost',
+  'ost',
+  'too',
+  'ghostbusters B',
+  'ghos',
+  'to ord',
+  'ghost2',
+  'Jan-Ole Olsen',
+  'Øst-Agder',
+];
 
 export const Overview = (args: SearchProps) => {
   return (
@@ -80,6 +97,22 @@ export const OverviewSizes = (args: SearchProps) => {
   );
 };
 
+export const OverviewWithSuggestions = (args: SearchProps) => {
+  return (
+    <StoryTemplate title="Search - overview with suggestions">
+      <Search.AutocompleteWrapper data={{ array }}>
+        <Search {...args} componentSize="large" />
+      </Search.AutocompleteWrapper>
+      <Search.AutocompleteWrapper data={{ array }}>
+        <Search {...args} componentSize="medium" />
+      </Search.AutocompleteWrapper>
+      <Search.AutocompleteWrapper data={{ array }}>
+        <Search {...args} componentSize="small" />
+      </Search.AutocompleteWrapper>
+    </StoryTemplate>
+  );
+};
+
 export const Default = (args: SearchProps) => {
   return (
     <StoryTemplate title="Search - default" display="block">
@@ -92,6 +125,16 @@ export const WithButton = (args: SearchProps) => {
   return (
     <StoryTemplate title="Search - with button" display="block">
       <Search {...args} buttonProps={{ onClick: () => {}, label: 'Søk' }} />
+    </StoryTemplate>
+  );
+};
+
+export const WithSuggestions = (args: SearchProps) => {
+  return (
+    <StoryTemplate title="Search - with suggestions" display="block">
+      <Search.AutocompleteWrapper data={{ array }}>
+        <Search {...args} />
+      </Search.AutocompleteWrapper>
     </StoryTemplate>
   );
 };

--- a/components/src/components/Search/Search.tokens.tsx
+++ b/components/src/components/Search/Search.tokens.tsx
@@ -5,7 +5,7 @@ import {
 import { StaticTypographyType } from '../Typography';
 import { SearchSize } from './Search';
 
-const { spacing, iconSizes } = ddsBaseTokens;
+const { spacing, iconSizes, colors } = ddsBaseTokens;
 const { textDefault } = ddsReferenceTokens;
 
 export const typographyTypes: { [k in SearchSize]: StaticTypographyType } = {
@@ -79,9 +79,21 @@ const icon = {
   },
 };
 
+const suggestionsContainer = {
+  marginTop: spacing.SizesDdsSpacingLocalX025,
+  border: `1px solid ${colors.DdsColorInteractiveBase}`,
+  boxShadow: `0 0 0 1px ${colors.DdsColorInteractiveBase}`,
+};
+
+const suggestionsHeader = {
+  paddingLeft: spacing.SizesDdsSpacingLocalX1,
+};
+
 export const searchTokens = {
   input,
   icon,
   horisontalContainer,
   outerContainer,
+  suggestionsContainer,
+  suggestionsHeader,
 };

--- a/components/src/components/Search/SearchAutocompleteWrapper.tsx
+++ b/components/src/components/Search/SearchAutocompleteWrapper.tsx
@@ -1,0 +1,153 @@
+import {
+  ChangeEvent,
+  MouseEvent,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { useOnClickOutside, useOnKeyDown } from '../../hooks';
+import { searchFilter } from '../../utils';
+import {
+  AutocompleteSearchContext,
+  AutocompleteSearchContextType,
+} from './AutocompleteSearch.context';
+
+type WeightedValue = {
+  text: string;
+  relevance: number;
+};
+
+export type WeightedSearchData = {
+  array: WeightedValue[];
+  sortFunction?: (a: WeightedValue, b: WeightedValue) => number;
+};
+
+export type SearchData = {
+  array: string[];
+  sortFunction?: (a: string, b: string) => number;
+};
+
+export type SearchAutocompleteWrapperProps = {
+  /**Array med data som kan søkes på og eventuelt tilhørende sorteringsfunksjon. Array kan bestå av elementer av typen `string`  eller objekter med vekt og tekst.*/
+  data?: SearchData | WeightedSearchData;
+  /** Ekstra callback ved `onChange` i `<Search>`. */
+  onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
+  /**Callback når et forslag blir valgt, inkludert søkefunksjon. */
+  onSuggestionSelection?: () => void;
+  /** Custom filter for forslag. */
+  filter?: (sugestion: string, query: string) => boolean;
+  /**Minst lengde på query når forslag skal vises. */
+  queryLength?: number;
+  /** Barnet til komponenten (`<Search />`). */
+  children?: ReactNode;
+  /**Initielle `value` i `<Search>`. */
+  value?: string;
+};
+
+export const SearchAutocompleteWrapper = (
+  props: SearchAutocompleteWrapperProps
+) => {
+  const {
+    value,
+    data,
+    filter,
+    queryLength = 2,
+    onChange,
+    onSuggestionSelection,
+    children,
+  } = props;
+
+  const [inputValue, setInputValue] = useState(value || '');
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  const closeSuggestions = () =>
+    showSuggestions === true && setShowSuggestions(false);
+
+  const openSuggestions = () =>
+    showSuggestions === false && setShowSuggestions(true);
+
+  useEffect(() => {
+    if (suggestions.length > 0) {
+      openSuggestions();
+    } else {
+      closeSuggestions();
+    }
+  }, [suggestions]);
+
+  const isWeightedValueData = (
+    data: SearchData | WeightedSearchData
+  ): data is WeightedSearchData =>
+    (data as WeightedSearchData).array[0].relevance !== undefined;
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const query = e.target.value;
+    setInputValue(query);
+    let finalSuggestions: string[] = [];
+
+    if (query.length >= queryLength) {
+      if (data) {
+        if (isWeightedValueData(data)) {
+          const { sortFunction, array } = data;
+
+          const filteredSuggestions: WeightedValue[] = array.filter(
+            suggestion =>
+              filter
+                ? filter(suggestion.text, query)
+                : searchFilter(suggestion.text, query)
+          );
+
+          finalSuggestions = filteredSuggestions
+            .sort(sortFunction ? (a, b) => sortFunction(a, b) : undefined)
+            .map(item => item.text);
+        } else {
+          const { sortFunction, array } = data;
+
+          const filteredSuggestions: string[] = array.filter(suggestion =>
+            filter ? filter(suggestion, query) : searchFilter(suggestion, query)
+          );
+
+          finalSuggestions = filteredSuggestions.sort(
+            sortFunction ? (a, b) => sortFunction(a, b) : undefined
+          );
+        }
+      }
+      setSuggestions(finalSuggestions);
+    } else {
+      setSuggestions([]);
+    }
+    onChange && onChange(e);
+  };
+
+  const handleSuggestionClick = (e: MouseEvent<HTMLButtonElement>) => {
+    setSuggestions([]);
+    setInputValue((e.target as HTMLButtonElement).innerText);
+    onSuggestionSelection && onSuggestionSelection();
+    closeSuggestions();
+  };
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const suggestionsRef = useRef<HTMLDivElement>(null);
+
+  useOnClickOutside([inputRef.current, suggestionsRef.current], () => {
+    closeSuggestions();
+  });
+
+  useOnKeyDown('Tab', () => closeSuggestions());
+
+  const contextProps: AutocompleteSearchContextType = {
+    showSuggestions,
+    inputRef,
+    suggestionsRef,
+    suggestions,
+    onValueChange: handleChange,
+    inputValue,
+    onSugggestionClick: handleSuggestionClick,
+  };
+  return (
+    <AutocompleteSearchContext.Provider value={contextProps}>
+      {children}
+    </AutocompleteSearchContext.Provider>
+  );
+};

--- a/components/src/components/Search/SearchSuggestions.tsx
+++ b/components/src/components/Search/SearchSuggestions.tsx
@@ -1,0 +1,141 @@
+import styled from 'styled-components';
+import { removeListStyling } from '../../helpers/styling/removeListStyling';
+import { OverflowMenuItem } from '../OverflowMenu/OverflowMenuItem';
+import { searchTokens as tokens, typographyTypes } from './Search.tokens';
+import { Paper } from '../../helpers';
+import { SearchProps, SearchSize } from './Search';
+import { Typography } from '../Typography';
+import { getFontStyling } from '../Typography/Typography.utils';
+import { BaseComponentProps, getBaseHTMLProps } from '../../types';
+import { forwardRef, MouseEvent } from 'react';
+import { useRoveFocus } from '../../hooks';
+import { scrollbarStyling } from '../ScrollableContainer';
+import { visibilityTransition } from '../../helpers/styling';
+import { derivativeIdGenerator } from '../../utils';
+
+const { suggestionsContainer, suggestionsHeader } = tokens;
+
+type SuggestionsContainerProps = {
+  isHidden?: boolean;
+};
+
+const SuggestionsContainer = styled(Paper)<SuggestionsContainerProps>`
+  ${({ isHidden }) => visibilityTransition(!isHidden)};
+  position: absolute;
+  top: 100%;
+  width: 100%;
+  max-height: 300px;
+  margin-top: ${suggestionsContainer.marginTop};
+  border: ${suggestionsContainer.border};
+  box-shadow: ${suggestionsContainer.boxShadow};
+  z-index: 3;
+  overflow-y: scroll;
+  ${scrollbarStyling.firefox}
+  ${scrollbarStyling.webkit}
+`;
+
+type MenuItemProps = {
+  size: SearchSize;
+};
+
+const MenuItem = styled(OverflowMenuItem)<MenuItemProps>`
+  ${({ size }) => getFontStyling(typographyTypes[size])}
+`;
+
+const SuggestionsList = styled.ul`
+  ${removeListStyling}
+`;
+
+const SuggestionsHeader = styled(Typography)`
+  padding-left: ${suggestionsHeader.paddingLeft};
+`;
+
+export type SearchSuggestionsProps = BaseComponentProps<
+  HTMLDivElement,
+  Pick<SearchProps, 'componentSize'> & {
+    /**Forslag som vises i listen. */
+    suggestions?: string[];
+    /** Om listen skal vises. */
+    showSuggestions?: boolean;
+    /**Callback når et forslag blir valgt, inkludert søkefunksjon. */
+    onSuggestionClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+    /** Maks antall forslag vist i listen. */
+    maxSuggestions?: number;
+    /**Id til `<Search>`. */
+    searchId: string;
+  }
+>;
+
+export const SearchSuggestions = forwardRef<
+  HTMLDivElement,
+  SearchSuggestionsProps
+>((props, ref) => {
+  const {
+    id,
+    searchId,
+    className,
+    htmlProps,
+    suggestions = [],
+    showSuggestions,
+    componentSize,
+    onSuggestionClick,
+    maxSuggestions,
+    ...rest
+  } = props;
+
+  const suggestionsHeaderId = derivativeIdGenerator(
+    searchId,
+    'suggestions-header'
+  );
+
+  const [focus, setFocus] = useRoveFocus(
+    suggestions && suggestions.length,
+    !showSuggestions
+  );
+
+  const suggestionsToRender = maxSuggestions
+    ? suggestions?.slice(maxSuggestions)
+    : suggestions;
+
+  const renderedSuggestions = (
+    <SuggestionsList role="listbox" aria-labelledby={suggestionsHeaderId}>
+      {suggestionsToRender.map((suggestion, index) => {
+        return (
+          <li key={index} role="option">
+            <MenuItem
+              index={index}
+              focus={focus === index && showSuggestions}
+              setFocus={setFocus}
+              aria-label={`søk på ${suggestion}`}
+              onClick={onSuggestionClick}
+              title={suggestion}
+              aria-setsize={suggestionsToRender.length}
+              aria-posinset={index}
+              size={componentSize}
+            ></MenuItem>
+          </li>
+        );
+      })}
+    </SuggestionsList>
+  );
+
+  const isHidden = !showSuggestions;
+
+  return (
+    <SuggestionsContainer
+      {...getBaseHTMLProps(id, className, htmlProps, rest)}
+      ref={ref}
+      isHidden={isHidden}
+      aria-hidden={isHidden}
+    >
+      <SuggestionsHeader
+        typographyType="supportingStyleTiny01"
+        forwardedAs="span"
+        id={suggestionsHeaderId}
+      >
+        Søkeforslag
+      </SuggestionsHeader>
+      {renderedSuggestions}
+    </SuggestionsContainer>
+  );
+});

--- a/components/src/components/Search/index.ts
+++ b/components/src/components/Search/index.ts
@@ -1,1 +1,30 @@
-export * from './Search';
+import { Search as BaseSearch, SearchProps, SearchSize } from './Search';
+import {
+  SearchAutocompleteWrapper,
+  SearchAutocompleteWrapperProps,
+  SearchData,
+  WeightedSearchData,
+} from './SearchAutocompleteWrapper';
+
+import { SearchSuggestions, SearchSuggestionsProps } from './SearchSuggestions';
+
+type SearchCompoundProps = typeof BaseSearch & {
+  AutocompleteWrapper: typeof SearchAutocompleteWrapper;
+  Suggestions: typeof SearchSuggestions;
+};
+
+const Search = BaseSearch as SearchCompoundProps;
+
+Search.AutocompleteWrapper = SearchAutocompleteWrapper;
+Search.Suggestions = SearchSuggestions;
+
+export { Search };
+
+export type {
+  SearchProps,
+  SearchSize,
+  SearchData,
+  WeightedSearchData,
+  SearchAutocompleteWrapperProps,
+  SearchSuggestionsProps,
+};

--- a/components/src/components/Select/Select.tsx
+++ b/components/src/components/Select/Select.tsx
@@ -20,6 +20,7 @@ import { CheckIcon, ChevronDownIcon, CloseSmallIcon } from '../../icons/tsx';
 import { WithRequiredIf } from '../../types/utils';
 import {
   derivativeIdGenerator,
+  searchFilter,
   spaceSeparatedIdListGenerator,
 } from '../../utils';
 import { Icon } from '../Icon';
@@ -146,18 +147,6 @@ const DDSControl = <TValue, IsMulti extends boolean>(
     {props.children}
   </Control>
 );
-
-function escapeRegexCharacters(text: string) {
-  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
-}
-
-export function searchFilter(text: string, search: string): boolean {
-  // Søkeordet er enten først i teksten, eller så har det mellomrom, bindestrek eller start-parentes før seg.
-  const searchFilterRegex = new RegExp(
-    `(?:^|[\\s-(])${escapeRegexCharacters(search.toLowerCase())}`
-  );
-  return searchFilterRegex.test(text.toLowerCase());
-}
 
 const defaultWidth: Property.Width<string> = '320px';
 

--- a/components/src/hooks/useRoveFocus.tsx
+++ b/components/src/hooks/useRoveFocus.tsx
@@ -43,7 +43,7 @@ export function useRoveFocus(
   reset?: boolean,
   direction: Direction = 'column'
 ): [number, Dispatch<SetStateAction<number>>] {
-  const [currentFocus, setCurrentFocus] = useState(0);
+  const [currentFocusIndex, setCurrentFocusIndex] = useState(-1);
 
   const nextKey = direction === 'row' ? 'ArrowRight' : 'ArrowDown';
   const previousKey = direction === 'row' ? 'ArrowLeft' : 'ArrowUp';
@@ -51,20 +51,24 @@ export function useRoveFocus(
   const handleKeyDown = useCallback(
     (e: Event) => {
       if (!size || !isKeyboardEvent(e)) return;
-      if (reset) setCurrentFocus(-1);
+      if (reset) setCurrentFocusIndex(-1);
       if (e.key === nextKey) {
         // Down arrow
         e.preventDefault();
-        setCurrentFocus(currentFocus === size - 1 ? 0 : currentFocus + 1);
+        setCurrentFocusIndex(
+          currentFocusIndex === size - 1 ? 0 : currentFocusIndex + 1
+        );
       } else if (e.key === previousKey) {
         // Up arrow
         e.preventDefault();
-        if (currentFocus !== -1) {
-          setCurrentFocus(currentFocus === 0 ? size - 1 : currentFocus - 1);
-        } else setCurrentFocus(size - 1);
+        if (currentFocusIndex !== -1) {
+          setCurrentFocusIndex(
+            currentFocusIndex === 0 ? size - 1 : currentFocusIndex - 1
+          );
+        } else setCurrentFocusIndex(size - 1);
       }
     },
-    [size, currentFocus, setCurrentFocus, reset]
+    [size, currentFocusIndex, setCurrentFocusIndex, reset]
   );
 
   useEffect(() => {
@@ -74,5 +78,5 @@ export function useRoveFocus(
     };
   }, [handleKeyDown]);
 
-  return [currentFocus, setCurrentFocus];
+  return [currentFocusIndex, setCurrentFocusIndex];
 }

--- a/components/src/utils/index.tsx
+++ b/components/src/utils/index.tsx
@@ -4,3 +4,4 @@ export * from './getScrollbarSize';
 export * from './text';
 export * from './color';
 export * from './getFocusableElements';
+export * from './searchFilter';

--- a/components/src/utils/searchFilter.tsx
+++ b/components/src/utils/searchFilter.tsx
@@ -1,0 +1,11 @@
+export function escapeRegexCharacters(text: string) {
+  return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+}
+
+export function searchFilter(text: string, query: string): boolean {
+  // Søkeordet er enten først i teksten, eller så har det mellomrom, bindestrek eller start-parentes før seg.
+  const searchFilterRegex = new RegExp(
+    `(?:^|[\\s-(])${escapeRegexCharacters(query.toLowerCase())}`
+  );
+  return searchFilterRegex.test(text.toLowerCase());
+}


### PR DESCRIPTION
- `<SearchAutocompleteWrapper>` - wrapper som håndterer autocomplete
- `<SearchSuggestions>` - liste med forslag
- Fikser initiell state i `useRoveFocus` slik at første elementet i listen får først fokus ved piltasttrykk.