### PR TITLE
ELSA1-224 Åpner opp for mer overstyring av CardAccordion

### DIFF
--- a/.changeset/mean-dolls-approve.md
+++ b/.changeset/mean-dolls-approve.md
@@ -1,0 +1,10 @@
+---
+"@norges-domstoler/dds-components": minor
+---
+
+Åpner opp for overstyring av CardAccordion.
+
+Lagt til nye props (alle optional):
+
+* `CardAccordionHeader`: `padding`, `typographyType`, `bold`
+* `CardAccordionBody`: `padding`

--- a/packages/components/src/components/Card/Card.stories.tsx
+++ b/packages/components/src/components/Card/Card.stories.tsx
@@ -1,22 +1,22 @@
+import { ddsBaseTokens } from '@norges-domstoler/dds-design-tokens';
+import { useState } from 'react';
+import styled from 'styled-components';
 import {
-  CardAccordion,
-  CardAccordionHeader,
-  CardAccordionBody,
   Card,
+  CardAccordion,
+  CardAccordionBody,
+  CardAccordionHeader,
   CardProps,
   ExpandableCardProps,
 } from '.';
 import { StoryTemplate } from '../../storybook';
-import { Divider } from '../Divider';
 import {
   DescriptionList,
   DescriptionListDesc,
   DescriptionListTerm,
 } from '../DescriptionList';
+import { Divider } from '../Divider';
 import { Typography } from '../Typography';
-import styled from 'styled-components';
-import { ddsBaseTokens } from '@norges-domstoler/dds-design-tokens';
-import { useState } from 'react';
 
 export default {
   title: 'Design system/Card',
@@ -209,6 +209,45 @@ export const AccordionControlled = (args: ExpandableCardProps) => {
         >
           <CardAccordionHeader>Header</CardAccordionHeader>
           <CardAccordionBody>Content</CardAccordionBody>
+        </CardAccordion>
+      </Card>
+    </StoryTemplate>
+  );
+};
+
+export const AccordionCustom = (args: ExpandableCardProps) => {
+  return (
+    <StoryTemplate title="Card - accordion" gap="0">
+      <Card {...args} cardType="expandable" color="strokeLight">
+        <CardAccordion>
+          <CardAccordionHeader
+            typographyType="bodySans01"
+            padding="4px 12px"
+            bold
+          >
+            Dekning av reiseutgifter
+          </CardAccordionHeader>
+          <CardAccordionBody padding="16px 12px">
+            <Typography typographyType="bodySans01">
+              I sivile saker avtales dekning av utgifter med den part som
+              innkalte deg. I straffesaker har du krav på reise- og
+              kostgodtgjørelse (
+              <Typography typographyType="a" href="#">
+                særavtale om dekning av utgifter til reise og kost
+              </Typography>
+              ). Reisen skal foretas på raskeste og rimeligste måte for staten.
+              Offentlig transport må benyttes der det er tilgjengelig.
+              Godtgjørelse for bruk av egen bil godtas bare i den utstrekning
+              det er rimeligst for det offentlige, med mindre særlige grunner
+              tilsier at du må bruke bil.Reiseutgiftene må dokumenteres med
+              kvitteringer, unntatt for rimeligste offentlig transport, for
+              eksempel buss, tog og så videre. For reiser over 15 km og som
+              varer utover 6 timer, dekkes utgifter til måltider etter satsene i
+              særavtalen om dekning av utgifter til reise og kost. Dersom
+              enkeltmåltider er dekket av andre enn deg selv, må du registrere
+              måltidsfradrag.
+            </Typography>
+          </CardAccordionBody>
         </CardAccordion>
       </Card>
     </StoryTemplate>

--- a/packages/components/src/components/Card/CardAccordion/CardAccordionBody.tsx
+++ b/packages/components/src/components/Card/CardAccordion/CardAccordionBody.tsx
@@ -1,3 +1,4 @@
+import { Property } from 'csstype';
 import {
   forwardRef,
   useEffect,
@@ -6,17 +7,16 @@ import {
   useState,
 } from 'react';
 import styled, { css } from 'styled-components';
-import {
-  cardAccordionTokens as tokens,
-  typographyTypes,
-} from './CardAccordion.tokens';
-import { Property } from 'csstype';
+import useIsMounted from '../../../hooks/useIsMounted';
 import {
   BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../../types';
-import useIsMounted from '../../../hooks/useIsMounted';
 import { getFontStyling } from '../../Typography/Typography.utils';
+import {
+  cardAccordionTokens as tokens,
+  typographyTypes,
+} from './CardAccordion.tokens';
 
 const expandingAnimation = css`
   @media (prefers-reduced-motion: no-preference) {
@@ -25,9 +25,16 @@ const expandingAnimation = css`
   }
 `;
 
+function getPadding(props: BodyProps): string {
+  const { padding } = props;
+
+  return padding || tokens.body.padding;
+}
+
 type BodyProps = {
   isExpanded?: boolean;
   paddingTop?: Property.PaddingTop<string>;
+  padding?: Property.Padding<string>;
   animate: boolean;
 };
 
@@ -35,7 +42,7 @@ const Body = styled.div<BodyProps>`
   @media (prefers-reduced-motion: no-preference) {
     ${({ animate }) => animate && expandingAnimation}
   }
-  padding: ${tokens.body.padding};
+  padding: ${getPadding};
   ${getFontStyling(typographyTypes.body)}
   ${({ paddingTop }) =>
     paddingTop &&
@@ -72,6 +79,8 @@ export type CardAccordionBodyProps = BaseComponentPropsWithChildren<
     headerId?: string;
     /**Overskriver default padding på toppen. Brukes når barn har spacing på toppen, f.eks. en overskrift. */
     paddingTop?: Property.PaddingTop<string>;
+    /**Overskriver default padding. */
+    padding?: Property.Padding<string>;
   }
 >;
 

--- a/packages/components/src/components/Card/CardAccordion/CardAccordionHeader.tsx
+++ b/packages/components/src/components/Card/CardAccordion/CardAccordionHeader.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, ButtonHTMLAttributes } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import {
   cardAccordionTokens as tokens,
   typographyTypes,
@@ -11,12 +11,32 @@ import {
   getBaseHTMLProps,
 } from '../../../types';
 import { getFontStyling } from '../../Typography/Typography.utils';
+import { Property } from 'csstype';
+import { StaticTypographyType } from '../../Typography';
 
 const { header, chevronWrapper } = tokens;
 
 const ContentWrapper = styled.div`
   text-align: left;
 `;
+
+function getPadding(props: HeaderProps): string {
+  const { padding } = props;
+
+  return padding || header.padding;
+}
+
+function getTypographyType(props: HeaderProps): StaticTypographyType {
+  const { typographyType } = props;
+
+  return typographyType || typographyTypes.header;
+}
+
+type HeaderProps = {
+  padding?: Property.Padding<string>;
+  typographyType?: StaticTypographyType;
+  bold?: boolean;
+};
 
 const HeaderContainer = styled.div`
   display: flex;
@@ -25,8 +45,13 @@ const HeaderContainer = styled.div`
   @media (prefers-reduced-motion: no-preference) {
     transition: box-shadow 0.2s;
   }
-  padding: ${header.padding};
-  ${getFontStyling(typographyTypes.header)}
+  padding: ${getPadding};
+  ${props => getFontStyling(getTypographyType(props))}
+  ${props =>
+    props.bold &&
+    css`
+      font-weight: 600;
+    `}
 `;
 
 const HeaderWrapper = styled.button`
@@ -69,6 +94,12 @@ export type CardAccordionHeaderProps = BaseComponentPropsWithChildren<
     toggleExpanded?: () => void;
     /** **OBS!** denne propen blir satt automatisk av forelder. Forteller `id` til `<CardAccordionBody />`.  */
     bodyId?: string;
+    /**Overskriver default padding. */
+    padding?: Property.Padding<string>;
+    /**Overskriver default teksttype. */
+    typographyType?: StaticTypographyType;
+    /**Angir om teksten skal være i "bold"-format. */
+    bold?: boolean;
   },
   ButtonHTMLAttributes<HTMLButtonElement>
 >;
@@ -85,6 +116,9 @@ export const CardAccordionHeader = forwardRef<
     id,
     className,
     htmlProps,
+    padding,
+    typographyType,
+    bold,
     ...rest
   } = props;
 
@@ -110,8 +144,12 @@ export const CardAccordionHeader = forwardRef<
 
   return (
     <HeaderWrapper {...headerWrapperProps}>
-      <HeaderContainer>
-        <ContentWrapper> {children} </ContentWrapper>
+      <HeaderContainer
+        typographyType={typographyType}
+        padding={padding}
+        bold={bold}
+      >
+        <ContentWrapper>{children}</ContentWrapper>
         <ChevronWrapper>
           <AnimatedChevronUpDown {...chevronProps} />
         </ChevronWrapper>


### PR DESCRIPTION
Både `CardAccordionHeader` og `CardAccordionBody` tar inn `padding` for å styre størrelsen på innholdet. `CardAccordionHeader` har i tillegg to props for å styre tekststilen.