### PR TITLE
Legger til style normalizer for knapper

### DIFF
--- a/components/src/components/Button/Button.styles.tsx
+++ b/components/src/components/Button/Button.styles.tsx
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components';
 import {
   focusVisible,
   focusVisibleTransitionValue,
+  normalizeButton,
   selection,
 } from '../../helpers/styling';
 import { getFontStyling } from '../Typography/Typography.utils';
@@ -91,6 +92,7 @@ type ButtonWrapperProps = {
 };
 
 export const ButtonWrapper = styled.button<ButtonWrapperProps>`
+  ${normalizeButton}
   border: ${base.border};
   user-select: text;
   display: inline-flex;

--- a/components/src/components/Card/CardAccordion/CardAccordionHeader.tsx
+++ b/components/src/components/Card/CardAccordion/CardAccordionHeader.tsx
@@ -5,7 +5,7 @@ import {
   typographyTypes,
 } from './CardAccordion.tokens';
 import { AnimatedChevronUpDown } from '../../../helpers';
-import { removeButtonStyling } from '../../../helpers/styling';
+import { normalizeButton, removeButtonStyling } from '../../../helpers/styling';
 import {
   BaseComponentPropsWithChildren,
   getBaseHTMLProps,
@@ -30,6 +30,7 @@ const HeaderContainer = styled.div`
 `;
 
 const HeaderWrapper = styled.button`
+  ${normalizeButton}
   user-select: text;
   position: relative;
   cursor: pointer;

--- a/components/src/components/OverflowMenu/OverflowMenuItem.tsx
+++ b/components/src/components/OverflowMenu/OverflowMenuItem.tsx
@@ -20,7 +20,7 @@ import { Icon } from '../Icon';
 import { useCombinedRef } from '../../hooks';
 import { BaseComponentProps, getBaseHTMLProps } from '../../types';
 import { SvgIcon } from '../../icons/utils';
-import { focusVisibleLink } from '../../helpers/styling';
+import { focusVisibleLink, normalizeButton } from '../../helpers/styling';
 import { getFontStyling } from '../Typography/Typography.utils';
 
 const { element, link } = tokens;
@@ -41,6 +41,7 @@ export const Span = styled.span`
 `;
 
 export const Link = styled.a`
+  ${normalizeButton}
   text-align: left;
   user-select: text;
   border: none;

--- a/components/src/components/Table/SortCell.tsx
+++ b/components/src/components/Table/SortCell.tsx
@@ -8,11 +8,16 @@ import {
   ChevronDownIcon,
 } from '../../icons/tsx';
 import styled from 'styled-components';
-import { focusVisible, removeButtonStyling } from '../../helpers/styling';
+import {
+  focusVisible,
+  normalizeButton,
+  removeButtonStyling,
+} from '../../helpers/styling';
 
 const { cell } = tableTokens;
 
 const StyledButton = styled.button`
+  ${normalizeButton}
   user-select: text;
   ${removeButtonStyling}
   display: flex;

--- a/components/src/components/Tabs/Tab.tsx
+++ b/components/src/components/Tabs/Tab.tsx
@@ -22,6 +22,7 @@ import {
 import {
   focusVisible,
   focusVisibleTransitionValue,
+  normalizeButton,
   removeButtonStyling,
 } from '../../helpers/styling';
 import { SvgIcon } from '../../icons/utils';
@@ -38,6 +39,7 @@ type ButtonProps = {
 };
 
 const Button = styled.button<ButtonProps>`
+  ${normalizeButton}
   ${removeButtonStyling}
   user-select: text;
   display: flex;

--- a/components/src/helpers/styling/index.tsx
+++ b/components/src/helpers/styling/index.tsx
@@ -6,3 +6,4 @@ export * from './focus';
 export * from './danger';
 export * from './hideInput';
 export * from './selection';
+export * from './normalize';

--- a/components/src/helpers/styling/normalize.tsx
+++ b/components/src/helpers/styling/normalize.tsx
@@ -1,0 +1,6 @@
+import { Property } from 'csstype';
+
+export const normalizeButton = {
+  margin: 0,
+  textTransform: 'none' as Property.TextTransform,
+};


### PR DESCRIPTION
Default styling i nettlesere kan føre til uforutsigbar styling i komponenter. Legger til en styling objekt som normaliserer `<button>`.