### PR TITLE
ELSA1-216 Fiks at `firstHalf`/`secondHalf` ikke fungerer på skjermer større enn 1920px

### DIFF
--- a/components/src/components/Grid/Grid.tokens.tsx
+++ b/components/src/components/Grid/Grid.tokens.tsx
@@ -4,11 +4,12 @@ import { ScreenSize } from '../../hooks';
 const { grid, spacing } = ddsBaseTokens;
 
 const allColumns = '1 / -1';
-const halfWayColumn = {
+const halfWayColumn: Record<ScreenSize, number> = {
+  [ScreenSize.XSmall]: grid.DdsGridXs0599Count / 2 + 1,
   [ScreenSize.Small]: grid.DdsGridSm600959Count / 2 + 1,
   [ScreenSize.Medium]: grid.DdsGridMd9601279Count / 2 + 1,
   [ScreenSize.Large]: grid.DdsGridLg12801919Count / 2 + 1,
-  [ScreenSize.XLarge]: grid.DdsGridXs0599Count / 2 + 1,
+  [ScreenSize.XLarge]: grid.DdsGridXl1920Count / 2 + 1,
 };
 
 export const gridTokens = {


### PR DESCRIPTION
`firstHalf` og `secondHalf` blir beregnet ut i fra den totale column count'en for skjermstørrelsen din. For skjermstørrelse XLarge (1920px-bred) var column count for skjermstørrelse XSmall brukt, som førte til at `firstHalf` ville kun bruke de to første kolonnene. Nå bruker `firstHalf` og `secondHalf` 6 kolonner hver.

## Før
![2023-01-12 11 02 18](https://user-images.githubusercontent.com/25374940/212040665-5872bfde-5a94-4fbd-8f00-12f47a7521ca.gif)

## Etter
![2023-01-12 11 14 16](https://user-images.githubusercontent.com/25374940/212040686-efeed53c-b43f-4400-aec2-870850ff14b8.gif)

Merk at vi her har satt en maksbredde i skjemaet, som gjør at det ikke faktisk vokser seg større.
