### PR TITLE
ELSA1-241 bytte til dependencies istedenfor peerDependencies for dds-pakker i dds-page-generator.

### DIFF
--- a/.changeset/bright-ears-shout.md
+++ b/.changeset/bright-ears-shout.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-page-generator": patch
+---
+
+Fjern nødvendighet for peerDependencies på andre designsystempakker

--- a/package-lock.json
+++ b/package-lock.json
@@ -45366,6 +45366,10 @@
       "name": "@norges-domstoler/dds-page-generator",
       "version": "2.0.0",
       "license": "MIT",
+      "dependencies": {
+        "@norges-domstoler/dds-components": "^11.3.0",
+        "@norges-domstoler/dds-design-tokens": "^3.0.1"
+      },
       "devDependencies": {
         "@babel/core": "^7.21.0",
         "@babel/preset-env": "^7.20.2",
@@ -45397,8 +45401,6 @@
         "vitest": "^0.29.1"
       },
       "peerDependencies": {
-        "@norges-domstoler/dds-components": "^11.2.0",
-        "@norges-domstoler/dds-design-tokens": "^3",
         "react": "^16 || ^17 || ^18",
         "react-dom": "^16 || ^17 || ^18",
         "styled-components": "^5"

--- a/packages/page-generator/package.json
+++ b/packages/page-generator/package.json
@@ -77,9 +77,11 @@
     "vite-plugin-dts": "^2.1.0",
     "vitest": "^0.29.1"
   },
+  "dependencies": {
+    "@norges-domstoler/dds-components": "^11.3.0",
+    "@norges-domstoler/dds-design-tokens": "^3.0.1"
+  },
   "peerDependencies": {
-    "@norges-domstoler/dds-components": "^11.2.0",
-    "@norges-domstoler/dds-design-tokens": "^3",
     "react": "^16 || ^17 || ^18",
     "react-dom": "^16 || ^17 || ^18",
     "styled-components": "^5"


### PR DESCRIPTION
Dette gjøres for at changesets ikke skal bumpe til ny major for hver endring i dds-components/dds-design-tokens