### PR TITLE
Konsekvent bruk av `onChange` i komponenter med navigasjon.

### DIFF
--- a/components/src/components/ProgressTracker/ProgressTracker.context.tsx
+++ b/components/src/components/ProgressTracker/ProgressTracker.context.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext } from 'react';
 
 type ProgressTrackerContextType = {
   activeStep: number;
+  handleStepChange?: (index: number) => void;
 };
 
 export const ProgressTrackerContext = createContext<ProgressTrackerContextType>(

--- a/components/src/components/ProgressTracker/ProgressTracker.stories.tsx
+++ b/components/src/components/ProgressTracker/ProgressTracker.stories.tsx
@@ -20,39 +20,24 @@ export const Overview = () => {
   const [activeStep, setActiveStep] = useState(0);
   const [completedSteps, setCompletedSteps] = useState(new Set());
 
-  const handleStepClick = (index: number) => {
-    setActiveStep(index);
-  };
-
   return (
     <StoryTemplate title="ProgressTracker - overview" display="block">
       <ProgressTracker
         activeStep={activeStep}
+        onStepChange={step => setActiveStep(step)}
+        clickable
         htmlProps={{ style: { maxWidth: '800px' } }}
       >
-        <ProgressTracker.Item
-          completed={completedSteps.has(0)}
-          onClick={handleStepClick}
-        >
+        <ProgressTracker.Item completed={completedSteps.has(0)}>
           Partopplysninger
         </ProgressTracker.Item>
-        <ProgressTracker.Item
-          completed={completedSteps.has(1)}
-          onClick={handleStepClick}
-        >
+        <ProgressTracker.Item completed={completedSteps.has(1)}>
           Slutning
         </ProgressTracker.Item>
-        <ProgressTracker.Item
-          completed={completedSteps.has(2)}
-          onClick={handleStepClick}
-        >
+        <ProgressTracker.Item completed={completedSteps.has(2)}>
           Vedlegg
         </ProgressTracker.Item>
-        <ProgressTracker.Item
-          completed={completedSteps.has(3)}
-          onClick={handleStepClick}
-          disabled
-        >
+        <ProgressTracker.Item completed={completedSteps.has(3)} disabled>
           Sammendrag
         </ProgressTracker.Item>
       </ProgressTracker>
@@ -83,41 +68,35 @@ export const WithIcons = () => {
   const [activeStep, setActiveStep] = useState(0);
   const [completedSteps, setCompletedSteps] = useState(new Set());
 
-  const handleStepClick = (index: number) => {
-    setActiveStep(index);
-  };
-
   return (
     <StoryTemplate title="ProgressTracker - with icons" display="block">
       <ProgressTracker
         activeStep={activeStep}
         htmlProps={{ style: { maxWidth: '800px' } }}
+        clickable
+        onStepChange={step => setActiveStep(step)}
       >
         <ProgressTracker.Item
           icon={PersonIcon}
           completed={completedSteps.has(0)}
-          onClick={handleStepClick}
         >
           Partopplysninger
         </ProgressTracker.Item>
         <ProgressTracker.Item
           icon={AttachmentIcon}
           completed={completedSteps.has(1)}
-          onClick={handleStepClick}
         >
           Vedlegg
         </ProgressTracker.Item>
         <ProgressTracker.Item
           icon={GavelIcon}
           completed={completedSteps.has(2)}
-          onClick={handleStepClick}
         >
           Slutning
         </ProgressTracker.Item>
         <ProgressTracker.Item
           icon={ChecklistIcon}
           completed={completedSteps.has(3)}
-          onClick={handleStepClick}
           disabled
         >
           Sammendrag

--- a/components/src/components/ProgressTracker/ProgressTracker.tsx
+++ b/components/src/components/ProgressTracker/ProgressTracker.tsx
@@ -41,6 +41,10 @@ type ProgressTrackerProps = BaseComponentPropsWithChildren<
   {
     /** Indeksen til det aktive steget. */
     activeStep?: number;
+    /** Ekstra logikk ved klikking på et steg. */
+    onStepChange?: (step: number) => void;
+    /** Om brukeren kan hoppe mellom stegene via museklikk på et steg. */
+    clickable?: boolean;
   }
 >;
 
@@ -54,6 +58,8 @@ export const ProgressTracker: ProgressTrackerComponent = (() => {
     const {
       id,
       activeStep = 0,
+      onStepChange,
+      clickable = false,
       children,
       className,
       htmlProps,
@@ -61,6 +67,11 @@ export const ProgressTracker: ProgressTrackerComponent = (() => {
     } = props;
 
     const [thisActiveStep, setActiveStep] = useState(activeStep);
+
+    const handleChange = (step: number) => {
+      setActiveStep(step);
+      onStepChange && onStepChange(step);
+    };
 
     useEffect(() => {
       if (activeStep !== undefined && activeStep != thisActiveStep) {
@@ -85,6 +96,7 @@ export const ProgressTracker: ProgressTrackerComponent = (() => {
       <ProgressTrackerContext.Provider
         value={{
           activeStep: thisActiveStep,
+          handleStepChange: clickable ? handleChange : undefined,
         }}
       >
         <div role="group" aria-label="progress" {...containerProps}>

--- a/components/src/components/ProgressTracker/ProgressTrackerItem.tsx
+++ b/components/src/components/ProgressTracker/ProgressTrackerItem.tsx
@@ -241,12 +241,12 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
     children,
   } = props;
 
-  const { activeStep } = useProgressTrackerContext();
+  const { activeStep, handleStepChange } = useProgressTrackerContext();
   const active = activeStep === index;
 
   const styleProps = {
     state: toItemState(active, completed, disabled),
-    clickable: props.onClick !== undefined,
+    clickable: handleStepChange !== undefined,
   };
 
   const stepNumberContent = useMemo(() => {
@@ -265,9 +265,11 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
     <ItemWrapper aria-current={active ? 'step' : undefined}>
       <ItemContentWrapper
         {...styleProps}
-        as={props.onClick ? 'button' : 'div'}
+        as={handleStepChange ? 'button' : 'div'}
         onClick={
-          !disabled && props.onClick ? () => props.onClick(index) : undefined
+          !disabled && handleStepChange
+            ? () => handleStepChange(index)
+            : undefined
         }
         disabled={disabled}
       >


### PR DESCRIPTION
Vi har en rekke komponenter som styrer navigasjon/visning av siden. Disse bør implementeres likt med tanke på oppførsel ved endring av aktivt element. I `<Tabs>` og `<ToggleBar>` styres selve endringen av det aktive elementet internt via wrapperen, og konsumenten kan sette en ekstra callback på wrapper. I `<ProgressTracker>` er det hvert barn som får en `onClick` event satt av konsumenten.

Den forestlåtte løsningen er å gjøre om `<ProgressTracker>` slik at den er lik andre kompontenter.