### PR TITLE
Gjør om `<Table>` komponenter til ordentlige subkomponenter

### DIFF
--- a/components/src/components/Grid/Grid.stories.tsx
+++ b/components/src/components/Grid/Grid.stories.tsx
@@ -6,7 +6,7 @@ import { Button } from '../Button';
 import { InternalHeader } from '../InternalHeader';
 import { Pagination } from '../Pagination';
 import { Search } from '../Search';
-import { Body, Cell, Head, Row, Table } from '../Table';
+import { Table } from '../Table';
 import { Tag } from '../Tag';
 import { TextInput } from '../TextInput';
 import { Heading } from '../Typography';
@@ -60,31 +60,33 @@ export const PageExample = (args: GridProps) => {
           />
         </GridChild>
         <GridChild columnsOccupied="all">
-          <Table style={{ width: '100%' }}>
-            <Head>
-              <Row type="head">
-                <Cell type="head">Navn</Cell>
-                <Cell type="head">Firma</Cell>
-                <Cell type="head">Status</Cell>
-              </Row>
-            </Head>
-            <Body>
-              <Row type="body">
-                <Cell> Marie Bjerke </Cell>
-                <Cell>Advokat Firma </Cell>
-                <Cell>
-                  <Tag text="Møterett" purpose="success" />
-                </Cell>
-              </Row>
-              <Row type="body">
-                <Cell>Sandra-Katrine Ingvaldsen Lovsetter</Cell>
-                <Cell>Advokatene AS</Cell>
-                <Cell>
-                  <Tag text="Ikke møterett" purpose="danger" />
-                </Cell>
-              </Row>
-            </Body>
-          </Table>
+          <Table.Wrapper>
+            <Table style={{ width: '100%' }}>
+              <Table.Head>
+                <Table.Row type="head">
+                  <Table.Cell type="head">Navn</Table.Cell>
+                  <Table.Cell type="head">Firma</Table.Cell>
+                  <Table.Cell type="head">Status</Table.Cell>
+                </Table.Row>
+              </Table.Head>
+              <Table.Body>
+                <Table.Row type="body">
+                  <Table.Cell> Marie Bjerke </Table.Cell>
+                  <Table.Cell>Advokat Firma </Table.Cell>
+                  <Table.Cell>
+                    <Tag text="Møterett" purpose="success" />
+                  </Table.Cell>
+                </Table.Row>
+                <Table.Row type="body">
+                  <Table.Cell>Sandra-Katrine Ingvaldsen Lovsetter</Table.Cell>
+                  <Table.Cell>Advokatene AS</Table.Cell>
+                  <Table.Cell>
+                    <Tag text="Ikke møterett" purpose="danger" />
+                  </Table.Cell>
+                </Table.Row>
+              </Table.Body>
+            </Table>
+          </Table.Wrapper>
         </GridChild>
         <GridChild columnsOccupied="all">
           <Pagination

--- a/components/src/components/InlineEdit/InlineEditInput.stories.tsx
+++ b/components/src/components/InlineEdit/InlineEditInput.stories.tsx
@@ -1,5 +1,5 @@
 import { StoryTemplate } from '../../storybook';
-import { Body, Cell, Head, Row, Table, TableWrapper } from '../Table';
+import { Table } from '../Table';
 import { useState } from 'react';
 import { InlineEditInput } from './InlineEditInput';
 import { InlineEditInputProps } from './InlineEdit.types';
@@ -77,33 +77,33 @@ export const InTable = () => {
   const [value2, setValue2] = useState();
   return (
     <StoryTemplate title="InlineEditInput - in table" display="block">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table>
-          <Head>
-            <Row type="head">
-              <Cell type="head">Header</Cell>
-              <Cell type="head">Header</Cell>
-              <Cell type="head">Header</Cell>
-            </Row>
-          </Head>
-          <Body>
-            <Row>
-              <Cell>
+          <Table.Head>
+            <Table.Row type="head">
+              <Table.Cell type="head">Header</Table.Cell>
+              <Table.Cell type="head">Header</Table.Cell>
+              <Table.Cell type="head">Header</Table.Cell>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>
                 <InlineEditInput onSetValue={() => setValue(value)} />
-              </Cell>
-              <Cell>innhold</Cell>
-              <Cell>innhold</Cell>
-            </Row>
-            <Row>
-              <Cell>
+              </Table.Cell>
+              <Table.Cell>innhold</Table.Cell>
+              <Table.Cell>innhold</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>
                 <InlineEditInput onSetValue={() => setValue2(value2)} />
-              </Cell>
-              <Cell>innhold</Cell>
-              <Cell>innhold</Cell>
-            </Row>
-          </Body>
+              </Table.Cell>
+              <Table.Cell>innhold</Table.Cell>
+              <Table.Cell>innhold</Table.Cell>
+            </Table.Row>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };

--- a/components/src/components/InlineEdit/InlineEditTextArea.stories.tsx
+++ b/components/src/components/InlineEdit/InlineEditTextArea.stories.tsx
@@ -1,5 +1,5 @@
 import { StoryTemplate } from '../../storybook';
-import { Body, Cell, Head, Row, Table, TableWrapper } from '../Table';
+import { Table } from '../Table';
 import { useState } from 'react';
 import { InlineEditTextArea } from './InlineEditTextArea';
 
@@ -83,33 +83,33 @@ export const InTable = () => {
   const [value2, setValue2] = useState();
   return (
     <StoryTemplate title="InlineEditTextArea - in table" display="block">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table>
-          <Head>
-            <Row type="head">
-              <Cell type="head">Header</Cell>
-              <Cell type="head">Header</Cell>
-              <Cell type="head">Header</Cell>
-            </Row>
-          </Head>
-          <Body>
-            <Row>
-              <Cell>
+          <Table.Head>
+            <Table.Row type="head">
+              <Table.Cell type="head">Header</Table.Cell>
+              <Table.Cell type="head">Header</Table.Cell>
+              <Table.Cell type="head">Header</Table.Cell>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell>
                 <InlineEditTextArea onSetValue={() => setValue(value)} />
-              </Cell>
-              <Cell>innhold</Cell>
-              <Cell>innhold</Cell>
-            </Row>
-            <Row>
-              <Cell>
+              </Table.Cell>
+              <Table.Cell>innhold</Table.Cell>
+              <Table.Cell>innhold</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>
                 <InlineEditTextArea onSetValue={() => setValue2(value2)} />
-              </Cell>
-              <Cell>innhold</Cell>
-              <Cell>innhold</Cell>
-            </Row>
-          </Body>
+              </Table.Cell>
+              <Table.Cell>innhold</Table.Cell>
+              <Table.Cell>innhold</Table.Cell>
+            </Table.Row>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };

--- a/components/src/components/Select/Select.stories.mdx
+++ b/components/src/components/Select/Select.stories.mdx
@@ -13,7 +13,7 @@ import {
   LinkToInteractiveStory,
 } from '../../storybook';
 import { Link } from '../Typography';
-import { TableWrapper, Table, Body, Cell, Head, Row } from '../Table';
+import { Table } from '../Table';
 
 <Meta title="Design system/Select/API" component={Select} />
 
@@ -63,170 +63,171 @@ Komponenten bruker <Link href='https://react-select.com/home' external>React-sel
 
 ### Elsa props
 
-<TableWrapper>
+<Table.Wrapper>
   <Table density="compact" style={{ width: '100%' }}>
-    <Head>
-      <Row type="head">
-        <Cell type="head">Property</Cell>
-        <Cell type="head">Datatype</Cell>
-        <Cell type="head">Påkrevd</Cell>
-        <Cell type="head">Default</Cell>
-        <Cell type="head">Beskrivelse</Cell>
-      </Row>
-    </Head>
-    <Body>
-      <Row>
-        <Cell> `label` </Cell>
-        <Cell> `string` </Cell>
-        <Cell> nei </Cell>
-        <Cell> - </Cell>
-        <Cell> Label for nedtrekkslisten. </Cell>
-      </Row>
-      <Row>
-        <Cell> `width` </Cell>
-        <Cell> `string` </Cell>
-        <Cell> nei </Cell>
-        <Cell> `'320px'` </Cell>
-        <Cell> Custom bredde ved behov.</Cell>
-      </Row>
-      <Row>
-        <Cell> `tip` </Cell>
-        <Cell> `string` </Cell>
-        <Cell> nei</Cell>
-        <Cell>-</Cell>
-        <Cell>Hjelpetekst.</Cell>
-      </Row>
-      <Row>
-        <Cell> `errorMessage` </Cell>
-        <Cell> `string` </Cell>
-        <Cell> nei </Cell>
-        <Cell>-</Cell>
-        <Cell> Meldingen som vises ved valideringsfeil.</Cell>
-      </Row>
-      <Row>
-        <Cell> `required` </Cell>
-        <Cell> `boolean` </Cell>
-        <Cell>nei </Cell>
-        <Cell>-</Cell>
-        <Cell>
+    <Table.Head>
+      <Table.Row type="head">
+        <Table.Cell type="head">Property</Table.Cell>
+        <Table.Cell type="head">Datatype</Table.Cell>
+        <Table.Cell type="head">Påkrevd</Table.Cell>
+        <Table.Cell type="head">Default</Table.Cell>
+        <Table.Cell type="head">Beskrivelse</Table.Cell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
+      <Table.Row>
+        <Table.Cell> `label` </Table.Cell>
+        <Table.Cell> `string` </Table.Cell>
+        <Table.Cell> nei </Table.Cell>
+        <Table.Cell> - </Table.Cell>
+        <Table.Cell> Label for nedtrekkslisten. </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `width` </Table.Cell>
+        <Table.Cell> `string` </Table.Cell>
+        <Table.Cell> nei </Table.Cell>
+        <Table.Cell> `'320px'` </Table.Cell>
+        <Table.Cell> Custom bredde ved behov.</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `tip` </Table.Cell>
+        <Table.Cell> `string` </Table.Cell>
+        <Table.Cell> nei</Table.Cell>
+        <Table.Cell>-</Table.Cell>
+        <Table.Cell>Hjelpetekst.</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `errorMessage` </Table.Cell>
+        <Table.Cell> `string` </Table.Cell>
+        <Table.Cell> nei </Table.Cell>
+        <Table.Cell>-</Table.Cell>
+        <Table.Cell> Meldingen som vises ved valideringsfeil.</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `required` </Table.Cell>
+        <Table.Cell> `boolean` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>-</Table.Cell>
+        <Table.Cell>
           Gir `required` styling. OBS! støtter ikke DOM required attributt.{' '}
-        </Cell>
-      </Row>
-      <Row>
-        <Cell> `readOnly` </Cell>
-        <Cell> `boolean` </Cell>
-        <Cell>nei </Cell>
-        <Cell>-</Cell>
-        <Cell>Nedtrekkslisten blir disabled og får `readOnly` styling. </Cell>
-      </Row>
-    </Body>
+        </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `readOnly` </Table.Cell>
+        <Table.Cell> `boolean` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>-</Table.Cell>
+        <Table.Cell>
+          Nedtrekkslisten blir disabled og får `readOnly` styling.
+        </Table.Cell>
+      </Table.Row>
+    </Table.Body>
   </Table>
-</TableWrapper>
+</Table.Wrapper>
 <br />
 ### Native React-select props
 
 Ofte brukt native props:
 
-<TableWrapper>
+<Table.Wrapper>
   <Table density="compact" style={{ width: '100%' }}>
-    <Head>
-      <Row type="head">
-                <Cell type="head">Property</Cell>
-        <Cell type="head">Datatype</Cell>
-        <Cell type="head">Påkrevd</Cell>
-        <Cell type="head">Default</Cell>
-        <Cell type="head">Beskrivelse</Cell>
-      </Row>
-    </Head>
-    <Body>
-      <Row>
-        <Cell> `options` </Cell>
-        <Cell> `{ label: string, value: string }[]` </Cell>
-        <Cell>nei </Cell>
-        <Cell>-</Cell>
-        <Cell>Alternativer som havner i nedtrekkslisten. </Cell>
-      </Row>
-       <Row>
-        <Cell> `onChange` </Cell>
-        <Cell> `(newValue: { label: string, value: string } | null, ActionMeta: ActionMeta<TOption>) => void` </Cell>
-        <Cell>nei </Cell>
-        <Cell>-</Cell>
-        <Cell> onChange funksjon.</Cell>
-      </Row>
-       <Row>
-        <Cell> `isDisabled` </Cell>
-        <Cell> `boolean` </Cell>
-        <Cell>nei </Cell>
-        <Cell>-</Cell>
-        <Cell>Gjør nedtrekkslisten disabled og gir den relevant styling. </Cell>
-      </Row>
-      <Row>
-        <Cell> `value` </Cell>
-        <Cell> `{ label: string; value: string; } | null` </Cell>
-        <Cell>nei </Cell>
-        <Cell>-</Cell>
-        <Cell> Forhåndsvalgt alternativ som brukeren ikke kan endre. OBS! Brukes kun i oppsummering av brukerens valg og lignende tilfeller.</Cell>
-      </Row>
-      <Row>
-        <Cell> `defaultValue` </Cell>
-        <Cell> `{ label: string; value: string; } | null` </Cell>
-        <Cell>nei </Cell>
-        <Cell>-</Cell>
-        <Cell>Forhåndsvalgt alternativ som brukeren kan endre. OBS! Brukes ikke i standard skjema da brukeren skal ta et bevisst valg. </Cell>
-      </Row>
-      <Row>
-        <Cell> `isMulti` </Cell>
-        <Cell> `boolean` </Cell>
-        <Cell>nei </Cell>
-        <Cell>-</Cell>
-        <Cell>Gjør komponenten om til multiselect.</Cell>
-      </Row>
-            <Row>
-        <Cell> `closeMenuOnSelect` </Cell>
-        <Cell> `boolean` </Cell>
-        <Cell>nei </Cell>
-        <Cell>false ved isMulti, true ellers</Cell>
-        <Cell>Spesifiserer om listen med alternativer skal lukkes når brukeren har valgt en alternativ.</Cell>
-      </Row>
-            <Row>
-        <Cell> `isClearable` </Cell>
-        <Cell> `boolean` </Cell>
-        <Cell>nei </Cell>
-        <Cell>`true`</Cell>
-        <Cell>Spesifiserer om valgt alternativ kan tømmes. OBS! settes til false i spesialtilfeller, bruker skal ha mulighet til å tømme valget i standard skjema.</Cell>
-      </Row>
-            <Row>
-        <Cell> `placeholder` </Cell>
-        <Cell> `string` </Cell>
-        <Cell>nei </Cell>
-        <Cell>`'-- Velg fra listen --'`</Cell>
-        <Cell>Tekst som vises når ingen alternativ er valgt.</Cell>
-      </Row>
-      <Row>
-        <Cell> `isLoading` </Cell>
-        <Cell> `boolean` </Cell>
-        <Cell>nei </Cell>
-        <Cell>-</Cell>
-        <Cell>Kan brukes mens komponenten lastes inn, rendrer en innlastningsindikator i inputfeltet.</Cell>
-      </Row>
-      <Row>
-        <Cell> `isSearchable` </Cell>
-        <Cell> `boolean` </Cell>
-        <Cell>nei </Cell>
-        <Cell>`true`</Cell>
-        <Cell>Spesifiserer om brukeren kan søke på alternativene.</Cell>
-      </Row>
-            <Row>
-        <Cell> `required` </Cell>
-        <Cell> `boolean` </Cell>
-        <Cell>nei </Cell>
-        <Cell>-</Cell>
-        <Cell>Markerer input som påkrevd til skjemavalidering. Gir `required` styling.</Cell>
-      </Row>
-    </Body>
-
+    <Table.Head>
+      <Table.Row type="head">
+        <Table.Cell type="head">Property</Table.Cell>
+        <Table.Cell type="head">Datatype</Table.Cell>
+        <Table.Cell type="head">Påkrevd</Table.Cell>
+        <Table.Cell type="head">Default</Table.Cell>
+        <Table.Cell type="head">Beskrivelse</Table.Cell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
+      <Table.Row>
+        <Table.Cell> `options` </Table.Cell>
+        <Table.Cell> `{ label: string, value: string }[]` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>-</Table.Cell>
+        <Table.Cell>Alternativer som havner i nedtrekkslisten. </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `onChange` </Table.Cell>
+        <Table.Cell> `(newValue: { label: string, value: string } | null, ActionMeta: ActionMeta<TOption>) => void` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>-</Table.Cell>
+        <Table.Cell> onChange funksjon.</Table.Cell>
+      </Table.Row>
+       <Table.Row>
+        <Table.Cell> `isDisabled` </Table.Cell>
+        <Table.Cell> `boolean` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>-</Table.Cell>
+        <Table.Cell>Gjør nedtrekkslisten disabled og gir den relevant styling. </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `value` </Table.Cell>
+        <Table.Cell> `{ label: string; value: string; } | null` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>-</Table.Cell>
+        <Table.Cell> Forhåndsvalgt alternativ som brukeren ikke kan endre. OBS! Brukes kun i oppsummering av brukerens valg og lignende tilfeller.</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `defaultValue` </Table.Cell>
+        <Table.Cell> `{ label: string; value: string; } | null` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>-</Table.Cell>
+        <Table.Cell>Forhåndsvalgt alternativ som brukeren kan endre. OBS! Brukes ikke i standard skjema da brukeren skal ta et bevisst valg. </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `isMulti` </Table.Cell>
+        <Table.Cell> `boolean` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>-</Table.Cell>
+        <Table.Cell>Gjør komponenten om til multiselect.</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `closeMenuOnSelect` </Table.Cell>
+        <Table.Cell> `boolean` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>false ved isMulti, true ellers</Table.Cell>
+        <Table.Cell>Spesifiserer om listen med alternativer skal lukkes når brukeren har valgt en alternativ.</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `isClearable` </Table.Cell>
+        <Table.Cell> `boolean` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>`true`</Table.Cell>
+        <Table.Cell>Spesifiserer om valgt alternativ kan tømmes. OBS! settes til false i spesialtilfeller, bruker skal ha mulighet til å tømme valget i standard skjema.</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `placeholder` </Table.Cell>
+        <Table.Cell> `string` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>`'-- Velg fra listen --'`</Table.Cell>
+        <Table.Cell>Tekst som vises når ingen alternativ er valgt.</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `isLoading` </Table.Cell>
+        <Table.Cell> `boolean` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>-</Table.Cell>
+        <Table.Cell>Kan brukes mens komponenten lastes inn, rendrer en innlastningsindikator i inputfeltet.</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `isSearchable` </Table.Cell>
+        <Table.Cell> `boolean` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>`true`</Table.Cell>
+        <Table.Cell>Spesifiserer om brukeren kan søke på alternativene.</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `required` </Table.Cell>
+        <Table.Cell> `boolean` </Table.Cell>
+        <Table.Cell>nei </Table.Cell>
+        <Table.Cell>-</Table.Cell>
+        <Table.Cell>Markerer input som påkrevd til skjemavalidering. Gir `required` styling.</Table.Cell>
+      </Table.Row>
+    </Table.Body>
   </Table>
-</TableWrapper>
+</Table.Wrapper>
 <br />
 Full liste over props er tilgjengelig i <Link href='https://react-select.com/props' external >react-select API</Link>.
 

--- a/components/src/components/Table/Body.tsx
+++ b/components/src/components/Table/Body.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 
 const StyledBody = styled.tbody``;
 
-export type BodyProps = HTMLAttributes<HTMLTableSectionElement>;
+export type TableBodyProps = HTMLAttributes<HTMLTableSectionElement>;
 
-export const Body = forwardRef<HTMLTableSectionElement, BodyProps>(
+export const Body = forwardRef<HTMLTableSectionElement, TableBodyProps>(
   ({ children, ...rest }, ref) => {
     const bodyProps = {
       ...rest,

--- a/components/src/components/Table/Foot.tsx
+++ b/components/src/components/Table/Foot.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 
 const StyledFoot = styled.tfoot``;
 
-export type FootProps = HTMLAttributes<HTMLTableSectionElement>;
+export type TableFootProps = HTMLAttributes<HTMLTableSectionElement>;
 
-export const Foot = forwardRef<HTMLTableSectionElement, FootProps>(
+export const Foot = forwardRef<HTMLTableSectionElement, TableFootProps>(
   ({ children, ...rest }, ref) => {
     const footProps = {
       ...rest,

--- a/components/src/components/Table/Head.tsx
+++ b/components/src/components/Table/Head.tsx
@@ -3,9 +3,9 @@ import styled from 'styled-components';
 
 const StyledHead = styled.thead``;
 
-export type HeadProps = HTMLAttributes<HTMLTableSectionElement>;
+export type TableHeadProps = HTMLAttributes<HTMLTableSectionElement>;
 
-export const Head = forwardRef<HTMLTableSectionElement, HeadProps>(
+export const Head = forwardRef<HTMLTableSectionElement, TableHeadProps>(
   ({ children, ...rest }, ref) => {
     const headProps = {
       ...rest,

--- a/components/src/components/Table/SortCell.spec.tsx
+++ b/components/src/components/Table/SortCell.spec.tsx
@@ -1,16 +1,16 @@
 import { fireEvent, render } from '@testing-library/react';
-import { Table, Row, Head, SortCell } from '.';
+import { Table } from '.';
 
 describe('<SortCell />', () => {
   it('should run onclick event', () => {
     const event = jest.fn();
     const { container } = render(
       <Table>
-        <Head>
-          <Row>
-            <SortCell onClick={event}></SortCell>
-          </Row>
-        </Head>
+        <Table.Head>
+          <Table.Row>
+            <Table.SortCell onClick={event}></Table.SortCell>
+          </Table.Row>
+        </Table.Head>
       </Table>
     );
     const sortButton = container.querySelector('th')?.querySelector('button');
@@ -21,15 +21,15 @@ describe('<SortCell />', () => {
   it('should have aria-sort', () => {
     const { container } = render(
       <Table>
-        <Head>
-          <Row>
-            <SortCell
+        <Table.Head>
+          <Table.Row>
+            <Table.SortCell
               isSorted={true}
               sortOrder="ascending"
               onClick={() => {}}
-            ></SortCell>
-          </Row>
-        </Head>
+            ></Table.SortCell>
+          </Table.Row>
+        </Table.Head>
       </Table>
     );
     const sortCell = container.querySelector('th');

--- a/components/src/components/Table/SortCell.tsx
+++ b/components/src/components/Table/SortCell.tsx
@@ -25,7 +25,7 @@ const StyledButton = styled.button`
 
 export type SortOrder = 'ascending' | 'descending';
 
-export type SortCellProps = {
+export type TableSortCellProps = {
   /**Spesifiserer om kolonnen er sortert. */
   isSorted?: boolean;
   /**Sorteringsrekkefølge i kolonnen. Avgjør hvilket ikon skal vises i cellen. */
@@ -46,7 +46,7 @@ const makeSortIcon = (isSorted?: boolean, sortOrder?: SortOrder) => {
   );
 };
 
-export const SortCell = forwardRef<HTMLTableCellElement, SortCellProps>(
+export const SortCell = forwardRef<HTMLTableCellElement, TableSortCellProps>(
   ({ isSorted, sortOrder, onClick, children, ...rest }, ref) => (
     <Cell
       ref={ref}

--- a/components/src/components/Table/Table.spec.tsx
+++ b/components/src/components/Table/Table.spec.tsx
@@ -1,15 +1,15 @@
 import { render, screen } from '@testing-library/react';
-import { Table, Cell, Row, Body, Head } from '.';
+import { Table } from '.';
 
 describe('<Table />', () => {
   it('renders a table', () => {
     render(
       <Table>
-        <Body>
-          <Row>
-            <Cell>Body</Cell>
-          </Row>
-        </Body>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>Body</Table.Cell>
+          </Table.Row>
+        </Table.Body>
       </Table>
     );
     const table = screen.getByRole('table');
@@ -20,16 +20,16 @@ describe('<Table />', () => {
     const bodyText = 'body';
     render(
       <Table>
-        <Head>
-          <Row type="head">
-            <Cell type="head">{headerText}</Cell>
-          </Row>
-        </Head>
-        <Body>
-          <Row>
-            <Cell>{bodyText}</Cell>
-          </Row>
-        </Body>
+        <Table.Head>
+          <Table.Row type="head">
+            <Table.Cell type="head">{headerText}</Table.Cell>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>{bodyText}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
       </Table>
     );
     const headerTextNode = screen.getByText(headerText);
@@ -41,11 +41,11 @@ describe('<Table />', () => {
     const headerText = 'header';
     render(
       <Table>
-        <Head>
-          <Row type="head">
-            <Cell type="head">{headerText}</Cell>
-          </Row>
-        </Head>
+        <Table.Head>
+          <Table.Row type="head">
+            <Table.Cell type="head">{headerText}</Table.Cell>
+          </Table.Row>
+        </Table.Head>
       </Table>
     );
     const headerTextNode = screen.getByRole('columnheader');
@@ -55,11 +55,11 @@ describe('<Table />', () => {
     const bodyText = 'body';
     render(
       <Table>
-        <Body>
-          <Row>
-            <Cell>{bodyText}</Cell>
-          </Row>
-        </Body>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>{bodyText}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
       </Table>
     );
     const bodyTextNode = screen.getByRole('cell');

--- a/components/src/components/Table/Table.stories.mdx
+++ b/components/src/components/Table/Table.stories.mdx
@@ -5,7 +5,7 @@ import {
   ArgsTable,
   PRIMARY_STORY,
 } from '@storybook/addon-docs';
-import { Table, Row, Cell, SortCell } from '.';
+import { Table } from '.';
 import {
   Source,
   ComponentLinkRow,
@@ -35,42 +35,42 @@ import {
 
 Tabeller bygges ved å bruke styled versjoner av native HTML elementer. Disse komponentene er:
 
-- `<TableWrapper />` - wrapper for tabell.
+- `<Table.Wrapper />` - wrapper for tabell.
 - `<Table />` - selve tabellen.
-- Subkomponenter: `<Head />`, `<Body />`, `<Foot />`, `<Row />`, `<Cell />`, `<SortCell />`.
+- Subkomponenter: `<Table.Head />`, `<Table.Body />`, `<Table.Foot />`, `<Table.Row />`, `<Table.Cell />`, `<Table.SortCell />`.
 
-Enkelte subkomponenter har props for å sørge for riktig styling og oppførsel, mens andre har kun native props, som forklart under.
+Enkelte subkomponenter har props for å sørge for riktig styling og oppførsel, mens andre har kun native props, som forklart i API.
 
 ## Bruk i koden
 
 <Source
-  code={`import { Table, TableWrapper, Head, Body, Row, Cell } from '@norges-domstoler/dds-components';
+  code={`import { Table } from '@norges-domstoler/dds-components';
 
-<TableWrapper>
+<Table.Wrapper>
   <Table>
-    <Head>
-      <Row type="head">
-        <Cell type="head">Navn</Cell>
-        <Cell type="head">Rolle</Cell>
-      </Row>
-    </Head>
-    <Body>
-      <Row>
-        <Cell>Sandra Lovsetter</Cell>
-        <Cell>Admin</Cell>
-      </Row>
-      <Row>
-        <Cell>Marie Bjerke</Cell>
-        <Cell>Admin</Cell>
-      </Row>
-    </Body>
+    <Table.Head>
+      <Table.Row type="head">
+        <Table.Cell type="head">Navn</Table.Cell>
+        <Table.Cell type="head">Rolle</Table.Cell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
+      <Table.Row>
+        <Table.Cell>Sandra Lovsetter</Table.Cell>
+        <Table.Cell>Admin</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>Marie Bjerke</Table.Cell>
+        <Table.Cell>Admin</Table.Cell>
+      </Table.Row>
+    </Table.Body>
   </Table>
-</TableWrapper>
+</Table.Wrapper>
 `} />
 
 ## API
 
-### TableWrapper
+### Table.Wrapper
 
 En wrapper som sørger for at tabellen får scrolling når den ikke får plass i bredden.
 
@@ -83,42 +83,48 @@ Tilsvarer `<table>`.
 <ArgsTable story={PRIMARY_STORY} />
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLTableElement>`-interface.
 
-### Body
+### Table.Body
 
 Tilsvarer `<tbody>`.
 
 Støtter alle native HTML-attributter som er en del av `HTMLAttributes<HTMLTableSectionElement>`-interface.
 
-### Head
+### Table.Head
 
 Tilsvarer `<thead>`.
 
 Støtter alle native HTML-attributter som er en del av `HTMLAttributes<HTMLTableSectionElement>`-interface.
 
-### Foot
+### Table.Foot
 
 Tilsvarer `<tfoot>`.
 
 Støtter alle native HTML-attributter som er en del av `HTMLAttributes<HTMLTableSectionElement>`-interface.
 
-### Row
+### Table.Row
 
 Tilsvarer `<tr>`.
 
-<ArgsTable of={Row} />
+<ArgsTable of={Table.Row} />
 
 Støtter alle native HTML-attributter som er en del av `HTMLAttributes<HTMLTableSectionElement>`-interface.
 
-### Cell
+### Table.Cell
 
-<ArgsTable of={Cell} />
+Tilsvarer `<th>` eller `<td>`.
+
+<ArgsTable of={Table.Cell} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLTableDataCellElement>` og `HTMLAttributes<HTMLTableHeaderCellElement>`-interface.
 
-### SortCell
+### Table.SortCell
 
-Et styled `<Cell type='head'>`-element som brukes som head-celle i sorteringskolonner. **OBS!** komponenten stiller kun med styling og ikoner, sortering implementeres i de respektive løsningene.
+Et styled `<Cell type='head'>`-element som brukes som `<th>` i sorteringskolonner. **OBS!** komponenten stiller kun med styling og ikoner, sortering implementeres i de respektive løsningene.
 
-<ArgsTable of={SortCell} />
+<ArgsTable of={Table.SortCell} />
 
 I tillegg støttes `<Cell>`-props, bortsett fra `type` da den er satt til `'head'`.
+
+## Retningslinjer
+
+- Bruk `<Table.Foot>` som footer i tabellen ved summering av verdier i en kolonne eller lignende.

--- a/components/src/components/Table/Table.stories.tsx
+++ b/components/src/components/Table/Table.stories.tsx
@@ -1,16 +1,5 @@
 import { useEffect, useState, ChangeEvent } from 'react';
-import {
-  Table,
-  TableProps,
-  Row,
-  Cell,
-  SortCell,
-  SortOrder,
-  Body,
-  Head,
-  Foot,
-  TableWrapper,
-} from '.';
+import { Table, TableProps, SortOrder } from '.';
 import { Button } from '../Button';
 import { Checkbox } from '../Checkbox';
 import {
@@ -43,31 +32,33 @@ export default {
 
 const mappedHeaderCells = headerCells.map(headerCell => {
   return (
-    <Cell key={`head-${headerCell.dataName}`} type="head">
+    <Table.Cell key={`head-${headerCell.dataName}`} type="head">
       {headerCell.name}
-    </Cell>
+    </Table.Cell>
   );
 });
 
 export const Default = (args: TableProps) => {
   return (
     <StoryTemplate title="Table - default">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table {...args}>
-          <Head>
-            <Row type="head">{mappedHeaderCells}</Row>
-          </Head>
-          <Body>
+          <Table.Head>
+            <Table.Row type="head">{mappedHeaderCells}</Table.Row>
+          </Table.Head>
+          <Table.Body>
             {mapCellContents(data, headerCells).map(row => (
-              <Row key={row.toString()}>
+              <Table.Row key={row.toString()}>
                 {row.map(cellContent => (
-                  <Cell key={`body-${cellContent}`}>{cellContent}</Cell>
+                  <Table.Cell key={`body-${cellContent}`}>
+                    {cellContent}
+                  </Table.Cell>
                 ))}
-              </Row>
+              </Table.Row>
             ))}
-          </Body>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };
@@ -75,22 +66,24 @@ export const Default = (args: TableProps) => {
 export const withDividers = (args: TableProps) => {
   return (
     <StoryTemplate title="Table - with dividers">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table {...args} withDividers>
-          <Head>
-            <Row type="head">{mappedHeaderCells}</Row>
-          </Head>
-          <Body>
+          <Table.Head>
+            <Table.Row type="head">{mappedHeaderCells}</Table.Row>
+          </Table.Head>
+          <Table.Body>
             {mapCellContents(data, headerCells).map(row => (
-              <Row key={row.toString()}>
+              <Table.Row key={row.toString()}>
                 {row.map(cellContent => (
-                  <Cell key={`body-${cellContent}`}>{cellContent}</Cell>
+                  <Table.Cell key={`body-${cellContent}`}>
+                    {cellContent}
+                  </Table.Cell>
                 ))}
-              </Row>
+              </Table.Row>
             ))}
-          </Body>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };
@@ -98,14 +91,14 @@ export const withDividers = (args: TableProps) => {
 export const Focusable = (args: TableProps) => {
   return (
     <StoryTemplate title="Table - focusable">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table {...args}>
-          <Head>
-            <Row type="head">{mappedHeaderCells}</Row>
-          </Head>
-          <Body>
+          <Table.Head>
+            <Table.Row type="head">{mappedHeaderCells}</Table.Row>
+          </Table.Head>
+          <Table.Body>
             {mapCellContents(data, headerCells).map(row => (
-              <Row
+              <Table.Row
                 key={row.toString()}
                 tabIndex={0}
                 onClick={() => {
@@ -113,13 +106,15 @@ export const Focusable = (args: TableProps) => {
                 }}
               >
                 {row.map(cellContent => (
-                  <Cell key={`body-${cellContent}`}>{cellContent}</Cell>
+                  <Table.Cell key={`body-${cellContent}`}>
+                    {cellContent}
+                  </Table.Cell>
                 ))}
-              </Row>
+              </Table.Row>
             ))}
-          </Body>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };
@@ -127,22 +122,24 @@ export const Focusable = (args: TableProps) => {
 export const Compact = (args: TableProps) => {
   return (
     <StoryTemplate title="Table - compact">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table {...args} density="compact">
-          <Head>
-            <Row type="head">{mappedHeaderCells}</Row>
-          </Head>
-          <Body>
+          <Table.Head>
+            <Table.Row type="head">{mappedHeaderCells}</Table.Row>
+          </Table.Head>
+          <Table.Body>
             {mapCellContents(data, headerCells).map(row => (
-              <Row key={row.toString()}>
+              <Table.Row key={row.toString()}>
                 {row.map(cellContent => (
-                  <Cell key={`body-${cellContent}`}>{cellContent}</Cell>
+                  <Table.Cell key={`body-${cellContent}`}>
+                    {cellContent}
+                  </Table.Cell>
                 ))}
-              </Row>
+              </Table.Row>
             ))}
-          </Body>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };
@@ -150,29 +147,33 @@ export const Compact = (args: TableProps) => {
 export const StickyHeader = (args: TableProps) => {
   return (
     <StoryTemplate title="Table - sticky header">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table {...args} stickyHeader>
-          <Head>
-            <Row type="head">{mappedHeaderCells}</Row>
-          </Head>
-          <Body>
+          <Table.Head>
+            <Table.Row type="head">{mappedHeaderCells}</Table.Row>
+          </Table.Head>
+          <Table.Body>
             {mapCellContents(data, headerCells).map(row => (
-              <Row key={row.toString()}>
+              <Table.Row key={row.toString()}>
                 {row.map(cellContent => (
-                  <Cell key={`body-${cellContent}`}>{cellContent}</Cell>
+                  <Table.Cell key={`body-${cellContent}`}>
+                    {cellContent}
+                  </Table.Cell>
                 ))}
-              </Row>
+              </Table.Row>
             ))}
             {mapCellContents(data, headerCells).map(row => (
-              <Row key={row.toString()}>
+              <Table.Row key={row.toString()}>
                 {row.map(cellContent => (
-                  <Cell key={`body-${cellContent}`}>{cellContent}</Cell>
+                  <Table.Cell key={`body-${cellContent}`}>
+                    {cellContent}
+                  </Table.Cell>
                 ))}
-              </Row>
+              </Table.Row>
             ))}
-          </Body>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };
@@ -180,22 +181,24 @@ export const StickyHeader = (args: TableProps) => {
 export const Hoverable = (args: TableProps) => {
   return (
     <StoryTemplate title="Table - hoverable">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table {...args}>
-          <Head>
-            <Row type="head">{mappedHeaderCells}</Row>
-          </Head>
-          <Body>
+          <Table.Head>
+            <Table.Row type="head">{mappedHeaderCells}</Table.Row>
+          </Table.Head>
+          <Table.Body>
             {mapCellContents(data, headerCells).map(row => (
-              <Row key={row.toString()} hoverable>
+              <Table.Row key={row.toString()} hoverable>
                 {row.map(cellContent => (
-                  <Cell key={`body-${cellContent}`}>{cellContent}</Cell>
+                  <Table.Cell key={`body-${cellContent}`}>
+                    {cellContent}
+                  </Table.Cell>
                 ))}
-              </Row>
+              </Table.Row>
             ))}
-          </Body>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };
@@ -212,32 +215,32 @@ export const WithButtonAndIcons = (args: TableProps) => {
   );
   return (
     <StoryTemplate title="Table - with buttons and icons">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table {...args}>
-          <Head>
-            <Row type="head">
-              <Cell type="head">Navn</Cell>
-              <Cell type="head">Navn</Cell>
-              <Cell type="head">Rolle</Cell>
-              <Cell type="head"></Cell>
-            </Row>
-          </Head>
-          <Body>
+          <Table.Head>
+            <Table.Row type="head">
+              <Table.Cell type="head">Navn</Table.Cell>
+              <Table.Cell type="head">Navn</Table.Cell>
+              <Table.Cell type="head">Rolle</Table.Cell>
+              <Table.Cell type="head"></Table.Cell>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
             {data.map(item => (
-              <Row key={item.name}>
-                <Cell layout="text and icon">
+              <Table.Row key={item.name}>
+                <Table.Cell layout="text and icon">
                   {adminIcon} {item.name}
-                </Cell>
-                <Cell layout="text and icon">
+                </Table.Cell>
+                <Table.Cell layout="text and icon">
                   {item.name} {adminIcon}
-                </Cell>
-                <Cell>Admin</Cell>
-                <Cell layout="center">{deleteButton}</Cell>
-              </Row>
+                </Table.Cell>
+                <Table.Cell>Admin</Table.Cell>
+                <Table.Cell layout="center">{deleteButton}</Table.Cell>
+              </Table.Row>
             ))}
-          </Body>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };
@@ -263,34 +266,34 @@ export const WithSum = (args: TableProps) => {
   ];
   return (
     <StoryTemplate title="Table - sum">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table {...args}>
-          <Head>
-            <Row type="head">
-              <Cell type="head">Saksnummer</Cell>
-              <Cell type="head" layout="right">
+          <Table.Head>
+            <Table.Row type="head">
+              <Table.Cell type="head">Saksnummer</Table.Cell>
+              <Table.Cell type="head" layout="right">
                 Antall dokumenter
-              </Cell>
-            </Row>
-          </Head>
-          <Body>
+              </Table.Cell>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
             {sumData.map(item => (
-              <Row key={item.id}>
-                <Cell>{item.id}</Cell>
-                <Cell layout="right">{item.amount}</Cell>
-              </Row>
+              <Table.Row key={item.id}>
+                <Table.Cell>{item.id}</Table.Cell>
+                <Table.Cell layout="right">{item.amount}</Table.Cell>
+              </Table.Row>
             ))}
-          </Body>
-          <Foot>
-            <Row mode="sum">
-              <Cell>Totalt</Cell>
-              <Cell layout="right">
+          </Table.Body>
+          <Table.Foot>
+            <Table.Row mode="sum">
+              <Table.Cell>Totalt</Table.Cell>
+              <Table.Cell layout="right">
                 {sumData.reduce((a, b) => a + (b.amount || 0), 0)}
-              </Cell>
-            </Row>
-          </Foot>
+              </Table.Cell>
+            </Table.Row>
+          </Table.Foot>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };
@@ -362,11 +365,11 @@ export const WithCheckbox = (args: TableProps) => {
   }
   return (
     <StoryTemplate title="Table - with checkboxes">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table {...args}>
-          <Head>
-            <Row type="head">
-              <Cell type="head">
+          <Table.Head>
+            <Table.Row type="head">
+              <Table.Cell type="head">
                 <Checkbox
                   indeterminate={
                     selectedRows?.length > 0 &&
@@ -378,11 +381,11 @@ export const WithCheckbox = (args: TableProps) => {
                   onChange={e => changeAll(e)}
                   // onClick={(e) => handleCheckboxClick(e)}
                 />
-              </Cell>
+              </Table.Cell>
               {mappedHeaderCells}
-            </Row>
-          </Head>
-          <Body>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
             {rows.map(row => {
               const isSelected = selectedRows.find(
                 selectedRow => row.id === selectedRow.id
@@ -390,13 +393,13 @@ export const WithCheckbox = (args: TableProps) => {
                 ? true
                 : false;
               return (
-                <Row
+                <Table.Row
                   key={`row-${row.id}`}
                   hoverable
                   selected={isSelected}
                   // onClick={() => handleClick(row)}
                 >
-                  <Cell>
+                  <Table.Cell>
                     <Checkbox
                       id={row.id}
                       name={row.name}
@@ -404,18 +407,18 @@ export const WithCheckbox = (args: TableProps) => {
                       onChange={e => handleChange(e, row)}
                       // onClick={(e) => handleCheckboxClick(e)}
                     />
-                  </Cell>
-                  <Cell>{row.name}</Cell>
-                  <Cell>{row.fnumber}</Cell>
-                  <Cell>{row.employer}</Cell>
-                  <Cell>{row.orgnumber}</Cell>
-                  <Cell>{row.percentage}</Cell>
-                </Row>
+                  </Table.Cell>
+                  <Table.Cell>{row.name}</Table.Cell>
+                  <Table.Cell>{row.fnumber}</Table.Cell>
+                  <Table.Cell>{row.employer}</Table.Cell>
+                  <Table.Cell>{row.orgnumber}</Table.Cell>
+                  <Table.Cell>{row.percentage}</Table.Cell>
+                </Table.Row>
               );
             })}
-          </Body>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };
@@ -423,76 +426,76 @@ export const WithCheckbox = (args: TableProps) => {
 export const Complex = (args: TableProps) => {
   return (
     <StoryTemplate title="Table - complex">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table {...args} stickyHeader>
           <colgroup>
             <col />
           </colgroup>
           <colgroup span={2}></colgroup>
           <colgroup span={2}></colgroup>
-          <Body>
-            <Row type="head">
-              <Cell rowSpan={2}></Cell>
-              <Cell type="head" colSpan={2} scope="colgroup">
+          <Table.Body>
+            <Table.Row type="head">
+              <Table.Cell rowSpan={2}></Table.Cell>
+              <Table.Cell type="head" colSpan={2} scope="colgroup">
                 Mars
-              </Cell>
-              <Cell type="head" colSpan={2} scope="colgroup">
+              </Table.Cell>
+              <Table.Cell type="head" colSpan={2} scope="colgroup">
                 Venus
-              </Cell>
-            </Row>
-            <Row type="head">
-              <Cell type="head" scope="col">
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row type="head">
+              <Table.Cell type="head" scope="col">
                 Produced
-              </Cell>
-              <Cell type="head" scope="col">
+              </Table.Cell>
+              <Table.Cell type="head" scope="col">
                 Sold
-              </Cell>
-              <Cell type="head" scope="col">
+              </Table.Cell>
+              <Table.Cell type="head" scope="col">
                 Produced
-              </Cell>
-              <Cell type="head" scope="col">
+              </Table.Cell>
+              <Table.Cell type="head" scope="col">
                 Sold
-              </Cell>
-            </Row>
-            <Row>
-              <Cell type="head" scope="row">
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell type="head" scope="row">
                 Teddy Bears
-              </Cell>
-              <Cell>50,000</Cell>
-              <Cell>30,000</Cell>
-              <Cell>100,000</Cell>
-              <Cell>80,000</Cell>
-            </Row>
-            <Row>
-              <Cell type="head" scope="row">
+              </Table.Cell>
+              <Table.Cell>50,000</Table.Cell>
+              <Table.Cell>30,000</Table.Cell>
+              <Table.Cell>100,000</Table.Cell>
+              <Table.Cell>80,000</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell type="head" scope="row">
                 Board Games
-              </Cell>
-              <Cell>10,000</Cell>
-              <Cell>5,000</Cell>
-              <Cell>12,000</Cell>
-              <Cell>9,000</Cell>
-            </Row>
-            <Row>
-              <Cell type="head" scope="row">
+              </Table.Cell>
+              <Table.Cell>10,000</Table.Cell>
+              <Table.Cell>5,000</Table.Cell>
+              <Table.Cell>12,000</Table.Cell>
+              <Table.Cell>9,000</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell type="head" scope="row">
                 Dolls
-              </Cell>
-              <Cell>50,000</Cell>
-              <Cell>30,000</Cell>
-              <Cell>100,000</Cell>
-              <Cell>80,000</Cell>
-            </Row>
-            <Row>
-              <Cell type="head" scope="row">
+              </Table.Cell>
+              <Table.Cell>50,000</Table.Cell>
+              <Table.Cell>30,000</Table.Cell>
+              <Table.Cell>100,000</Table.Cell>
+              <Table.Cell>80,000</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell type="head" scope="row">
                 Action Figures
-              </Cell>
-              <Cell>10,000</Cell>
-              <Cell>5,000</Cell>
-              <Cell>12,000</Cell>
-              <Cell>9,000</Cell>
-            </Row>
-          </Body>
+              </Table.Cell>
+              <Table.Cell>10,000</Table.Cell>
+              <Table.Cell>5,000</Table.Cell>
+              <Table.Cell>12,000</Table.Cell>
+              <Table.Cell>9,000</Table.Cell>
+            </Table.Row>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };
@@ -548,20 +551,20 @@ export const Sortable = (args: TableProps) => {
 
   return (
     <StoryTemplate title="Table - sortable">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table {...args}>
-          <Head>
-            <Row type="head">
+          <Table.Head>
+            <Table.Row type="head">
               {headerSortCells.map(headerCell => {
                 if (!headerCell.sortOrder) {
                   return (
-                    <Cell type="head" key={`head-${headerCell.dataName}`}>
+                    <Table.Cell type="head" key={`head-${headerCell.dataName}`}>
                       {headerCell.name}
-                    </Cell>
+                    </Table.Cell>
                   );
                 }
                 return (
-                  <SortCell
+                  <Table.SortCell
                     key={`head-${headerCell.dataName}`}
                     onClick={() => onClickSort(headerCell)}
                     isSorted={headerCell.isSorted}
@@ -572,22 +575,24 @@ export const Sortable = (args: TableProps) => {
                     }
                   >
                     {headerCell.name}
-                  </SortCell>
+                  </Table.SortCell>
                 );
               })}
-            </Row>
-          </Head>
-          <Body>
+            </Table.Row>
+          </Table.Head>
+          <Table.Body>
             {dataCellContents?.map(row => (
-              <Row key={row.toString()}>
+              <Table.Row key={row.toString()}>
                 {row.map(cellContent => (
-                  <Cell key={`body-${cellContent}`}>{cellContent}</Cell>
+                  <Table.Cell key={`body-${cellContent}`}>
+                    {cellContent}
+                  </Table.Cell>
                 ))}
-              </Row>
+              </Table.Row>
             ))}
-          </Body>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };
@@ -595,36 +600,36 @@ export const Sortable = (args: TableProps) => {
 export const ColumnAndRowHeaders = (args: TableProps) => {
   return (
     <StoryTemplate title="Table - column and row headers">
-      <TableWrapper>
+      <Table.Wrapper>
         <Table {...args}>
-          <Body>
-            <Row>
-              <Cell></Cell>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell></Table.Cell>
               {headerCells.map(headerCell => (
-                <Cell
+                <Table.Cell
                   key={`head-${headerCell.dataName}`}
                   type="head"
                   scope="col"
                 >
                   {headerCell.name}
-                </Cell>
+                </Table.Cell>
               ))}
-            </Row>
+            </Table.Row>
             {data.map(item => (
-              <Row key={item.name}>
-                <Cell type="head" scope="row">
+              <Table.Row key={item.name}>
+                <Table.Cell type="head" scope="row">
                   Header
-                </Cell>
-                <Cell> {item.name} </Cell>
-                <Cell> {item.fnumber} </Cell>
-                <Cell> {item.employer} </Cell>
-                <Cell> {item.orgnumber} </Cell>
-                <Cell> {item.percentage} </Cell>
-              </Row>
+                </Table.Cell>
+                <Table.Cell> {item.name} </Table.Cell>
+                <Table.Cell> {item.fnumber} </Table.Cell>
+                <Table.Cell> {item.employer} </Table.Cell>
+                <Table.Cell> {item.orgnumber} </Table.Cell>
+                <Table.Cell> {item.percentage} </Table.Cell>
+              </Table.Row>
             ))}
-          </Body>
+          </Table.Body>
         </Table>
-      </TableWrapper>
+      </Table.Wrapper>
     </StoryTemplate>
   );
 };

--- a/components/src/components/Table/index.ts
+++ b/components/src/components/Table/index.ts
@@ -1,8 +1,45 @@
-export * from './Table';
-export * from './Body';
-export * from './Head';
-export * from './Row';
-export * from './Cell';
-export * from './SortCell';
-export * from './Foot';
-export * from './TableWrapper';
+import { Table as BaseTable, TableProps, TableDensity } from './Table';
+import { Head, TableHeadProps } from './Head';
+import { Body, TableBodyProps } from './Body';
+import { Foot, TableFootProps } from './Foot';
+import { Row, TableRowProps, TableRowType } from './Row';
+import { Cell, TableCellProps, TableCellLayout, TableCellType } from './Cell';
+import { SortCell, TableSortCellProps, SortOrder } from './SortCell';
+import { TableWrapper } from './TableWrapper';
+
+type TableCompoundProps = typeof BaseTable & {
+  Wrapper: typeof TableWrapper;
+  Head: typeof Head;
+  Body: typeof Body;
+  Foot: typeof Foot;
+  Row: typeof Row;
+  Cell: typeof Cell;
+  SortCell: typeof SortCell;
+};
+
+const Table = BaseTable as TableCompoundProps;
+
+Table.Wrapper = TableWrapper;
+Table.Head = Head;
+Table.Body = Body;
+Table.Cell = Cell;
+Table.SortCell = SortCell;
+Table.Row = Row;
+Table.Foot = Foot;
+
+export { Table };
+
+export type {
+  TableCellProps,
+  TableDensity,
+  TableProps,
+  TableRowProps,
+  TableRowType,
+  TableHeadProps,
+  TableBodyProps,
+  TableFootProps,
+  TableSortCellProps,
+  SortOrder,
+  TableCellLayout,
+  TableCellType,
+};

--- a/components/src/components/Tooltip/Tooltip.stories.mdx
+++ b/components/src/components/Tooltip/Tooltip.stories.mdx
@@ -12,7 +12,7 @@ import {
   SB_DESIGNSYSTEM_URL,
   LinkToInteractiveStory,
 } from '../../storybook';
-import { TableWrapper, Table, Body, Cell, Head, Row } from '../Table';
+import { Table } from '../Table';
 
 <Meta title="Design system/Tooltip/API" component={Tooltip} />
 
@@ -59,39 +59,39 @@ I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes
 
 Det brukes ulike events til å lukke eller åpne tooltip. For å bruke callback på event som styrer tooltip må den sendes som prop til riktig element. Se oversikt over hvilket element bruker hvilken event:
 
-<TableWrapper>
+<Table.Wrapper>
   <Table density="compact" style={{ width: '100%' }}>
-    <Head>
-      <Row type="head">
-        <Cell type="head">Event</Cell>
-        <Cell type="head">`Tooltip`</Cell>
-        <Cell type="head">Anchor-element</Cell>
-      </Row>
-    </Head>
-    <Body>
-      <Row>
-        <Cell> `onMouseOver` </Cell>
-        <Cell> ✅ </Cell>
-        <Cell> </Cell>
-      </Row>
-      <Row>
-        <Cell> `onMouseLeave`</Cell>
-        <Cell> ✅ </Cell>
-        <Cell> </Cell>
-      </Row>
-      <Row>
-        <Cell> `onFocus` </Cell>
-        <Cell> </Cell>
-        <Cell> ✅ </Cell>
-      </Row>
-      <Row>
-        <Cell> `onBlur` </Cell>
-        <Cell> </Cell>
-        <Cell> ✅ </Cell>
-      </Row>
-    </Body>
+    <Table.Head>
+      <Table.Row type="head">
+        <Table.Cell type="head">Event</Table.Cell>
+        <Table.Cell type="head">`Tooltip`</Table.Cell>
+        <Table.Cell type="head">Anchor-element</Table.Cell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
+      <Table.Row>
+        <Table.Cell> `onMouseOver` </Table.Cell>
+        <Table.Cell> ✅ </Table.Cell>
+        <Table.Cell> </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `onMouseLeave`</Table.Cell>
+        <Table.Cell> ✅ </Table.Cell>
+        <Table.Cell> </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `onFocus` </Table.Cell>
+        <Table.Cell> </Table.Cell>
+        <Table.Cell> ✅ </Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell> `onBlur` </Table.Cell>
+        <Table.Cell> </Table.Cell>
+        <Table.Cell> ✅ </Table.Cell>
+      </Table.Row>
+    </Table.Body>
   </Table>
-</TableWrapper>
+</Table.Wrapper>
 
 #### Eksempel
 

--- a/components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -2,7 +2,7 @@ import { VisuallyHidden, VisuallyHiddenProps } from '.';
 import { StoryTemplate } from '../../storybook';
 import { Typography } from '../Typography';
 import { SB_DESIGNSYSTEM_PREFIX } from '../../storybook';
-import { Table, Cell, Row, Head, Body } from '../Table';
+import { Table } from '../Table';
 import { Button } from '../Button';
 
 export default {
@@ -38,32 +38,34 @@ export const Link = () => (
 
 export const TableButtons = () => (
   <StoryTemplate title="VisuallyHidden - table example">
-    <Table density="compact">
-      <Head>
-        <Row type="head">
-          <Cell type="head">Navn</Cell>
-          <Cell type="head">Rolle</Cell>
-          <Cell type="head">
-            <VisuallyHidden as="span">Aksjoner</VisuallyHidden>
-          </Cell>
-        </Row>
-      </Head>
-      <Body>
-        <Row type="body">
-          <Cell>Ane Bjerke</Cell>
-          <Cell>Administrator</Cell>
-          <Cell>
-            <Button label="Slett" size="small" purpose="danger" />
-          </Cell>
-        </Row>
-        <Row type="body">
-          <Cell>Sandra Lovsetter</Cell>
-          <Cell>Bruker</Cell>
-          <Cell>
-            <Button label="Slett" size="small" purpose="danger" />
-          </Cell>
-        </Row>
-      </Body>
-    </Table>
+    <Table.Wrapper>
+      <Table density="compact">
+        <Table.Head>
+          <Table.Row type="head">
+            <Table.Cell type="head">Navn</Table.Cell>
+            <Table.Cell type="head">Rolle</Table.Cell>
+            <Table.Cell type="head">
+              <VisuallyHidden as="span">Aksjoner</VisuallyHidden>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          <Table.Row type="body">
+            <Table.Cell>Ane Bjerke</Table.Cell>
+            <Table.Cell>Administrator</Table.Cell>
+            <Table.Cell>
+              <Button label="Slett" size="small" purpose="danger" />
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row type="body">
+            <Table.Cell>Sandra Lovsetter</Table.Cell>
+            <Table.Cell>Bruker</Table.Cell>
+            <Table.Cell>
+              <Button label="Slett" size="small" purpose="danger" />
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </Table.Wrapper>
   </StoryTemplate>
 );


### PR DESCRIPTION
Hittil hadde vi komponenter som `<Body>`, `<Row>` osv. for native HTML elementer relaterte til tabell. Disse navnene er ikke beskrivende (`<Row>` kan tolkes som rad i layout osv.). Det er også unødvendig å importere disse komponentene uavhengig av `<Table>`. Derfor gjøres de om til subkomponenter i `<Table>`.

Breaking:
- Endring i importering av konsumenter. Det importeres bare `{ Table }` som inkluderer alle subkomponentene.
- Endring i bruk. For eksempel `<Table.Row>` istedenfor `<Row>`.
- Nye navn for props typer. Alle props typer har nå `Table` som prefiks. For eksempel `TableBodyProps` istedenfor `BodyProps`.

Relatert opprydding:
- Fikser alle stories som bruker tabeller.
- Oppdaterer `<Table>` API og retningslinjer.