### PR TITLE
Fjerner overstyring av fontstørrelse for DescriptionList

### DIFF
--- a/.changeset/heavy-nails-melt.md
+++ b/.changeset/heavy-nails-melt.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Fjerner overstyring av fontstørrelse for DescriptionList

--- a/packages/components/src/components/DescriptionList/DescriptionList.tokens.tsx
+++ b/packages/components/src/components/DescriptionList/DescriptionList.tokens.tsx
@@ -1,17 +1,6 @@
 import { ddsBaseTokens } from '@norges-domstoler/dds-design-tokens';
-import { StaticTypographyType } from '../Typography';
-import { DescriptionListAppearance } from './DescriptionList';
 
 const { spacing, colors } = ddsBaseTokens;
-
-export const termTypographyTypes: {
-  [k in DescriptionListAppearance]: StaticTypographyType;
-} = {
-  bold: 'bodySans03',
-  small: 'bodySans01',
-};
-
-export const descTypographyType: StaticTypographyType = 'bodySans03';
 
 const term = {
   appearance: {

--- a/packages/components/src/components/DescriptionList/DescriptionList.tsx
+++ b/packages/components/src/components/DescriptionList/DescriptionList.tsx
@@ -2,11 +2,7 @@ import { forwardRef } from 'react';
 import styled, { css } from 'styled-components';
 import { selection } from '../../helpers/styling';
 import { BaseComponentPropsWithChildren, getBaseHTMLProps } from '../../types';
-import { getFontStyling } from '../Typography/Typography.utils';
-import {
-  descriptionListTokens as tokens,
-  termTypographyTypes,
-} from './DescriptionList.tokens';
+import { descriptionListTokens as tokens } from './DescriptionList.tokens';
 
 const { term, desc, list } = tokens;
 
@@ -22,7 +18,6 @@ const DList = styled.dl<DListProps>`
     css`
       dt {
         color: ${term.appearance[appearance].color};
-        ${getFontStyling(termTypographyTypes[appearance])}
         ${appearance === 'bold' &&
         css`
           font-weight: 600;

--- a/packages/components/src/components/DescriptionList/DescriptionListDesc.tsx
+++ b/packages/components/src/components/DescriptionList/DescriptionListDesc.tsx
@@ -1,20 +1,15 @@
 import { forwardRef } from 'react';
 import styled from 'styled-components';
-import {
-  descriptionListTokens as tokens,
-  descTypographyType,
-} from './DescriptionList.tokens';
+import { descriptionListTokens as tokens } from './DescriptionList.tokens';
 import { Icon } from '../Icon';
 import { BaseComponentPropsWithChildren, getBaseHTMLProps } from '../../types';
 import { SvgIcon } from '../../icons/utils';
-import { getFontStyling } from '../Typography/Typography.utils';
 
 const DListDesc = styled.dd`
   margin-inline-start: 0;
   align-items: center;
   display: flex;
   color: ${tokens.desc.base.color};
-  ${getFontStyling(descTypographyType)}
   gap: ${tokens.desc.base.gap};
 `;
 


### PR DESCRIPTION
Etter diskusjon med Marianne fjernes overstyring av fontstørrelse for DescriptionList. Appearance styrer dermed kun om teksten i header er bold eller tynn. All tekststørrelse styres av body-fontsize.

Før: 
<img width="414" alt="image" src="https://user-images.githubusercontent.com/397559/236782751-ffc850d5-650a-42e6-a07a-9f247e881216.png">

Etter: 
<img width="357" alt="image" src="https://user-images.githubusercontent.com/397559/236782786-bd975486-e1fd-4764-99f8-9e6bc993e38d.png">
