### PR TITLE
ELSA1-188 Småfikser feedback-komponent

### DIFF
--- a/packages/components/src/components/Feedback/CommentComponent.tsx
+++ b/packages/components/src/components/Feedback/CommentComponent.tsx
@@ -19,6 +19,7 @@ type CommentComponentType = {
   feedbackText: string | undefined;
   positiveFeedbackLabel: string;
   negativeFeedbackLabel: string;
+  ratingSubmittedTitle: string;
   loading: boolean;
   handleSubmit: () => void;
   handleFeedbackTextChange: (newText: string) => void;
@@ -29,6 +30,7 @@ export const CommentComponent = ({
   feedbackText,
   positiveFeedbackLabel,
   negativeFeedbackLabel,
+  ratingSubmittedTitle,
   loading,
   handleSubmit,
   handleFeedbackTextChange,
@@ -40,9 +42,7 @@ export const CommentComponent = ({
           icon={rating === 'positive' ? ThumbupFilled : ThumbdownFilled}
           color={ddsBaseTokens.colors.DdsColorInteractiveBase}
         />
-        <Paragraph>
-          Tusen takk! Tilbakemeldingen din hjelper oss å forbedre løsningen
-        </Paragraph>
+        <Paragraph>{ratingSubmittedTitle} </Paragraph>
       </IconLabelSpan>
       <TextArea
         value={feedbackText}

--- a/packages/components/src/components/Feedback/Feedback.tsx
+++ b/packages/components/src/components/Feedback/Feedback.tsx
@@ -9,6 +9,8 @@ export const Feedback = ({
   ratingLabel = 'Hva syns du om tjenesten?',
   positiveFeedbackLabel = 'Hva kan vi forbedre? (valgfritt)',
   negativeFeedbackLabel = 'Hva kan vi forbedre? (valgfritt)',
+  ratingSubmittedTitle = 'Tusen takk! Tilbakemeldingen din hjelper oss å forbedre løsningen',
+  submittedTitle = 'Tusen takk! Tilbakemeldingen din hjelper oss å forbedre løsningen',
   ratingValue: ratingProp,
   feedbackTextValue: feedbackTextProp,
   thumbUpTooltip = 'Bra',
@@ -75,6 +77,7 @@ export const Feedback = ({
         feedbackText={feedbackText}
         positiveFeedbackLabel={positiveFeedbackLabel}
         negativeFeedbackLabel={negativeFeedbackLabel}
+        ratingSubmittedTitle={ratingSubmittedTitle}
         loading={loading}
         handleSubmit={handleSubmit}
         handleFeedbackTextChange={handleFeedbackTextChange}
@@ -82,9 +85,5 @@ export const Feedback = ({
     );
   }
 
-  return (
-    <Paragraph>
-      Tusen takk! Tilbakemeldingen din hjelper oss å forbedre løsningen
-    </Paragraph>
-  );
+  return <Paragraph>{submittedTitle}</Paragraph>;
 };

--- a/packages/components/src/components/Feedback/Feedback.types.tsx
+++ b/packages/components/src/components/Feedback/Feedback.types.tsx
@@ -7,6 +7,10 @@ export type FeedbackProps = {
   positiveFeedbackLabel?: string;
   /**Label til fritekstfeltet når bruker har gitt tommel ned */
   negativeFeedbackLabel?: string;
+  /**Tittel som vises når bruker har gitt tommel opp/ned, og enda ikke sendt inn kommentar */
+  ratingSubmittedTitle?: string;
+  /**Tittel som vises når bruker har gitt feedback (inkl. eventuell kommentar) */
+  submittedTitle?: string;
   /**Om tommel opp eller ned er valgt. Brukes når komponenten skal være styrt utenfra. */
   ratingValue?: Rating | null;
   /**Verdien til fritekstfeltet. Brukes når komponenten skal være styrt utenfra. */

--- a/packages/components/src/components/Feedback/RatingComponent.tsx
+++ b/packages/components/src/components/Feedback/RatingComponent.tsx
@@ -17,7 +17,7 @@ const RatingContainer = styled.div<RatingContainerProps>`
   gap: ${ddsBaseTokens.spacing.SizesDdsSpacingLocalX1};
   ${({ layout }) => css`
     flex-direction: ${layout === 'horizontal' ? 'row' : 'column'};
-    align-items: center;
+    align-items: ${layout === 'horizontal' ? 'center' : 'start'};
   `}
 `;
 


### PR DESCRIPTION
- Det er nå mulig å sette tittelen som vises når tommel opp/ned er gitt og når "fullstending" feedback (inkl. eventuell kommentar) er gitt, via props
<img width="471" alt="image" src="https://github.com/domstolene/designsystem/assets/37186014/71d2dfe7-48b4-4a94-8e2d-e65a16d7fdb0">
<img width="411" alt="image" src="https://github.com/domstolene/designsystem/assets/37186014/eb7ac060-e23d-469c-9bc6-9a34233f5afd">


- Når ratingLayout er vertikal, er tommelknappene nå venstrestilt:
<img width="282" alt="image" src="https://github.com/domstolene/designsystem/assets/37186014/992c758a-b879-462d-a164-32a60ff72b6b">
