### PR TITLE
Spesifiser brekkpunkt i stedet for bolsk verdi

### DIFF
--- a/packages/components/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/components/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -6,6 +6,9 @@ import { ChevronRightIcon, ArrowLeftIcon } from '../../icons/tsx';
 import { BaseComponentPropsWithChildren, getBaseHTMLProps } from '../../types';
 import { removeListStyling } from '../../helpers/styling/removeListStyling';
 import { getFontStyling } from '../Typography/Typography.utils';
+import { ddsBaseTokens } from '@norges-domstoler/dds-design-tokens';
+
+const { breakpoints } = ddsBaseTokens;
 
 const { icon, list, listItem } = breadcrumbTokens;
 
@@ -17,46 +20,86 @@ const List = styled.ol`
   gap: ${list.gap};
 `;
 
-const ListItem = styled.li`
+const ListItem = styled.li<{ mediaQuery: string }>`
   align-items: center;
   display: flex;
   gap: ${listItem.gap};
   ${getFontStyling(typographyType)}
+
+  @media ${p => p.mediaQuery} {
+    display: none;
+  }
+
+  &:nth-last-child(2) {
+    display: flex;
+  }
 `;
 
-const StyledIcon = styled(Icon)`
+const StyledIcon = styled(Icon)<{ mediaQuery: string }>`
   color: ${icon.color};
+
+  @media ${p => p.mediaQuery} {
+    display: none;
+  }
 `;
+
+const BackIcon = styled(Icon)<{ mediaQuery: string }>`
+  color: ${icon.color};
+  display: none;
+
+  @media ${p => p.mediaQuery} {
+    display: inline-block;
+  }
+`;
+
+type ScreenSize = 'XSmall' | 'Small' | 'Medium' | 'Large' | 'XLarge';
+
+const mediaQueries: Record<ScreenSize, string> = {
+  XSmall: `only screen and (max-width: ${breakpoints.DdsBreakpointXs})`,
+  Small: `only screen and (max-width: ${breakpoints.DdsBreakpointSm})`,
+  Medium: `only screen and (max-width: ${breakpoints.DdsBreakpointMd})`,
+  Large: `only screen and (max-width: ${breakpoints.DdsBreakpointLg})`,
+  XLarge: `only screen and (max-width: ${breakpoints.DdsBreakpointXl})`,
+};
 
 export type BreadcrumbsProps = BaseComponentPropsWithChildren<
   HTMLElement,
   {
-    /** Spesifiserer om versjonen for små skjermer skal vises; den viser `<Breadcrumb />` kun til den forrige siden.  */
-    smallScreen?: boolean;
+    /** Spesifiserer brekkpunkt for når små skjermer skal vises; den viser `<Breadcrumb />` kun til den forrige siden.  */
+    smallScreenBreakpoint?: ScreenSize;
   }
 >;
 
 export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
   (props, ref) => {
-    const { smallScreen, children, id, className, htmlProps, ...rest } = props;
+    const {
+      smallScreenBreakpoint,
+      children,
+      id,
+      className,
+      htmlProps,
+      ...rest
+    } = props;
 
     const childrenArray = Children.toArray(children);
 
-    const breadcrumbChildren = smallScreen ? (
-      <ListItem>
-        <StyledIcon icon={ArrowLeftIcon} iconSize="small" />
-        {childrenArray[childrenArray.length - 2]}
+    const mediaQuery = mediaQueries[smallScreenBreakpoint ?? 'XSmall'];
+
+    const breadcrumbChildren = childrenArray.map((item, index) => (
+      <ListItem mediaQuery={mediaQuery} key={`breadcrumb-${index}`}>
+        {index !== 0 && (
+          <StyledIcon icon={ChevronRightIcon} mediaQuery={mediaQuery} />
+        )}
+        {index === childrenArray.length - 2 && (
+          <BackIcon
+            icon={ArrowLeftIcon}
+            iconSize="small"
+            mediaQuery={mediaQuery}
+          />
+        )}
+        {item}
       </ListItem>
-    ) : (
-      childrenArray.map((item, index) => {
-        return (
-          <ListItem key={`breadcrumb-${index}`}>
-            {index !== 0 && <StyledIcon icon={ChevronRightIcon} />}
-            {item}
-          </ListItem>
-        );
-      })
-    );
+    ));
 
     return (
       <nav


### PR DESCRIPTION
Breadcrumb tar per nå inn en boolsk verdi for om komprimert eller full versjon skal rendres. Meningen er at komprimert versjon skal vises på "små" skjermer, men parameteret smallScreen reflekterer ikke dette. I stedet kan vi ta inn et brekkpunkt for når man skal vise komprimert versjon.

Dette er mest en PR for å diskutere et alternativt API. Utfordringen jeg har med nåværende API er at det inviterer til å bruke noe som kalkulerer om man skal vise komprimert eller full versjon. Dette "noe" er gjerne `useScreenSize`-hooken, som både er unødvendig kompleks for å håndtere akkurat dette, og ikke funker så bra med SSR (Hei, Remix!).

Tidligere ble altså komponenten brukt slik:
```
const screenSize = useScreenSize();
const isSmallScreen = screenSize === ScreenSize.Small;

<Breadcrumbs smaalScreen={isSmallScreen}>
  <Breadcrumb href="#">Side 1</Breadcrumb>
  <Breadcrumb href="#">Side 2</Breadcrumb>
  <Breadcrumb>Side 3</Breadcrumb>
</Breadcrumbs>
```

Og nå blir APIet slik:
```
<Breadcrumbs smallScreenBreakpoint='Small'>
  <Breadcrumb href="#">Side 1</Breadcrumb>
  <Breadcrumb href="#">Side 2</Breadcrumb>
  <Breadcrumb>Side 3</Breadcrumb>
</Breadcrumbs>
```