### PR TITLE
Legg til ny type SectionGeneratorRow

### DIFF
--- a/.changeset/brave-bugs-wait.md
+++ b/.changeset/brave-bugs-wait.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-page-generator": minor
+---
+
+Legg til ny type SectionGeneratorRow

--- a/packages/page-generator/src/components/SectionGenerator.tsx
+++ b/packages/page-generator/src/components/SectionGenerator.tsx
@@ -6,10 +6,10 @@ import {
 } from '@norges-domstoler/dds-components';
 import {
   PageGeneratorField,
-  PageGeneratorRow,
   PageGeneratorState,
   PageGeneratorStateOptionTypes,
   SectionGeneratorProps,
+  SectionGeneratorRow,
 } from '../types';
 import React from 'react';
 import {
@@ -17,8 +17,9 @@ import {
   getButtonRow,
   getComponent,
   isMultiValue,
-  isPageGeneratorRow,
+  isSectionGeneratorRow,
 } from '../helpers';
+import { getStandardRow } from '../helpers/getStandardRow';
 
 /**
  * Generer komponenter fra @norges-domstoler/dds-components, basert på `fields` propertien. SectionGenerator legger på en wrapper, basert på `as` propertien.
@@ -32,8 +33,8 @@ export const SectionGenerator = (props: SectionGeneratorProps) => {
 
   useEffect(() => {
     let state: PageGeneratorState<PageGeneratorStateOptionTypes> = {};
-    fields.forEach((field: PageGeneratorField | PageGeneratorRow) => {
-      if (isPageGeneratorRow(field)) {
+    fields.forEach((field: PageGeneratorField | SectionGeneratorRow) => {
+      if (isSectionGeneratorRow(field)) {
         field.fields.forEach((field: PageGeneratorField) => {
           state = addFieldToState(field, state);
         });
@@ -107,7 +108,7 @@ export const SectionGenerator = (props: SectionGeneratorProps) => {
   return (
     <Parent>
       {fields.map((obj, index) => {
-        if (isPageGeneratorRow(obj)) {
+        if (isSectionGeneratorRow(obj)) {
           if (obj.rowType === 'button') {
             return (
               !obj.hide &&
@@ -121,21 +122,13 @@ export const SectionGenerator = (props: SectionGeneratorProps) => {
             );
           } else {
             return (
-              !obj.hide && (
-                <React.Fragment key={index}>
-                  {obj.fields.map((field, groupedIndex) => {
-                    return (
-                      !field.hide &&
-                      getComponent(
-                        field,
-                        groupedIndex,
-                        fieldOnChange,
-                        selectOnChange,
-                        screenSize
-                      )
-                    );
-                  })}
-                </React.Fragment>
+              !obj.hide &&
+              getStandardRow(
+                index,
+                obj,
+                fieldOnChange,
+                selectOnChange,
+                screenSize
               )
             );
           }

--- a/packages/page-generator/src/helpers/getStandardRow.tsx
+++ b/packages/page-generator/src/helpers/getStandardRow.tsx
@@ -1,0 +1,59 @@
+import {
+  BaseComponentPropsWithChildren,
+  getBaseHTMLProps,
+  ScreenSize,
+} from '@norges-domstoler/dds-components';
+import { SectionGeneratorRow } from '../types';
+import { MultiValue, SingleValue } from 'react-select';
+import { ChangeEvent } from 'react';
+import { getComponent } from '.';
+import React from 'react';
+
+type T = HTMLInputElement & Record<string, never>;
+
+const Row = (
+  props: BaseComponentPropsWithChildren<HTMLElement, SectionGeneratorRow>
+) => {
+  const { id, className, htmlProps, ...rest } = props;
+  if (props.as === 'div') {
+    return (
+      <div {...getBaseHTMLProps(id, className, htmlProps, rest)}>
+        {props.children}
+      </div>
+    );
+  } else if (props.as === 'fragment') {
+    return <React.Fragment>{props.children}</React.Fragment>;
+  } else {
+    return <></>;
+  }
+};
+
+export const getStandardRow = (
+  index: number,
+  obj: SectionGeneratorRow,
+  fieldOnChange: (event: ChangeEvent<T>) => void,
+  selectOnChange: (
+    chosen:
+      | SingleValue<Record<string, unknown>>
+      | MultiValue<Record<string, unknown>>,
+    name: string
+  ) => void,
+  screenSize: ScreenSize
+) => {
+  return (
+    <Row {...obj} key={index}>
+      {obj.fields.map((field, groupedIndex) => {
+        return (
+          !field.hide &&
+          getComponent(
+            field,
+            groupedIndex,
+            fieldOnChange,
+            selectOnChange,
+            screenSize
+          )
+        );
+      })}
+    </Row>
+  );
+};

--- a/packages/page-generator/src/helpers/getStandardRow.tsx
+++ b/packages/page-generator/src/helpers/getStandardRow.tsx
@@ -21,10 +21,8 @@ const Row = (
         {props.children}
       </div>
     );
-  } else if (props.as === 'fragment') {
-    return <React.Fragment>{props.children}</React.Fragment>;
   } else {
-    return <></>;
+    return <React.Fragment>{props.children}</React.Fragment>;
   }
 };
 

--- a/packages/page-generator/src/helpers/index.ts
+++ b/packages/page-generator/src/helpers/index.ts
@@ -3,3 +3,4 @@ export * from './getButtonRow';
 export * from './getComponent';
 export * from './isMultiValue';
 export * from './isPageGeneratorRow';
+export * from './isSectionGeneratorRow';

--- a/packages/page-generator/src/helpers/isSectionGeneratorRow.tsx
+++ b/packages/page-generator/src/helpers/isSectionGeneratorRow.tsx
@@ -1,0 +1,7 @@
+import { PageGeneratorField, SectionGeneratorRow } from '../types';
+
+export const isSectionGeneratorRow = (
+  obj: PageGeneratorField | SectionGeneratorRow
+): obj is SectionGeneratorRow => {
+  return (obj as SectionGeneratorRow).rowType !== undefined;
+};

--- a/packages/page-generator/src/types/SectionGeneratorProps.tsx
+++ b/packages/page-generator/src/types/SectionGeneratorProps.tsx
@@ -1,12 +1,12 @@
 import { BaseComponentPropsWithChildren } from '@norges-domstoler/dds-components/dist/cjs/types';
 import { PageGeneratorField } from './PageGeneratorField';
-import { PageGeneratorRow } from './PageGeneratorRow';
+import { SectionGeneratorRow } from './SectionGeneratorRow';
 
 export type SectionGeneratorProps = BaseComponentPropsWithChildren<
   HTMLElement,
   {
     /** Definere liste med felt/komponenter og/eller rader med felt/komponenter */
-    fields: (PageGeneratorField | PageGeneratorRow)[];
+    fields: (PageGeneratorField | SectionGeneratorRow)[];
     /** For å hente ut state etter endringer */
     stateOnChange?: (newState: object) => void;
     /** Setter form, div eller fragment som wrapper-element */

--- a/packages/page-generator/src/types/SectionGeneratorRow.tsx
+++ b/packages/page-generator/src/types/SectionGeneratorRow.tsx
@@ -1,0 +1,10 @@
+import { ScreenSize } from '@norges-domstoler/dds-components';
+import { PageGeneratorField } from './PageGeneratorField';
+
+export type SectionGeneratorRow = {
+  rowType: 'button' | 'standard';
+  breakpoint?: ScreenSize;
+  fields: PageGeneratorField[];
+  hide?: boolean;
+  as?: 'div' | 'fragment';
+};

--- a/packages/page-generator/src/types/index.ts
+++ b/packages/page-generator/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './PageGeneratorRow';
 export * from './PageGeneratorState';
 export * from './PageGeneratorSupportedFields';
 export * from './SectionGeneratorProps';
+export * from './SectionGeneratorRow';


### PR DESCRIPTION
Legger til en ny type som brukes i SectionGenerator. Denne støtter property'en "as", som man kan definere som div-element eller fragment.