### PR TITLE
Oppdaterer `z-index` i enkelte komponenter

### DIFF
--- a/components/src/components/Search/SearchSuggestions.tsx
+++ b/components/src/components/Search/SearchSuggestions.tsx
@@ -28,7 +28,7 @@ const SuggestionsContainer = styled(Paper)<SuggestionsContainerProps>`
   margin-top: ${suggestionsContainer.marginTop};
   border: ${suggestionsContainer.border};
   box-shadow: ${suggestionsContainer.boxShadow};
-  z-index: 100;
+  z-index: 80;
   overflow-y: scroll;
   ${scrollbarStyling.firefox}
   ${scrollbarStyling.webkit}

--- a/components/src/components/SkipToContent/SkipToContent.tsx
+++ b/components/src/components/SkipToContent/SkipToContent.tsx
@@ -45,7 +45,7 @@ const Wrapper = styled.div<WrapperProps>`
     height: auto;
     overflow: auto;
     width: 100%;
-    z-index: 200;
+    z-index: 250;
     opacity: 1;
   }
 `;

--- a/components/src/components/Tooltip/Tooltip.styles.tsx
+++ b/components/src/components/Tooltip/Tooltip.styles.tsx
@@ -28,7 +28,7 @@ export const TooltipWrapper = styled(Paper)<WrapperProps>`
   ${({ open }) => visibilityTransition(open)}
   width: fit-content;
   position: absolute;
-  z-index: 100;
+  z-index: 80;
   text-align: center;
   padding: ${wrapper.padding};
   ${getFontStyling(defaultTypographyType)};


### PR DESCRIPTION
Følgende `z-index` verdier er satt basert på [z-indeks retningslinjer](https://design.domstol.no/987b33f71/p/4862a7-z-indeks):
	- 10 for dekorative ikoner i inputfelt (TextInput, InlineEdit, Search)
	- 80 for Tooltip og SearchSuggestions
	- 250 for SkipToContent