### PR TITLE
ELSA1-295 legge til nye transformeringsfunksjoner for DatePicker

### DIFF
--- a/.changeset/eight-poems-share.md
+++ b/.changeset/eight-poems-share.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Legger til util-funksjonene `nativeDateToCalendarDate`, `nativeDateToTime` og `calendarDateToNativeDate` for å løse problemer folk hadde med transformeringsfunksjonene som kom ut sammen med den nye `DatePicker`-en. De andre funksjonene ga `DateValue`, som ikke er støttet av `DatePicker`. Den krever `CalendarDate` som `value`.

--- a/packages/components/src/components/date-inputs/DatePicker/DatePicker.mdx
+++ b/packages/components/src/components/date-inputs/DatePicker/DatePicker.mdx
@@ -55,8 +55,8 @@ Om du derimot allikevel skulle ha behov for å bruke native JS Date, så har vi 
 
 <Source
   code={`
-function nativeDateToDateValue(date: Date, timeZone: string | undefined = 'Europe/Oslo'): DateValue;
-function dateValueToNativeDate(date: DateValue, timeZone: string | undefined = 'Europe/Oslo'): Date;
+function nativeDateToCalendarDate(date: Date): CalendarDate;
+function calendarDateToNativeDate(date: CalendarDate, time?: Time): Date;
 `}
 />
 
@@ -64,14 +64,14 @@ function dateValueToNativeDate(date: DateValue, timeZone: string | undefined = '
 
 <Source code={`
 import { useState } from 'react';
-import { DatePicker, nativeDateToDateValue, dateValueToNativeDate } from '@norges-domstoler/dds-datepicker';
+import { DatePicker, nativeDateToCalendarDate, calendarDateToNativeDate } from '@norges-domstoler/dds-datepicker';
 
 const [value, setValue] = useState<Date>(new Date());
 
 <DatePicker
   label="Velg dato"
-  value={nativeDateToDateValue(value)}
-  onChange={d => dateValueToNativeDate(setValue)}
+  value={nativeDateToCalendarDate(value)}
+  onChange={d => setValue(calendarDateToNativeDate(d))}
 />
 `}/>
 

--- a/packages/components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
@@ -15,6 +15,10 @@ import { Modal } from '../../Modal';
 import { HStack, VStack } from '../../Stack';
 import { TimePicker } from '../TimePicker';
 import { Paragraph } from '../../Typography';
+import {
+  calendarDateToNativeDate,
+  nativeDateToCalendarDate,
+} from '../utils/transform';
 
 const meta: Meta<typeof DatePicker> = {
   title: 'dds-components/DatePicker',
@@ -193,5 +197,15 @@ export const DateAndTime = () => {
         {norwegianDateFormatter.format(dateTime.toDate('Europe/Oslo'))}
       </Paragraph>
     </StoryTemplate>
+  );
+};
+
+export const NativeDate = () => {
+  const [date, setDate] = useState<Date>(new Date());
+  return (
+    <DatePicker
+      value={nativeDateToCalendarDate(date)}
+      onChange={d => setDate(calendarDateToNativeDate(d))}
+    />
   );
 };

--- a/packages/components/src/components/date-inputs/index.ts
+++ b/packages/components/src/components/date-inputs/index.ts
@@ -4,4 +4,7 @@ export { TimePicker, type TimePickerProps } from './TimePicker';
 export {
   dateValueToNativeDate,
   nativeDateToDateValue,
+  calendarDateToNativeDate,
+  nativeDateToCalendarDate,
+  nativeDateToTime,
 } from './utils/transform';

--- a/packages/components/src/components/date-inputs/utils/transform.ts
+++ b/packages/components/src/components/date-inputs/utils/transform.ts
@@ -1,4 +1,9 @@
-import { DateValue, fromDate } from '@internationalized/date';
+import {
+  CalendarDate,
+  DateValue,
+  Time,
+  fromDate,
+} from '@internationalized/date';
 
 export function nativeDateToDateValue(
   date: Date,
@@ -12,4 +17,30 @@ export function dateValueToNativeDate(
   timeZone: string | undefined = 'Europe/Oslo',
 ): Date {
   return date.toDate(timeZone);
+}
+
+export function nativeDateToCalendarDate(date: Date): CalendarDate {
+  return new CalendarDate(
+    date.getFullYear(),
+    date.getMonth() + 1,
+    date.getDate(),
+  );
+}
+
+export function nativeDateToTime(date: Date): Time {
+  return new Time(date.getHours(), date.getMinutes(), date.getSeconds());
+}
+
+export function calendarDateToNativeDate(
+  date: CalendarDate,
+  time: Time = new Time(12, 0, 0, 0),
+): Date {
+  return new Date(
+    date.year,
+    date.month - 1,
+    date.day,
+    time.hour,
+    time.minute,
+    time.second,
+  );
 }


### PR DESCRIPTION
Transformeringsfunksjonene som allerede var der passet ikke lenger til `DatePicker`-en etter at vi fjernet muligheten for at `value` kunne være en generisk `DateValue`.