### PR TITLE
Fikser unødvendig gap i Search

### DIFF
--- a/components/src/components/Search/Search.tsx
+++ b/components/src/components/Search/Search.tsx
@@ -80,10 +80,18 @@ const OuterContainer = styled.div`
   gap: ${outerContainer.gap};
 `;
 
-const HorisontalContainer = styled.div`
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: ${horisontalContainer.gap};
+type HorisontalContainerProps = {
+  hasSearchButton: boolean;
+};
+
+const HorisontalContainer = styled.div<HorisontalContainerProps>`
+  ${props =>
+    props.hasSearchButton &&
+    css`
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: ${horisontalContainer.gap};
+    `}
 `;
 
 const InputContainer = styled.div`
@@ -177,12 +185,16 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
     } = buttonProps || {};
 
     const hasSuggestions = !!context.suggestions;
+    const showSearchButton = !!buttonProps && !!onClick;
 
     return (
       <OuterContainer>
         {hasLabel && <Label htmlFor={uniqueId}>{label}</Label>}
         <div>
-          <HorisontalContainer {...containerProps}>
+          <HorisontalContainer
+            hasSearchButton={showSearchButton}
+            {...containerProps}
+          >
             <InputContainer>
               <StyledIcon
                 icon={SearchIcon}
@@ -213,7 +225,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
                 </>
               )}
             </InputContainer>
-            {buttonProps && onClick && (
+            {showSearchButton && (
               <Button
                 size={componentSize}
                 label={buttonLabel || 'Søk'}


### PR DESCRIPTION
Uten søkeknapp vil søkefeltet bare ha et tomt område på slutten. Det gjør at man aldri får fyllt bredden fullt ut.

Eksempel fra Beramming:

<img width="398" alt="Screenshot 2022-11-18 at 14 45 51" src="https://user-images.githubusercontent.com/8463735/202719280-651165cd-65ed-4dd6-b22d-ff66fee0b804.png">

Ønsket oppførsel:

<img width="404" alt="Screenshot 2022-11-18 at 14 47 16" src="https://user-images.githubusercontent.com/8463735/202719392-8a790b59-86a2-4beb-8a46-e602a4f8869e.png">


