### PR TITLE
Gjør internpakker offentlig.

### DIFF
--- a/.changeset/stupid-crabs-eat.md
+++ b/.changeset/stupid-crabs-eat.md
@@ -1,0 +1,8 @@
+---
+"@norges-domstoler/dds-typography": patch
+"@norges-domstoler/dds-icons": patch
+"@norges-domstoler/dds-core": patch
+"@norges-domstoler/dds-form": patch
+---
+
+Publiser internpakker. Ikke meningen å ta disse i bruk av eksterne enda.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22412,7 +22412,7 @@
     },
     "packages/components": {
       "name": "@norges-domstoler/dds-components",
-      "version": "13.6.0",
+      "version": "13.6.1",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^1.3.0",
@@ -22498,7 +22498,7 @@
     },
     "packages/core": {
       "name": "@norges-domstoler/dds-core",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "devDependencies": {
         "@norges-domstoler/dds-design-tokens": "*",
@@ -22806,7 +22806,7 @@
     },
     "packages/form": {
       "name": "@norges-domstoler/dds-form",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@norges-domstoler/dds-core": "*",
@@ -23233,7 +23233,7 @@
     },
     "packages/icons": {
       "name": "@norges-domstoler/dds-icons",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@norges-domstoler/dds-core": "*"
@@ -23659,7 +23659,7 @@
     },
     "packages/typography": {
       "name": "@norges-domstoler/dds-typography",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
         "@norges-domstoler/dds-core": "*",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@norges-domstoler/dds-core",
-  "private": true,
   "version": "0.0.1",
   "description": "Base components/styles and other helpers used in Elsa - domstolenes designsystem",
   "author": "Elsa team",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@norges-domstoler/dds-form",
-  "private": true,
   "version": "0.0.1",
   "description": "Base components/styles and other helpers used in Elsa - domstolenes designsystem",
   "author": "Elsa team",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@norges-domstoler/dds-icons",
-  "private": true,
   "version": "0.0.1",
   "description": "Icons used in Elsa - domstolenes designsystem",
   "author": "Elsa team",

--- a/packages/typography/package.json
+++ b/packages/typography/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@norges-domstoler/dds-typography",
-  "private": true,
   "version": "0.0.1",
   "description": "Typography components and styles used in Elsa - domstolenes designsystem",
   "author": "Elsa team",


### PR DESCRIPTION
Ikke helt optimalt, men det kreves for å kunne depende på de av andre pakker i komponentbiblioteket som skal publiseres