### PR TITLE
Gjør padding på LocalMessage mer konsistent på tvers av layouts

### DIFF
--- a/.changeset/loud-seahorses-yell.md
+++ b/.changeset/loud-seahorses-yell.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Gjør padding i LocalMessage mer konsistent på tvers av layouts

--- a/packages/components/src/components/LocalMessage/LocalMessage.stories.tsx
+++ b/packages/components/src/components/LocalMessage/LocalMessage.stories.tsx
@@ -7,7 +7,10 @@ export default {
   title: 'design system/LocalMessage',
   component: LocalMessage,
   argTypes: {
-    message: { control: { type: 'text' } },
+    message: {
+      control: { type: 'text' },
+      defaultValue: 'En tilfeldig melding',
+    },
     width: { control: { type: 'text' } },
     closable: { control: { type: 'boolean' } },
   },
@@ -16,71 +19,20 @@ export default {
 export const Overview = (args: LocalMessageProps) => {
   return (
     <StoryTemplate title="LocalMessage - overview">
-      <LocalMessage {...args} purpose="info" message="En tilfeldig melding" />
-      <LocalMessage
-        {...args}
-        purpose="warning"
-        message="En tilfeldig melding"
-      />
-      <LocalMessage {...args} purpose="danger" message="En tilfeldig melding" />
-      <LocalMessage
-        {...args}
-        purpose="confidential"
-        message="En tilfeldig melding"
-      />
-      <LocalMessage
-        {...args}
-        purpose="success"
-        message="En tilfeldig melding"
-      />
-      <LocalMessage {...args} purpose="tips" message="En tilfeldig melding" />
-      <LocalMessage
-        {...args}
-        message="En tilfeldig melding"
-        layout="vertical"
-      />
-      <LocalMessage
-        {...args}
-        purpose="info"
-        message="En tilfeldig melding"
-        closable
-      />
-      <LocalMessage
-        {...args}
-        purpose="warning"
-        message="En tilfeldig melding"
-        closable
-      />
-      <LocalMessage
-        {...args}
-        purpose="danger"
-        message="En tilfeldig melding"
-        closable
-      />
-      <LocalMessage
-        {...args}
-        purpose="confidential"
-        message="En tilfeldig melding"
-        closable
-      />
-      <LocalMessage
-        {...args}
-        purpose="success"
-        message="En tilfeldig melding"
-        closable
-      />
-      <LocalMessage
-        {...args}
-        purpose="tips"
-        message="En tilfeldig melding"
-        closable
-      />
-      <LocalMessage
-        {...args}
-        message="En tilfeldig melding"
-        layout="vertical"
-        closable
-      />
+      <LocalMessage {...args} purpose="info" />
+      <LocalMessage {...args} purpose="warning" />
+      <LocalMessage {...args} purpose="danger" />
+      <LocalMessage {...args} purpose="confidential" />
+      <LocalMessage {...args} purpose="success" />
+      <LocalMessage {...args} purpose="tips" />
+      <LocalMessage {...args} layout="vertical" />
+      <LocalMessage {...args} purpose="info" closable />
+      <LocalMessage {...args} purpose="warning" closable />
+      <LocalMessage {...args} purpose="danger" closable />
+      <LocalMessage {...args} purpose="confidential" closable />
+      <LocalMessage {...args} purpose="success" closable />
+      <LocalMessage {...args} purpose="tips" closable />
+      <LocalMessage {...args} layout="vertical" closable />
     </StoryTemplate>
   );
 };
@@ -88,10 +40,7 @@ export const Overview = (args: LocalMessageProps) => {
 export const Default = (args: LocalMessageProps) => {
   return (
     <StoryTemplate title="LocalMessage - default">
-      <LocalMessage
-        {...args}
-        message={args.message || 'En tilfeldig melding'}
-      />
+      <LocalMessage {...args} message={args.message} />
     </StoryTemplate>
   );
 };
@@ -102,7 +51,7 @@ export const Closable = (args: LocalMessageProps) => {
       <LocalMessage
         {...args}
         purpose={args.purpose}
-        message={args.message || 'En tilfeldig melding'}
+        message={args.message}
         closable
       />
     </StoryTemplate>

--- a/packages/components/src/components/LocalMessage/LocalMessage.tokens.tsx
+++ b/packages/components/src/components/LocalMessage/LocalMessage.tokens.tsx
@@ -20,7 +20,8 @@ const container = {
     boxShadow: outerShadow.DdsShadow1Onlight,
     borderRadius: borderRadius.RadiiDdsBorderRadius1Radius,
     border: `${border.BordersDdsBorderStyleLightStrokeWeight} solid`,
-    padding: `0 ${spacing.SizesDdsSpacingLocalX1}`,
+    padding: spacing.SizesDdsSpacingLocalX075,
+    gap: spacing.SizesDdsSpacingLocalX05,
   },
   purpose: {
     info: {
@@ -50,7 +51,7 @@ const container = {
   },
 };
 
-export const purposeVariants: {
+const purposeVariants: {
   [k in LocalMessagePurpose]: {
     icon: SvgIcon;
     closeButtonPurpose: ButtonPurpose;
@@ -104,28 +105,8 @@ const icon = {
   },
 };
 
-const contentContainer = {
-  paddingRight: spacing.SizesDdsSpacingLocalX15,
-  paddingTop: spacing.SizesDdsSpacingLocalX075,
-  paddingBottom: spacing.SizesDdsSpacingLocalX075,
-  withClosable: {
-    paddingRight: spacing.SizesDdsSpacingLocalX075,
-  },
-  vertical: {
-    paddingBottom: spacing.SizesDdsSpacingLocalX15,
-  },
-};
-
-const topContainer = {
-  paddingTop: spacing.SizesDdsSpacingLocalX15,
-  withClosable: {
-    paddingTop: spacing.SizesDdsSpacingLocalX1,
-  },
-};
-
 export const localMessageTokens = {
   container,
-  contentContainer,
-  topContainer,
+  purposeVariants,
   icon,
 };


### PR DESCRIPTION
Dette gjør at vertikal og horisontal `LocalMessage` har mer konsistent padding.

## Før
![Screenshot 2023-04-25 at 2 12 39 PM](https://user-images.githubusercontent.com/25374940/234277627-c467f2d2-c254-4390-a47c-396048609c2f.png)

## Etter
![Screenshot 2023-04-25 at 2 12 47 PM](https://user-images.githubusercontent.com/25374940/234277638-aea3ec5c-0a46-407a-bb03-656b4b15de92.png)

