### PR TITLE
Fjerner bakgrunnsfarge for InputMessage av typen 'tip'

### DIFF
--- a/.changeset/lucky-books-shake.md
+++ b/.changeset/lucky-books-shake.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Fjerner bakgrunnsfarge for InputMessage av typen 'tip'

--- a/packages/components/src/components/InputMessage/InputMessage.tsx
+++ b/packages/components/src/components/InputMessage/InputMessage.tsx
@@ -17,11 +17,7 @@ const InputMessageWrapper = styled.div<WrapperProps>`
   word-break: break-word;
   max-width: 100%;
   ${({ messageType }) =>
-    messageType === 'tip'
-      ? css`
-          background-color: ${tokens.message.tip.backgroundColor};
-        `
-      : messageType === 'error'
+    messageType === 'error'
       ? css`
           color: ${tokens.message.error.color};
           background-color: ${tokens.message.error.backgroundColor};


### PR DESCRIPTION
Tidligere, ved bruk av `<InputMessage />` i en boks:
![image](https://user-images.githubusercontent.com/397559/219322896-f685a53a-b35c-42fd-b1fe-e41519dc6667.png)

Etter fiks:
![image](https://user-images.githubusercontent.com/397559/219322939-1bebbec0-e3b1-4897-b9fe-446a11f56f80.png)
