### PR TITLE
Legger til valgfri tooltip

### DIFF
--- a/.changeset/tame-emus-breathe.md
+++ b/.changeset/tame-emus-breathe.md
@@ -2,4 +2,4 @@
 "@norges-domstoler/dds-components": minor
 ---
 
-Legger til valgfri tooltip på Spinner-komponenten. Fjerner default tooltip-tekst: "Innlasting pågår".
+Legger til tooltip på Spinner-komponenten. Beholder samme default tooltip-tekst: "Innlasting pågår".

--- a/.changeset/tame-emus-breathe.md
+++ b/.changeset/tame-emus-breathe.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": minor
+---
+
+Legger til valgfri tooltip på Spinner-komponenten. Fjerner default tooltip-tekst: "Innlasting pågår".

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -21,6 +21,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       href,
       target,
       loading = false,
+      loadingTooltip = 'Lagring pågår',
       fullWidth = false,
       icon,
       onClick,
@@ -96,6 +97,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             <Spinner
               color={appearances[appearance].purpose[purpose].base.color}
               size={sizes[size].justIcon.icon.fontSize}
+              tooltip={loadingTooltip}
             />
           </StyledIconWrapperSpan>
         )}

--- a/packages/components/src/components/Button/Button.types.tsx
+++ b/packages/components/src/components/Button/Button.types.tsx
@@ -27,6 +27,8 @@ export type ButtonProps = BaseComponentProps<
     appearance?: ButtonAppearance;
     /**Indikerer en loading-knapp. */
     loading?: boolean;
+    /**Tooltip som vises ved loading. */
+    loadingTooltip?: string;
     /**Ikonet som ligger i knappen.  */
     icon?: SvgIcon;
     /**Knapp med full bredde. */

--- a/packages/components/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/components/src/components/Spinner/Spinner.stories.tsx
@@ -19,7 +19,7 @@ export const Overview = () => (
     gap="30px"
   >
     <Spinner />
-    <Spinner size="60px" />
+    <Spinner size="60px" tooltip="Egendefinert melding" />
     <Spinner color="gray4" />
     <Spinner color="gray4" size="60px" />
     <Spinner color="success" />

--- a/packages/components/src/components/Spinner/Spinner.tsx
+++ b/packages/components/src/components/Spinner/Spinner.tsx
@@ -64,6 +64,8 @@ export type SpinnerProps = BaseComponentProps<
     color?: TextColor | string;
     /**Størrelse; Setter høyde og bredde på spinneren. */
     size?: Property.Width<string>;
+    /**Tekst som vises ved hover. */
+    tooltip?: string;
   }
 >;
 
@@ -71,6 +73,7 @@ export function Spinner(props: SpinnerProps) {
   const {
     size = ddsBaseTokens.iconSizes.DdsIconsizeMedium,
     color = 'interactive',
+    tooltip = 'Innlasting pågår',
     id,
     className,
     htmlProps,
@@ -102,7 +105,7 @@ export function Spinner(props: SpinnerProps) {
       aria-labelledby={uniqueId}
       {...spinnerProps}
     >
-      <title id={uniqueId}>innlastning pågår</title>
+      {tooltip && <title id={uniqueId}>{tooltip}</title>}
       <Circle
         {...circleProps}
         cx="25"


### PR DESCRIPTION
`Spinner` brukes i forskjellige situasjoner der teksten "Innlasting pågår" ikke nødvendigvis passer som beskrivelse. Et eksempel er når `loading` er satt på `Button` ved f.eks. lagring av data. 

Legger til `tooltip`-prop på `Spinner` som kan sette en tooltip-tekst:

<img width="280" alt="Screenshot 2023-04-25 at 12 48 17" src="https://user-images.githubusercontent.com/8463735/234254816-648f1a23-5e2f-4b72-a470-1b8eb996e050.png">

For knapper default:

<img width="348" alt="Screenshot 2023-04-25 at 12 49 03" src="https://user-images.githubusercontent.com/8463735/234254875-dc19dde5-0397-49ff-afbe-185cfba19a7e.png">

PRen vil beholde samme default som det er i dag.