### PR TITLE
Ta i bruk npm package provenance

### DIFF
--- a/.changeset/rich-buttons-hope.md
+++ b/.changeset/rich-buttons-hope.md
@@ -1,0 +1,9 @@
+---
+"@norges-domstoler/development-utils": patch
+"@norges-domstoler/dds-page-generator": patch
+"@norges-domstoler/dds-components": patch
+"@norges-domstoler/dds-formatting": patch
+---
+
+Ta i bruk [npm package provenance](https://github.blog/2023-04-19-introducing-npm-package-provenance/).
+Dette gjør at konsumenter verifiserbart kan sjekke hvor pakkens innhold kommer fra.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -105,5 +105,8 @@
     "focus-visible": "^5.2.0",
     "react-select": "^5.6.0",
     "tslib": "^2.4.0"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/development-utils/package.json
+++ b/packages/development-utils/package.json
@@ -74,5 +74,8 @@
     "react": "^16 || ^17 || ^18",
     "react-dom": "^16 || ^17 || ^18",
     "styled-components": "^5"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/formatting/package.json
+++ b/packages/formatting/package.json
@@ -59,5 +59,8 @@
     "vite": "^4.1.4",
     "vite-plugin-dts": "^2.1.0",
     "vitest": "^0.29.1"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/page-generator/package.json
+++ b/packages/page-generator/package.json
@@ -86,5 +86,8 @@
     "react": "^16 || ^17 || ^18",
     "react-dom": "^16 || ^17 || ^18",
     "styled-components": "^5"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -48,5 +48,8 @@
     "rollup-plugin-typescript2": "^0.34.1",
     "style-dictionary": "^3.7.2",
     "typescript": "^5.0.2"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }


### PR DESCRIPTION
Dette gjør at konsumenter verifiserbart kan sjekke pakkens kilde.
Ref.: https://github.blog/2023-04-19-introducing-npm-package-provenance/