### PR TITLE
Fikser størrelse på Select med isMulti

### DIFF
--- a/packages/components/src/components/Select/Select.styles.ts
+++ b/packages/components/src/components/Select/Select.styles.ts
@@ -29,10 +29,18 @@ const {
   placeholder,
   icon,
   valueContainer,
-  inputContainer,
 } = tokens;
 
 export const prefix = 'dds-select';
+
+function getContainerControlPadding(
+  componentSize: InputSize,
+  isMulti: boolean | undefined
+) {
+  return isMulti
+    ? control.isMulti.sizes[componentSize].padding
+    : control.sizes[componentSize].padding;
+}
 
 type StyledContainerProps = {
   errorMessage?: string;
@@ -54,11 +62,7 @@ export const Container = styled.div<StyledContainerProps>`
 
   ${({ componentSize, isMulti }) => css`
     .${prefix}__control {
-      padding: ${isMulti && componentSize === 'tiny'
-        ? control.sizes.small.padding
-        : isMulti && componentSize !== 'tiny'
-        ? control.isMulti.sizes[componentSize].padding
-        : control.sizes[componentSize].padding};
+      padding: ${getContainerControlPadding(componentSize, isMulti)};
       ${getFontStyling(typographyTypes.control[componentSize], true)}
     }
     .${prefix}__option {
@@ -158,13 +162,10 @@ export const getCustomStyles = <TOption>(): Partial<
     color: placeholder.color,
     margin: 0,
   }),
-  input: (provided, state) => ({
+  input: provided => ({
     ...provided,
     margin: 0,
     padding: 0,
-    ...(state.isMulti && {
-      minHeight: inputContainer.isMulti.minHeight,
-    }),
   }),
   indicatorSeparator: () => ({}),
   dropdownIndicator: (provided, state) => ({

--- a/packages/components/src/components/Select/Select.tokens.tsx
+++ b/packages/components/src/components/Select/Select.tokens.tsx
@@ -7,10 +7,9 @@ import {
   inputTypographyTypes,
   InputTypographyTypes,
 } from '../../helpers';
-import { calculateHeightWithLineHeight } from '../../utils';
 import { StaticTypographyType } from '../Typography';
 
-const { colors, spacing, fontPackages, borderRadius, border } = ddsBaseTokens;
+const { colors, spacing, borderRadius, border } = ddsBaseTokens;
 
 const { textDefault } = ddsReferenceTokens;
 
@@ -36,21 +35,6 @@ export const typographyTypes: {
   multiValueLabel: 'bodySans01',
 };
 
-//custom spacing so that multiselect has same height as single value select
-const controlPaddingBottomMultiMedium = `${
-  spacing.SizesDdsSpacingLocalX075NumberPx - 1
-}px`;
-const controlPaddingBottomMultiSmall = `${
-  spacing.SizesDdsSpacingLocalX05NumberPx - 1
-}px`;
-const inputContainerMinHeightMulti = `${
-  spacing.SizesDdsSpacingLocalX0125NumberPx * 2 +
-  calculateHeightWithLineHeight(
-    fontPackages.body_sans_01.numbers.lineHeightNumber,
-    fontPackages.body_sans_01.numbers.fontSizeNumber
-  )
-}px`;
-
 const control = {
   borderRadius: borderRadius.RadiiDdsBorderRadius1Radius,
   border: `${border.BordersDdsBorderStyleLightStrokeWeight} solid`,
@@ -68,10 +52,13 @@ const control = {
   isMulti: {
     sizes: {
       medium: {
-        padding: `${spacing.SizesDdsSpacingLocalX075} ${spacing.SizesDdsSpacingLocalX05} ${controlPaddingBottomMultiMedium} ${spacing.SizesDdsSpacingLocalX075}`,
+        padding: `${spacing.SizesDdsSpacingLocalX075} ${spacing.SizesDdsSpacingLocalX05} ${spacing.SizesDdsSpacingLocalX075} ${spacing.SizesDdsSpacingLocalX075}`,
       },
       small: {
-        padding: `${spacing.SizesDdsSpacingLocalX05} ${spacing.SizesDdsSpacingLocalX05} ${controlPaddingBottomMultiSmall} ${spacing.SizesDdsSpacingLocalX075}`,
+        padding: `${spacing.SizesDdsSpacingLocalX05} ${spacing.SizesDdsSpacingLocalX05} ${spacing.SizesDdsSpacingLocalX05} ${spacing.SizesDdsSpacingLocalX075}`,
+      },
+      tiny: {
+        padding: `${spacing.SizesDdsSpacingLocalX025} ${spacing.SizesDdsSpacingLocalX05}`,
       },
     },
   },
@@ -159,14 +146,14 @@ const multiValue = {
 };
 
 const multiValueLabel = {
-  padding: `${spacing.SizesDdsSpacingLocalX0125} ${spacing.SizesDdsSpacingLocalX025}`,
+  padding: `0 ${spacing.SizesDdsSpacingLocalX025}`,
   color: colors.DdsColorNeutralsGray9,
 };
 
 const multiValueRemove = {
   base: {
     color: colors.DdsColorNeutralsGray9,
-    padding: spacing.SizesDdsSpacingLocalX025,
+    padding: `0 ${spacing.SizesDdsSpacingLocalX025}`,
     borderTopRightRadius: borderRadius.RadiiDdsBorderRadius1Radius,
     borderBottomRightRadius: borderRadius.RadiiDdsBorderRadius1Radius,
   },
@@ -183,12 +170,6 @@ const valueContainer = {
   },
 };
 
-const inputContainer = {
-  isMulti: {
-    minHeight: inputContainerMinHeightMulti,
-  },
-};
-
 const icon = {
   marginRight: spacing.SizesDdsSpacingLocalX05,
 };
@@ -201,7 +182,6 @@ export const selectTokens = {
   groupHeading,
   option,
   valueContainer,
-  inputContainer,
   multiValue,
   multiValueLabel,
   multiValueRemove,


### PR DESCRIPTION
For component size small var multi select 3px større enn andre form elementer, inkludert single select

Endrer på størrelser for å få samsvar på tvers av komponentstørrelser

#### Før: Component size = `small`

<img width="700" alt="Screenshot 2023-05-04 at 16 25 17" src="https://user-images.githubusercontent.com/9928210/236237842-840cc7c5-309a-487e-aa70-47e5e5e037be.png">

https://user-images.githubusercontent.com/9928210/236238083-8e2164cf-8a5e-4217-82de-adfa6c43af5e.mov


#### Etter: Component size = `small`

<img width="700" alt="Screenshot 2023-05-04 at 16 26 08" src="https://user-images.githubusercontent.com/9928210/236237888-abbefefc-8ddf-478b-aa63-e02632870f58.png">

https://user-images.githubusercontent.com/9928210/236238284-498ff842-79f7-4fb3-9ecb-14769865252c.mov

#### Etter: Component size = `medium`
https://user-images.githubusercontent.com/9928210/236238189-8ab28384-86f9-4f91-b55d-85541ddfae12.mov



