### PR TITLE
Justerer opp z-index

### DIFF
--- a/components/src/components/Drawer/Drawer.tsx
+++ b/components/src/components/Drawer/Drawer.tsx
@@ -40,7 +40,7 @@ const Container = styled(Paper)<ContainerProps>`
   flex-direction: column-reverse;
   justify-content: flex-end;
   min-width: 300px;
-  z-index: 50;
+  z-index: 100;
   padding: ${container.padding};
 
   ${({ size }) => css`

--- a/components/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/components/src/components/OverflowMenu/OverflowMenu.tsx
@@ -26,7 +26,7 @@ type ContainerProps = { isOpen: boolean };
 
 export const Container = styled.div<ContainerProps>`
   box-sizing: border-box;
-  z-index: 3;
+  z-index: 100;
   overflow-y: auto;
   min-width: 180px;
   max-width: 300px;

--- a/components/src/components/Popover/Popover.tsx
+++ b/components/src/components/Popover/Popover.tsx
@@ -33,7 +33,7 @@ const Wrapper = styled(Paper)<WrapperProps>`
     hasTransitionedIn && visibilityTransition(hasTransitionedIn && isOpen)}
   position: absolute;
   width: fit-content;
-  z-index: 20;
+  z-index: 100;
   padding: ${wrapper.padding};
 
   &:focus-visible {

--- a/components/src/components/Search/SearchSuggestions.tsx
+++ b/components/src/components/Search/SearchSuggestions.tsx
@@ -28,7 +28,7 @@ const SuggestionsContainer = styled(Paper)<SuggestionsContainerProps>`
   margin-top: ${suggestionsContainer.marginTop};
   border: ${suggestionsContainer.border};
   box-shadow: ${suggestionsContainer.boxShadow};
-  z-index: 3;
+  z-index: 100;
   overflow-y: scroll;
   ${scrollbarStyling.firefox}
   ${scrollbarStyling.webkit}

--- a/components/src/components/Select/Select.styles.ts
+++ b/components/src/components/Select/Select.styles.ts
@@ -226,7 +226,7 @@ export const getCustomStyles = <TOption>(): Partial<
         },
   menu: provided => ({
     ...provided,
-    zIndex: 3,
+    zIndex: 100,
     transition: '0.2s',
     width: 'calc(100% + 2px)',
     transform: 'translate(-1px)',

--- a/components/src/components/Tooltip/Tooltip.styles.tsx
+++ b/components/src/components/Tooltip/Tooltip.styles.tsx
@@ -28,7 +28,7 @@ export const TooltipWrapper = styled(Paper)<WrapperProps>`
   ${({ open }) => visibilityTransition(open)}
   width: fit-content;
   position: absolute;
-  z-index: 20;
+  z-index: 100;
   text-align: center;
   padding: ${wrapper.padding};
   ${getFontStyling(defaultTypographyType)};

--- a/components/src/helpers/Backdrop/Backdrop.tsx
+++ b/components/src/helpers/Backdrop/Backdrop.tsx
@@ -18,7 +18,7 @@ export const Backdrop = styled.div<BackdropProps>`
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 50;
+  z-index: 200;
   opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
   @media (prefers-reduced-motion: no-preference) {
     transition: opacity 0.2s;


### PR DESCRIPTION
Øker z-index til en mer romslig verdi så vi slipper konflikt hos konsumentene som har egne z-index nivåer. Disse komponentene skal som regel vises over alt annet "vanlig" innhold, og bør derfor ha en z-index som distanserer de et stykke fra dem.