### PR TITLE
Muliggjør innhold med dynamisk størrelse i CardAccordion

### DIFF
--- a/.changeset/wise-lies-train.md
+++ b/.changeset/wise-lies-train.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Muliggjør innhold med dynamisk størrelse i CardAccordion

--- a/apps/testapp/app/routes/card/accordion.tsx
+++ b/apps/testapp/app/routes/card/accordion.tsx
@@ -1,32 +1,34 @@
 import {
+  Button,
   Card,
   CardAccordion,
   CardAccordionBody,
   CardAccordionHeader,
-  Paragraph
-} from '@norges-domstoler/dds-components';
+  Paragraph,
+  VStack,
+} from "@norges-domstoler/dds-components";
+import { useState } from "react";
 
 export default function Accordion() {
+  const [bodyItemCount, setBodyItemCount] = useState(0);
+
   return (
-    <Card cardType="expandable">
-      <CardAccordion>
-        <CardAccordionHeader>Åpne meg!</CardAccordionHeader>
-        <CardAccordionBody>
-          Her er litt tekst. Det er plass til mye tekst her.
-          <Paragraph>
+    <VStack align="flex-start" gap="layout-x1">
+      <Button
+        onClick={() => setBodyItemCount((prev) => prev + 1)}
+        label="Legg til barn"
+      />
+      <Card cardType="expandable">
+        <CardAccordion>
+          <CardAccordionHeader>Åpne meg!</CardAccordionHeader>
+          <CardAccordionBody>
             Her er litt tekst. Det er plass til mye tekst her.
-            Her er litt tekst. Det er plass til mye tekst her.
-            Her er litt tekst. Det er plass til mye tekst her.
-            Her er litt tekst. Det er plass til mye tekst her.
-            Her er litt tekst. Det er plass til mye tekst her.
-            Her er litt tekst. Det er plass til mye tekst her.
-            Her er litt tekst. Det er plass til mye tekst her.
-            Her er litt tekst. Det er plass til mye tekst her.
-            Her er litt tekst. Det er plass til mye tekst her.
-            Her er litt tekst. Det er plass til mye tekst her.
-          </Paragraph>
-        </CardAccordionBody>
-      </CardAccordion>
-    </Card>
-  )
+            {Array.from({ length: bodyItemCount }, (_, i) => i).map((el) => (
+              <Paragraph key={el}>test</Paragraph>
+            ))}
+          </CardAccordionBody>
+        </CardAccordion>
+      </Card>
+    </VStack>
+  );
 }

--- a/packages/components/src/components/Card/CardAccordion/useElementHeight.ts
+++ b/packages/components/src/components/Card/CardAccordion/useElementHeight.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export function useElementHeight(element: HTMLDivElement | null): number {
+  const [height, setHeight] = useState(0);
+
+  useEffect(() => {
+    if (!element) return;
+
+    const resizeObserver = new ResizeObserver(() => {
+      setHeight(element.offsetHeight || 0);
+    });
+
+    resizeObserver.observe(element);
+
+    return () => resizeObserver.disconnect();
+  }, [element]);
+
+  return height;
+}


### PR DESCRIPTION
Oppdaterer høyden på ekspandert `CardAccordion` utifra størrelsen på innholdet.

Andre endringer:

* Lytter på størrelsen via ref med en `ResizeObserver`
* Bruker `height` i stedet for `max-height` i transisjonen
* Fjerner `padding` fra transisjon - ligger implisitt i høyden
* Fjerner `visibility` - har ingen effekt i en transisjon

Har også fjernet `useLayoutEffect` for å se om `ResizeObserver` håndterer problemet i https://github.com/domstolene/designsystem/pull/336. Får ikke verifisert det tilfredsstillende i storybook.