### PR TITLE
ELSA1-192 "Steg x av y" wrapper på veldig små skjermer

### DIFF
--- a/packages/components/src/components/ProgressTracker/ProgressTracker.tsx
+++ b/packages/components/src/components/ProgressTracker/ProgressTracker.tsx
@@ -36,6 +36,7 @@ const ItemsWrapper = styled.ol`
 const SmallScreenWrapper = styled.div`
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
 `;
 
 const ProgressTrackerConnector = styled.div`

--- a/packages/components/src/components/ProgressTracker/ProgressTrackerItem.tsx
+++ b/packages/components/src/components/ProgressTracker/ProgressTrackerItem.tsx
@@ -78,7 +78,7 @@ const ItemWrapper = styled.li`
   flex: 1;
   position: relative;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
 `;
 
 const ItemNumber = styled.div<ItemStyleProps>`


### PR DESCRIPTION
Gir det mening å definere et changeset til denne endringen gitt at forrige changeset ikke ble rullet ut? Jeg tenker at denne går under [forrige PR](https://github.com/domstolene/designsystem/pull/656)

![Animation](https://user-images.githubusercontent.com/22095633/228203825-adb48393-b2b2-43ac-9d31-a5244e75c756.gif)
