### PR TITLE
ELSA1-195: Sett riktig brekkpunkt ved innlasting for useScreenSize hook

### DIFF
--- a/components/src/hooks/useScreenSize.tsx
+++ b/components/src/hooks/useScreenSize.tsx
@@ -59,6 +59,7 @@ export const useScreenSize = function () {
         }
       }
     }
+    listener();
 
     window.addEventListener('resize', listener);
     return () => window.removeEventListener('resize', listener);


### PR DESCRIPTION
Ved innlasting, ble ikke riktig brekkpunt satt, da den kun ble kjørt ved resize. Legger til kall av funksjon, slik at brekkpunkt blir satt korrekt.