### PR TITLE
Legg til støtte for basic HTML props i FormGenerator

### DIFF
--- a/components/src/components/FormGenerator/FormGenerator.tsx
+++ b/components/src/components/FormGenerator/FormGenerator.tsx
@@ -33,12 +33,9 @@ import { getBaseHTMLProps } from '../../types';
 
 export const FormGenerator = (props: FormGeneratorProps) => {
   const { fields = [], stateOnChange } = props;
-  const { id,
-    className,
-    htmlProps,
-    ...rest } = props;
+  const { id, className, htmlProps, ...rest } = props;
 
-    const baseHTMLProps = {
+  const baseHTMLProps = {
     ...getBaseHTMLProps(id, className, htmlProps, rest),
   };
 

--- a/components/src/components/FormGenerator/FormGenerator.tsx
+++ b/components/src/components/FormGenerator/FormGenerator.tsx
@@ -29,9 +29,18 @@ import {
   SubContainer,
 } from './FormGenerator.styles';
 import { formGeneratorTokens } from './FormGenerator.tokens';
+import { getBaseHTMLProps } from '../../types';
 
 export const FormGenerator = (props: FormGeneratorProps) => {
   const { fields = [], stateOnChange } = props;
+  const { id,
+    className,
+    htmlProps,
+    ...rest } = props;
+
+    const baseHTMLProps = {
+    ...getBaseHTMLProps(id, className, htmlProps, rest),
+  };
 
   const [myState, setState] = useState({});
 
@@ -223,7 +232,7 @@ export const FormGenerator = (props: FormGeneratorProps) => {
   const screenSize = useScreenSize();
 
   return (
-    <Grid as="form" rowGap={formGeneratorTokens.rowGaps}>
+    <Grid {...baseHTMLProps} as="form" rowGap={formGeneratorTokens.rowGaps}>
       {fields.map((obj, index) => {
         if (isFormGeneratorRow(obj)) {
           if (obj.rowType === 'button') {

--- a/components/src/components/FormGenerator/FormGenerator.tsx
+++ b/components/src/components/FormGenerator/FormGenerator.tsx
@@ -35,10 +35,6 @@ export const FormGenerator = (props: FormGeneratorProps) => {
   const { fields = [], stateOnChange } = props;
   const { id, className, htmlProps, ...rest } = props;
 
-  const baseHTMLProps = {
-    ...getBaseHTMLProps(id, className, htmlProps, rest),
-  };
-
   const [myState, setState] = useState({});
 
   const fieldOnChange = <T extends HTMLInputElement>(event: ChangeEvent<T>) => {
@@ -229,7 +225,7 @@ export const FormGenerator = (props: FormGeneratorProps) => {
   const screenSize = useScreenSize();
 
   return (
-    <Grid {...baseHTMLProps} as="form" rowGap={formGeneratorTokens.rowGaps}>
+    <Grid {...getBaseHTMLProps(id, className, htmlProps, rest)} as="form" rowGap={formGeneratorTokens.rowGaps}>
       {fields.map((obj, index) => {
         if (isFormGeneratorRow(obj)) {
           if (obj.rowType === 'button') {

--- a/components/src/components/FormGenerator/FormGenerator.tsx
+++ b/components/src/components/FormGenerator/FormGenerator.tsx
@@ -225,7 +225,11 @@ export const FormGenerator = (props: FormGeneratorProps) => {
   const screenSize = useScreenSize();
 
   return (
-    <Grid {...getBaseHTMLProps(id, className, htmlProps, rest)} as="form" rowGap={formGeneratorTokens.rowGaps}>
+    <Grid
+      {...getBaseHTMLProps(id, className, htmlProps, rest)}
+      as="form"
+      rowGap={formGeneratorTokens.rowGaps}
+    >
       {fields.map((obj, index) => {
         if (isFormGeneratorRow(obj)) {
           if (obj.rowType === 'button') {


### PR DESCRIPTION
Dette gjør at man f.eks. kan sette id og className på parent-elementet i FormGenerator, som er et Grid-element