### PR TITLE
Kjør dependabot for npm på rotnivå

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/packages/components"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "npm"
-    directory: "/packages/tokens"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
* Tidligere ble dependabot kjørt på components og tokens individuelt, men med nytt workspace setup så kan vi kjøre det på rotnivå og få common-pakker bumpet sammen.