### PR TITLE
Fikser noen småbugs med FileUploader

### DIFF
--- a/components/src/components/FileUploader/fileUploaderReducer.ts
+++ b/components/src/components/FileUploader/fileUploaderReducer.ts
@@ -6,11 +6,6 @@ export type FileUploaderFile = {
   errors: string[];
 };
 
-type FileChangePayload = {
-  rootErrors: RootErrorList;
-  files: FileUploaderFile[];
-};
-
 export type RootErrorList = string[];
 
 export type FileUploaderAction =
@@ -20,11 +15,11 @@ export type FileUploaderAction =
   | { type: 'dragLeave' }
   | {
       type: 'onSetFiles';
-      payload: FileChangePayload;
+      payload: FileUploaderFile[];
     }
   | {
       type: 'onRemoveFile';
-      payload: FileChangePayload;
+      payload: FileUploaderFile[];
     }
   | {
       type: 'setRootErrors';
@@ -59,14 +54,12 @@ export const fileUploaderReducer: Reducer<
       return {
         ...state,
         isDragActive: false,
-        rootErrors: action.payload.rootErrors,
-        files: action.payload.files,
+        files: action.payload,
       };
     case 'onRemoveFile':
       return {
         ...state,
-        rootErrors: action.payload.rootErrors,
-        files: action.payload.files,
+        files: action.payload,
       };
     case 'setRootErrors':
       return {

--- a/components/src/components/FileUploader/useFileUploader.ts
+++ b/components/src/components/FileUploader/useFileUploader.ts
@@ -59,7 +59,7 @@ const calcRootErrors = (
 export const useFileUploader = <TRootElement extends HTMLElement>(
   props: FileUploaderHookProps
 ) => {
-  const { initialFiles = [], accept, maxFiles, disabled, errorMessage } = props;
+  const { initialFiles, accept, maxFiles, disabled, errorMessage } = props;
 
   const rootRef = useRef<TRootElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -67,7 +67,7 @@ export const useFileUploader = <TRootElement extends HTMLElement>(
 
   const initialFileUploaderFiles = useMemo(
     () =>
-      initialFiles.map<FileUploaderFile>(f => ({
+      (initialFiles ?? []).map<FileUploaderFile>(f => ({
         file: f,
         errors: [],
       })),
@@ -86,14 +86,14 @@ export const useFileUploader = <TRootElement extends HTMLElement>(
     ),
   });
 
+  const { files: stateFiles } = state;
+
   useEffect(() => {
     dispatch({
       type: 'setRootErrors',
-      payload: calcRootErrors(initialFileUploaderFiles, maxFiles, errorMessage),
+      payload: calcRootErrors(stateFiles, maxFiles, errorMessage),
     });
-  }, [dispatch, initialFileUploaderFiles, maxFiles, errorMessage]);
-
-  const { files: stateFiles } = state;
+  }, [dispatch, stateFiles, maxFiles, errorMessage]);
 
   const onRootFocus = useCallback(
     () => dispatch({ type: 'focus' }),
@@ -163,10 +163,9 @@ export const useFileUploader = <TRootElement extends HTMLElement>(
           })
           .concat(stateFiles);
 
-        const rootErrors = calcRootErrors(newFiles, maxFiles, errorMessage);
         dispatch({
           type: 'onSetFiles',
-          payload: { rootErrors, files: newFiles },
+          payload: newFiles,
         });
       }
     },
@@ -185,11 +184,9 @@ export const useFileUploader = <TRootElement extends HTMLElement>(
       const newFiles = [...stateFiles];
       newFiles.splice(stateFiles.indexOf(file), 1);
 
-      const rootErrors = calcRootErrors(newFiles, maxFiles, errorMessage);
-
       dispatch({
         type: 'onRemoveFile',
-        payload: { rootErrors, files: newFiles },
+        payload: newFiles,
       });
     },
     [stateFiles, maxFiles, errorMessage]


### PR DESCRIPTION
* Effekten for å sette rootErrors ble i enkelte tilfeller kjørt i loop pga `initialFiles` ble instansiert til `[]` og dermed alltid fikk ny verdi for hver render
* Rydder opp litt slik at vi kun setter `rootErrors` ett sted.