### PR TITLE
Revert "eksportere typer fra subpakker igjen"

### DIFF
--- a/.changeset/fluffy-jobs-greet.md
+++ b/.changeset/fluffy-jobs-greet.md
@@ -1,5 +1,0 @@
----
-"@norges-domstoler/dds-components": patch
----
-
-Eksporter typer fra sub-pakker

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,14 +1,7 @@
 export * from '@norges-domstoler/dds-core';
-export type * from '@norges-domstoler/dds-core';
-
 export * from '@norges-domstoler/dds-form';
-export type * from '@norges-domstoler/dds-form';
-
 export * from '@norges-domstoler/dds-icons';
-export type * from '@norges-domstoler/dds-icons';
-
 export * from '@norges-domstoler/dds-typography';
-export type * from '@norges-domstoler/dds-typography';
 
 export * from './components/AppShell';
 export * from './components/SelectionControl/RadioButton';


### PR DESCRIPTION
Reverts domstolene/designsystem#900

Problemet var at dds-icons pakken ikke bygde dts