### PR TITLE
Støtte for `required` i `<Select>`

### DIFF
--- a/components/package-lock.json
+++ b/components/package-lock.json
@@ -13,7 +13,7 @@
         "attr-accept": "^2.2.2",
         "file-selector": "^0.6.0",
         "focus-visible": "^5.2.0",
-        "react-select": "^5.4.0",
+        "react-select": "^5.6.0",
         "tslib": "^2.4.0"
       },
       "devDependencies": {

--- a/components/package.json
+++ b/components/package.json
@@ -119,7 +119,7 @@
     "attr-accept": "^2.2.2",
     "file-selector": "^0.6.0",
     "focus-visible": "^5.2.0",
-    "react-select": "^5.4.0",
+    "react-select": "^5.6.0",
     "tslib": "^2.4.0"
   }
 }

--- a/components/src/components/Select/Select.stories.mdx
+++ b/components/src/components/Select/Select.stories.mdx
@@ -216,6 +216,13 @@ Ofte brukt native props:
         <Cell>`true`</Cell>
         <Cell>Spesifiserer om brukeren kan søke på alternativene.</Cell>
       </Row>
+            <Row>
+        <Cell> `required` </Cell>
+        <Cell> `boolean` </Cell>
+        <Cell>nei </Cell>
+        <Cell>-</Cell>
+        <Cell>Markerer input som påkrevd til skjemavalidering. Gir `required` styling.</Cell>
+      </Row>
     </Body>
 
   </Table>

--- a/components/src/components/Select/Select.tsx
+++ b/components/src/components/Select/Select.tsx
@@ -187,8 +187,6 @@ export type SelectProps<
 > = {
   /**Ledetekst for nedtrekkslisten. */
   label?: string;
-  /**Gir required styling. **OBS!** støtter ikke DOM `required` attributt.   */
-  required?: boolean;
   /**Størrelsen på komponenten. */
   componentSize?: InputSize;
   /**Ikonet som vises i komponenten. */
@@ -321,6 +319,7 @@ const SelectInner = <
       Control: props => DDSControl(props, componentSize, icon),
     },
     'aria-invalid': hasErrorMessage ? true : undefined,
+    required,
     ...rest,
   };
 


### PR DESCRIPTION
I react-select@5.6.0 støttes `required` som nativ HTML attributt for `<input>`. Legger til støtte i komponenten.
Støtten må testes hos konsumentene som er interesserte.