### PR TITLE
Legg til støtte nested card accordions 

### DIFF
--- a/components/src/components/Card/CardAccordion/CardAccordionBody.tsx
+++ b/components/src/components/Card/CardAccordion/CardAccordionBody.tsx
@@ -60,7 +60,7 @@ const BodyContainer = styled.div<BodyContainerProps>`
   ${({ animate }) => animate && expandingAnimation}
   overflow: hidden;
   visibility: ${({ isExpanded }) => (isExpanded ? 'visible' : 'hidden')};
-  max-height: ${({ maxHeight }) => (maxHeight ? maxHeight : 0)}px;
+  height: ${({ isExpanded }) => (isExpanded ? 'auto' : 0)}px;
 `;
 
 export type CardAccordionBodyProps = BaseComponentPropsWithChildren<


### PR DESCRIPTION
Fjerner `max-height` og bruker heller `height` slik at Card kan ekspandere utover sin egen høyde.