### PR TITLE
Sette peer dependency range på interne pakker til å følge major-versjon.

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": ["testapp"]
+  "ignore": ["testapp"],
+  "onlyUpdatePeerDependentsWhenOutOfRange": true
 }

--- a/.changeset/sixty-snails-grin.md
+++ b/.changeset/sixty-snails-grin.md
@@ -1,0 +1,6 @@
+---
+"@norges-domstoler/dds-page-generator": patch
+"@norges-domstoler/dds-components": patch
+---
+
+Endre alle `peerDependencies` til å være mer føyelig i hvilke versjoner vi tillater.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,7 +52,7 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",
     "@mdx-js/react": "^2.2.1",
-    "@norges-domstoler/dds-design-tokens": "^3.0.1",
+    "@norges-domstoler/dds-design-tokens": "*",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^24.0.0",
     "@rollup/plugin-image": "^3.0.1",
@@ -94,7 +94,7 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "@norges-domstoler/dds-design-tokens": "^3.0.1",
+    "@norges-domstoler/dds-design-tokens": "^3",
     "react": "^16 || ^17 || ^18",
     "react-dom": "^16 || ^17 || ^18",
     "styled-components": "^5"

--- a/packages/page-generator/package.json
+++ b/packages/page-generator/package.json
@@ -52,8 +52,8 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-react": "^7.18.6",
     "@mdx-js/react": "^2.2.1",
-    "@norges-domstoler/dds-components": "^11.3.0",
-    "@norges-domstoler/dds-design-tokens": "^3.0.1",
+    "@norges-domstoler/dds-components": "*",
+    "@norges-domstoler/dds-design-tokens": "*",
     "@testing-library/react": "^14.0.0",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.11",
@@ -78,8 +78,8 @@
     "vitest": "^0.29.1"
   },
   "peerDependencies": {
-    "@norges-domstoler/dds-components": "^11.3.0",
-    "@norges-domstoler/dds-design-tokens": "^3.0.1",
+    "@norges-domstoler/dds-components": "^11.2.0",
+    "@norges-domstoler/dds-design-tokens": "^3",
     "react": "^16 || ^17 || ^18",
     "react-dom": "^16 || ^17 || ^18",
     "styled-components": "^5"


### PR DESCRIPTION
Dette gjøres i et forsøk på å gjøre "Update dependencies"-bumper til å ikke bli major-versjon bumper, men er også en endring som uansett er greit å ha på plass.