### PR TITLE
Håndterer input fra Autocomplete til Search

### DIFF
--- a/components/src/components/Search/Search.tsx
+++ b/components/src/components/Search/Search.tsx
@@ -168,12 +168,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
         context.suggestions ? suggestionsDescriptionId : undefined,
         ariaDescribedby,
       ]),
-      value:
-        context.inputValue !== undefined
-          ? context.inputValue
-          : value
-          ? value
-          : '',
+      value: context.inputValue !== undefined ? context.inputValue : value,
       onChange: handleChange,
       autoComplete: 'off',
     };

--- a/components/src/components/Search/SearchAutocompleteWrapper.tsx
+++ b/components/src/components/Search/SearchAutocompleteWrapper.tsx
@@ -83,7 +83,7 @@ export const SearchAutocompleteWrapper = (
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const query = e.target.value;
-    setInputValue(query);
+    handleSetInputValue(query);
     let finalSuggestions: string[] = [];
 
     if (query.length >= queryLength) {
@@ -122,9 +122,13 @@ export const SearchAutocompleteWrapper = (
 
   const handleSuggestionClick = (e: MouseEvent<HTMLButtonElement>) => {
     setSuggestions([]);
-    setInputValue((e.target as HTMLButtonElement).innerText);
+    handleSetInputValue((e.target as HTMLButtonElement).innerText);
     onSuggestionSelection && onSuggestionSelection();
     closeSuggestions();
+  };
+
+  const handleSetInputValue = (value: string | undefined) => {
+    setInputValue(value || '');
   };
 
   const inputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
Dersom f.eks. `AutocompletSearch` benyttes vil `context.inputValue` bli satt og skal foretrekkes over `value`. Hvis ikke er `inputValue` `undefined` og konsumenten avgjør om `Search` skal være `controlled / uncontrolled`.