### PR TITLE
Legger til `hideIcon` prop i `<InlineEdit>`

### DIFF
--- a/components/src/components/InlineEdit/InlineEdit.spec.tsx
+++ b/components/src/components/InlineEdit/InlineEdit.spec.tsx
@@ -13,14 +13,14 @@ const newValue = 'text';
 
 const TestComponentTextArea = (props: InlineEditTextAreaProps) => {
   const { value: propValue, ...rest } = props;
-  const [value, setValue] = useState(propValue);
+  const [value, setValue] = useState(propValue || '');
 
   return <InlineEditTextArea value={value} onSetValue={setValue} {...rest} />;
 };
 
 const TestComponentInput = (props: InlineEditInputProps) => {
   const { value: propValue, ...rest } = props;
-  const [value, setValue] = useState(propValue);
+  const [value, setValue] = useState(propValue || '');
 
   return <InlineEditInput value={value} onSetValue={setValue} {...rest} />;
 };

--- a/components/src/components/InlineEdit/InlineEdit.styles.tsx
+++ b/components/src/components/InlineEdit/InlineEdit.styles.tsx
@@ -1,31 +1,45 @@
 import styled, { css } from 'styled-components';
 import { inlineEditTokens } from './InlineEdit.tokens';
-const { inlineEdit, iconWrapper } = inlineEditTokens;
 import { Property } from 'csstype';
+import { StatefulInput } from '../../helpers';
+import { scrollbarStyling } from '../ScrollableContainer';
+
+const { inlineEdit, iconWrapper } = inlineEditTokens;
 
 export const defaultWidth: Property.Width = '140px';
 
-export const getInlineEditInputStyling = (isEditing?: boolean) => {
-  return css`
-    border-color: transparent;
-    background-color: ${inlineEdit.backgroundColor};
-    padding: ${inlineEdit.padding};
-    ${inlineEdit.font};
-    ${!isEditing &&
+type StyledInlineInputProps = {
+  isEditing?: boolean;
+  hideIcon?: boolean;
+};
+
+export const StyledInlineInput = styled(StatefulInput)<StyledInlineInputProps>`
+  border-color: transparent;
+  background-color: ${inlineEdit.backgroundColor};
+  padding: ${inlineEdit.padding};
+  ${inlineEdit.font};
+  ${({ isEditing, hideIcon }) =>
+    !isEditing &&
+    !hideIcon &&
     css`
-      padding-left: ${inlineEdit.paddingLeft};
+      padding-left: ${inlineEdit.withIcon.paddingLeft};
     `}
 
-    &:hover:enabled:read-write:not(:focus) {
-      background-color: ${inlineEdit.hover.backgroundColor};
-      border-color: transparent;
-      box-shadow: none;
-    }
-    &:focus {
-      background-color: ${inlineEdit.focus.backgroundColor};
-    }
-  `;
-};
+  &:hover:enabled:read-write:not(:focus) {
+    background-color: ${inlineEdit.hover.backgroundColor};
+    border-color: transparent;
+    box-shadow: none;
+  }
+  &:focus {
+    background-color: ${inlineEdit.focus.backgroundColor};
+  }
+`;
+
+export const StyledInlineTextArea = styled(StyledInlineInput)`
+  resize: vertical;
+  ${scrollbarStyling.webkit}
+  ${scrollbarStyling.firefox}
+`;
 
 export const IconWrapper = styled.span`
   position: absolute;

--- a/components/src/components/InlineEdit/InlineEdit.tokens.ts
+++ b/components/src/components/InlineEdit/InlineEdit.tokens.ts
@@ -4,9 +4,11 @@ const { colors, spacing, fontPackages } = ddsBaseTokens;
 
 const inlineEdit = {
   padding: spacing.SizesDdsSpacingLocalX025,
-  paddingLeft: spacing.SizesDdsSpacingLocalX2,
   font: fontPackages.body_sans_02.base,
   backgroundColor: 'transparent',
+  withIcon: {
+    paddingLeft: spacing.SizesDdsSpacingLocalX2,
+  },
   hover: {
     backgroundColor: colors.DdsColorInteractiveLightest,
   },

--- a/components/src/components/InlineEdit/InlineEdit.types.tsx
+++ b/components/src/components/InlineEdit/InlineEdit.types.tsx
@@ -13,6 +13,8 @@ export type BaseInlineInputProps = {
   errorMessage?: string;
   /** Bredde på komponenten. */
   width?: Property.Width;
+  /**Om redigeringsikonet skal vises. */
+  hideIcon?: boolean;
   /** **OBS!** settes automatisk av forelder. Spesifiserer om brukeren kan tømme inputfeltet. */
   emptiable?: boolean;
   /** **OBS!** settes automatisk av forelder. Spesifiserer om komponenten er i redigeringsmodus. */
@@ -40,7 +42,7 @@ export type CommonInlineEditWrapperProps = Pick<
   InlineEditProps,
   'onSetValue' | 'emptiable' | 'onBlur' | 'onFocus' | 'onChange'
 > &
-  Pick<BaseInlineInputProps, 'error' | 'errorMessage' | 'width'>;
+  Pick<BaseInlineInputProps, 'error' | 'errorMessage' | 'width' | 'hideIcon'>;
 
 export type InlineEditTextAreaProps = Omit<
   TextareaHTMLAttributes<HTMLTextAreaElement>,

--- a/components/src/components/InlineEdit/InlineEditInput.stories.tsx
+++ b/components/src/components/InlineEdit/InlineEditInput.stories.tsx
@@ -35,6 +35,7 @@ export const Overview = (args: InlineEditInputProps) => {
   const [value3, setValue3] = useState('');
   const [value4, setValue4] = useState('');
   const [value5, setValue5] = useState('tømbar');
+  const [value6, setValue6] = useState('uten ikon');
   return (
     <StoryTemplate title="InlineEditInput - overview">
       <InlineEditInput {...args} value={value} onSetValue={setValue} />
@@ -51,6 +52,12 @@ export const Overview = (args: InlineEditInputProps) => {
         onSetValue={setValue5}
         value={value5}
         emptiable
+      />
+      <InlineEditInput
+        {...args}
+        onSetValue={setValue6}
+        value={value6}
+        hideIcon
       />
     </StoryTemplate>
   );

--- a/components/src/components/InlineEdit/InlineEditTextArea.stories.tsx
+++ b/components/src/components/InlineEdit/InlineEditTextArea.stories.tsx
@@ -36,6 +36,7 @@ export const Overview = (args: InlineEditTextAreaProps) => {
   const [value3, setValue3] = useState('');
   const [value4, setValue4] = useState('');
   const [value5, setValue5] = useState('tømbar');
+  const [value6, setValue6] = useState('uten ikon');
   return (
     <StoryTemplate title="InlineEditTextArea - overview">
       <InlineEditTextArea {...args} value={value} onSetValue={setValue} />
@@ -57,6 +58,12 @@ export const Overview = (args: InlineEditTextAreaProps) => {
         onSetValue={setValue5}
         value={value5}
         emptiable
+      />
+      <InlineEditTextArea
+        {...args}
+        onSetValue={setValue6}
+        value={value6}
+        hideIcon
       />
     </StoryTemplate>
   );

--- a/components/src/components/InlineEdit/InlineInput.tsx
+++ b/components/src/components/InlineEdit/InlineInput.tsx
@@ -1,32 +1,22 @@
 import { forwardRef, InputHTMLAttributes, useId } from 'react';
-import styled from 'styled-components';
 import { EditIcon } from '../../icons/tsx';
 import { Icon } from '../Icon';
 import {
   InputContainer,
   OuterInputContainer,
   renderInputMessage,
-  StatefulInput,
 } from '../../helpers';
 import {
   derivativeIdGenerator,
   spaceSeparatedIdListGenerator,
 } from '../../utils';
 import {
-  getInlineEditInputStyling,
   IconWrapper,
   defaultWidth,
+  StyledInlineInput,
 } from './InlineEdit.styles';
 import { BaseInlineInputProps } from './InlineEdit.types';
 import { inlineEditVisuallyHidden } from './InlineEdit.utils';
-
-type StyledInlineInputProps = {
-  isEditing?: boolean;
-};
-
-const StyledInlineInput = styled(StatefulInput)<StyledInlineInputProps>`
-  ${({ isEditing }) => getInlineEditInputStyling(isEditing)}
-`;
 
 export type InlineInputProps = BaseInlineInputProps &
   InputHTMLAttributes<HTMLInputElement>;
@@ -41,6 +31,7 @@ export const InlineInput = forwardRef<HTMLInputElement, InlineInputProps>(
       width = defaultWidth,
       'aria-describedby': ariaDescribedby,
       emptiable,
+      hideIcon,
       ...rest
     } = props;
 
@@ -55,7 +46,7 @@ export const InlineInput = forwardRef<HTMLInputElement, InlineInputProps>(
     return (
       <OuterInputContainer width={width}>
         <InputContainer>
-          {!isEditing && (
+          {!isEditing && !hideIcon && (
             <IconWrapper>
               <Icon icon={EditIcon} iconSize="small" />
             </IconWrapper>
@@ -66,6 +57,7 @@ export const InlineInput = forwardRef<HTMLInputElement, InlineInputProps>(
             ref={ref}
             hasErrorMessage={hasErrorState}
             isEditing={isEditing}
+            hideIcon={hideIcon}
             aria-describedby={spaceSeparatedIdListGenerator([
               hasErrorMessage ? errorMessageId : undefined,
               descId,

--- a/components/src/components/InlineEdit/InlineTextArea.tsx
+++ b/components/src/components/InlineEdit/InlineTextArea.tsx
@@ -1,36 +1,22 @@
 import { forwardRef, TextareaHTMLAttributes, useId } from 'react';
-import styled from 'styled-components';
 import { EditIcon } from '../../icons/tsx';
 import { Icon } from '../Icon';
 import {
   InputContainer,
   OuterInputContainer,
   renderInputMessage,
-  StatefulInput,
 } from '../../helpers';
 import {
   derivativeIdGenerator,
   spaceSeparatedIdListGenerator,
 } from '../../utils';
-import { scrollbarStyling } from '../ScrollableContainer';
 import {
-  getInlineEditInputStyling,
   IconWrapper,
   defaultWidth,
+  StyledInlineTextArea,
 } from './InlineEdit.styles';
 import { BaseInlineInputProps } from './InlineEdit.types';
 import { inlineEditVisuallyHidden } from './InlineEdit.utils';
-
-type StyledInlineTextAreaProps = {
-  isEditing?: boolean;
-};
-
-const StyledInlineTextArea = styled(StatefulInput)<StyledInlineTextAreaProps>`
-  ${({ isEditing }) => getInlineEditInputStyling(isEditing)}
-  resize: vertical;
-  ${scrollbarStyling.webkit}
-  ${scrollbarStyling.firefox}
-`;
 
 export type InlineTextAreaProps = BaseInlineInputProps &
   TextareaHTMLAttributes<HTMLTextAreaElement>;
@@ -47,6 +33,7 @@ export const InlineTextArea = forwardRef<
     width = defaultWidth,
     'aria-describedby': ariaDescribedby,
     emptiable,
+    hideIcon,
     ...rest
   } = props;
 
@@ -59,7 +46,7 @@ export const InlineTextArea = forwardRef<
   return (
     <OuterInputContainer width={width}>
       <InputContainer>
-        {!isEditing && (
+        {!isEditing && !hideIcon && (
           <IconWrapper>
             <Icon icon={EditIcon} iconSize="small" />
           </IconWrapper>
@@ -71,6 +58,7 @@ export const InlineTextArea = forwardRef<
           ref={ref}
           hasErrorMessage={!!error || hasErrorMessage}
           isEditing={isEditing}
+          hideIcon={hideIcon}
           aria-describedby={spaceSeparatedIdListGenerator([
             hasErrorMessage ? errorMessageId : undefined,
             descId,


### PR DESCRIPTION
`hideIcon` tillater å velge om redigerinsikonet skal dukke opp i komponenten. Ikonet vises som default.