### PR TITLE
ELSA1-274 fiks bug hvor første popover åpning scroller til toppen

### DIFF
--- a/.changeset/twelve-dodos-dance.md
+++ b/.changeset/twelve-dodos-dance.md
@@ -1,5 +1,5 @@
 ---
-'@norges-domstoler/dds-components': minor
+'@norges-domstoler/dds-components': patch
 ---
 
 Fikser bug hvor åpning av popover førte til av vinduet ble scrollet til toppen av siden.

--- a/.changeset/twelve-dodos-dance.md
+++ b/.changeset/twelve-dodos-dance.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Fikser bug hvor åpning av popover førte til av vinduet ble scrollet til toppen av siden.

--- a/packages/components/src/components/Popover/Popover.stories.tsx
+++ b/packages/components/src/components/Popover/Popover.stories.tsx
@@ -74,6 +74,19 @@ export const ContentOverview = (args: PopoverProps) => {
           </Popover>
         </PopoverGroup>
       </div>
+      <div style={{marginTop: "100vh"}}>
+        <PopoverGroup>
+          <Button>Åpne</Button>
+          <Popover {...args}>
+            <div style={{ display: 'flex', flexDirection: 'column' }}>
+              <Typography withMargins>
+                Dette er en popover lengre nede på siden som ikke scroller deg opp
+              </Typography>
+              <Button>Klikk</Button>
+            </div>
+          </Popover>
+        </PopoverGroup>
+      </div>
     </StoryTemplate>
   );
 };

--- a/packages/components/src/components/Popover/Popover.stories.tsx
+++ b/packages/components/src/components/Popover/Popover.stories.tsx
@@ -74,19 +74,6 @@ export const ContentOverview = (args: PopoverProps) => {
           </Popover>
         </PopoverGroup>
       </div>
-      <div style={{marginTop: "100vh"}}>
-        <PopoverGroup>
-          <Button>Åpne</Button>
-          <Popover {...args}>
-            <div style={{ display: 'flex', flexDirection: 'column' }}>
-              <Typography withMargins>
-                Dette er en popover lengre nede på siden som ikke scroller deg opp
-              </Typography>
-              <Button>Klikk</Button>
-            </div>
-          </Popover>
-        </PopoverGroup>
-      </div>
     </StoryTemplate>
   );
 };

--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -132,9 +132,17 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       htmlProps = {},
       ...rest
     } = props;
+    const hasTransitionedIn = useMountTransition(isOpen, 400);
 
-    const popoverRef = useReturnFocusOnBlur(
-      isOpen,
+    const { refs, styles } = useFloatPosition(null, {
+      placement,
+      offset,
+    });
+     // Use position from anchor element for the popover
+     refs.setReference(anchorElement || null);
+
+     const popoverRef = useReturnFocusOnBlur(
+      isOpen && hasTransitionedIn,
       () => {
         onClose && onClose();
         onBlur && onBlur();
@@ -142,17 +150,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       anchorElement && anchorElement,
     );
 
-    const { refs, styles } = useFloatPosition(null, {
-      placement,
-      offset,
-    });
-    const multiRef = useCombinedRef(ref, popoverRef, refs.setFloating);
-
-    useEffect(() => {
-      anchorElement
-        ? refs.setReference(anchorElement)
-        : refs.setReference(null);
-    }, [anchorElement]);
+     const multiRef = useCombinedRef(ref, popoverRef, refs.setFloating);
 
     const elements: (HTMLElement | null)[] = [popoverRef.current!];
     if (anchorElement) elements.push(anchorElement);
@@ -161,7 +159,6 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       if (isOpen) onClose && onClose();
     });
 
-    const hasTransitionedIn = useMountTransition(isOpen, 400);
 
     return isOpen || hasTransitionedIn ? (
       <Wrapper

--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -138,10 +138,10 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       placement,
       offset,
     });
-     // Use position from anchor element for the popover
-     refs.setReference(anchorElement || null);
+    // Use position from anchor element for the popover
+    refs.setReference(anchorElement || null);
 
-     const popoverRef = useReturnFocusOnBlur(
+    const popoverRef = useReturnFocusOnBlur(
       isOpen && hasTransitionedIn,
       () => {
         onClose && onClose();
@@ -150,7 +150,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       anchorElement && anchorElement,
     );
 
-     const multiRef = useCombinedRef(ref, popoverRef, refs.setFloating);
+    const multiRef = useCombinedRef(ref, popoverRef, refs.setFloating);
 
     const elements: (HTMLElement | null)[] = [popoverRef.current!];
     if (anchorElement) elements.push(anchorElement);

--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -159,7 +159,6 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
       if (isOpen) onClose && onClose();
     });
 
-
     return isOpen || hasTransitionedIn ? (
       <Wrapper
         {...getBaseHTMLProps(id, className, htmlProps, rest)}


### PR DESCRIPTION
Rearrangerer rekkefølgen på kalkulasjoner, samt dropper en useEffect som krevde rerender for å bli rett.