### PR TITLE
Sett interop til 'compat' for cjs-bygg.

### DIFF
--- a/components/rollup.config.mjs
+++ b/components/rollup.config.mjs
@@ -25,6 +25,7 @@ export default {
       dir: 'dist/cjs',
       format: 'cjs',
       exports: 'named',
+      interop: 'compat',
     },
     {
       dir: 'dist',


### PR DESCRIPTION
* Dette fikser feilen som førte til at styled-components ikke ble riktig importert i cjs-bygget av dds-components