### PR TITLE
Endre til PascalCase i changeset for ikoner

### DIFF
--- a/.changeset/khaki-houses-fly.md
+++ b/.changeset/khaki-houses-fly.md
@@ -4,13 +4,13 @@
 
 Lagt inn nye ikoner
 
-- starHalfFilled
-- thumbup
-- thumbupFilled
-- thumbdown
-- thumbdownFilled
-- hourglassTop
-- hourglassBottom
-- hourglassFull
-- hourglassEmpty
-- hourglassDisabled
+- StarHalfFilled
+- Thumbup
+- ThumbupFilled
+- Thumbdown
+- ThumbdownFilled
+- HourglassTop
+- HourglassBottom
+- HourglassFull
+- HourglassEmpty
+- HourglassDisabled


### PR DESCRIPTION
Siden React-komponentene er i PascalCase, så burde changeset også referere til de som PascalCase