### PR TITLE
ELSA1-297 fikse `<DatePicker>` høyde feil

### DIFF
--- a/.changeset/nine-panthers-beg.md
+++ b/.changeset/nine-panthers-beg.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Fikset en styling feil som gjorde at `<DatePicker>` med label var `1px` lavere enn `<TextInput>`.

--- a/packages/components/src/components/InlineEdit/InlineInput.tsx
+++ b/packages/components/src/components/InlineEdit/InlineInput.tsx
@@ -46,7 +46,7 @@ export const InlineInput = forwardRef<HTMLInputElement, InlineInputProps>(
     const combinedRef = useCombinedRef(ref, inputRef);
 
     return (
-      <OuterInputContainer width={width}>
+      <OuterInputContainer $width={width}>
         <InputContainer>
           {!isEditing && !hideIcon && (
             <IconWrapper

--- a/packages/components/src/components/InlineEdit/InlineTextArea.tsx
+++ b/packages/components/src/components/InlineEdit/InlineTextArea.tsx
@@ -46,7 +46,7 @@ export const InlineTextArea = forwardRef<
   const combinedRef = useCombinedRef(ref, inputRef);
 
   return (
-    <OuterInputContainer width={width}>
+    <OuterInputContainer $width={width}>
       <InputContainer>
         {!isEditing && !hideIcon && (
           <IconWrapper

--- a/packages/components/src/components/TextArea/TextArea.tsx
+++ b/packages/components/src/components/TextArea/TextArea.tsx
@@ -88,7 +88,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     const showRequiredStyling = required || !!ariaRequired;
 
     const containerProps = {
-      width,
+      $width: width,
       className,
       style,
     };

--- a/packages/components/src/components/TextInput/TextInput.tsx
+++ b/packages/components/src/components/TextInput/TextInput.tsx
@@ -180,7 +180,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     const outerInputContainerProps = {
       className,
       style,
-      width: getWidth(componentSize, width),
+      $width: getWidth(componentSize, width),
     };
 
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/packages/components/src/components/date-inputs/DatePicker/CalendarPopover.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/CalendarPopover.tsx
@@ -59,9 +59,7 @@ export const CalendarPopover = ({
  * CalendarPopoverAnchor
  *------------------------------------------------------------------------*/
 
-const Anchor = styled.div`
-  display: inline-flex;
-`;
+const Anchor = styled.div``;
 
 interface CalendarPopoverAnchorProps {
   children: ReactElement;

--- a/packages/components/src/components/date-inputs/DatePicker/DateField/DateField.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/DateField/DateField.tsx
@@ -10,7 +10,13 @@ import {
 } from '@react-aria/datepicker';
 import { useDateFieldState } from '@react-stately/datepicker';
 import type * as CSS from 'csstype';
-import { forwardRef, useRef } from 'react';
+import {
+  type ForwardRefExoticComponent,
+  type Ref,
+  type RefAttributes,
+  forwardRef,
+  useRef,
+} from 'react';
 
 import { CalendarButton } from './CalendarButton';
 import { DateSegment } from './DateSegment';
@@ -22,6 +28,7 @@ export type DateFieldProps<T extends DateValue = CalendarDate> =
   AriaDateFieldOptions<T> & {
     className?: string;
     buttonProps?: ReturnType<typeof useDatePicker>['buttonProps'];
+    groupProps?: ReturnType<typeof useDatePicker>['groupProps'];
     /**
      * For å sette en egendefinert bredde på komponenten.
      */
@@ -31,52 +38,63 @@ export type DateFieldProps<T extends DateValue = CalendarDate> =
       'componentSize' | 'errorMessage' | 'tip' | 'disabled' | 'style'
     >;
 
-export const DateField = forwardRef<HTMLDivElement, DateFieldProps>(
-  ({ componentSize = 'medium', buttonProps, ...props }, forwardedRef) => {
-    const state = useDateFieldState({
-      ...props,
-      locale,
-      createCalendar,
-    });
+function _DateField(
+  {
+    componentSize = 'medium',
+    buttonProps,
+    groupProps,
+    ...props
+  }: DateFieldProps,
+  forwardedRef: Ref<HTMLDivElement>,
+) {
+  const state = useDateFieldState({
+    ...props,
+    locale,
+    createCalendar,
+  });
 
-    const ref = useRef<HTMLInputElement>(null);
-    const { labelProps, fieldProps } = useDateField(props, state, ref);
+  const ref = useRef<HTMLInputElement>(null);
+  const { labelProps, fieldProps } = useDateField(props, state, ref);
 
-    const disabled = props.isDisabled || !!fieldProps['aria-disabled'];
+  const disabled = props.isDisabled || !!fieldProps['aria-disabled'];
 
-    return (
-      <DateInput
-        {...props}
-        componentSize={componentSize}
-        label={props.label}
-        disabled={disabled}
-        required={props.isRequired}
-        ref={forwardedRef}
-        internalRef={ref}
-        readOnly={props.isReadOnly}
-        prefix={
-          !props.isReadOnly && (
-            <CalendarButton
-              componentSize={componentSize}
-              {...buttonProps}
-              isDisabled={disabled}
-            />
-          )
-        }
-        labelProps={labelProps}
-        fieldProps={fieldProps}
-      >
-        {state.segments.map((segment, i) => (
-          <DateSegment
+  return (
+    <DateInput
+      {...props}
+      groupProps={groupProps}
+      componentSize={componentSize}
+      label={props.label}
+      disabled={disabled}
+      required={props.isRequired}
+      ref={forwardedRef}
+      internalRef={ref}
+      readOnly={props.isReadOnly}
+      prefix={
+        !props.isReadOnly && (
+          <CalendarButton
             componentSize={componentSize}
-            key={i}
-            segment={segment}
-            state={state}
+            {...buttonProps}
+            isDisabled={disabled}
           />
-        ))}
-      </DateInput>
-    );
-  },
-);
+        )
+      }
+      labelProps={labelProps}
+      fieldProps={fieldProps}
+    >
+      {state.segments.map((segment, i) => (
+        <DateSegment
+          componentSize={componentSize}
+          key={i}
+          segment={segment}
+          state={state}
+        />
+      ))}
+    </DateInput>
+  );
+}
+
+export const DateField: ForwardRefExoticComponent<
+  DateFieldProps & RefAttributes<HTMLDivElement>
+> = forwardRef(_DateField);
 
 DateField.displayName = 'DateField';

--- a/packages/components/src/components/date-inputs/DatePicker/DatePicker.spec.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/DatePicker.spec.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DatePicker } from './DatePicker';
+import { HStack } from '../../Stack';
+import { TextInput } from '../../TextInput';
+
+describe('<DatePicker>', () => {
+  it('is same height as <TextInput>', () => {
+    render(
+      <HStack>
+        <DatePicker label="Dato" data-testid="datepicker" />
+        <TextInput label="Dato" data-testid="textinput" />
+      </HStack>,
+    );
+
+    const datePicker = screen.getByTestId('datepicker');
+    const textInput = screen.getByTestId('textinput');
+
+    const datePickerHeight = datePicker.getBoundingClientRect().height;
+    const textInputHeight = textInput.getBoundingClientRect().height;
+
+    expect(datePickerHeight).toBe(textInputHeight);
+  });
+});

--- a/packages/components/src/components/date-inputs/DatePicker/DatePicker.tokens.ts
+++ b/packages/components/src/components/date-inputs/DatePicker/DatePicker.tokens.ts
@@ -67,15 +67,15 @@ const calendarButton = {
 
 const datefield = {
   medium: {
-    minWidth: '160px',
+    width: '160px',
     paddingX: ddsBaseTokens.spacing.SizesDdsSpacingX05,
   },
   small: {
-    minWidth: '140px',
+    width: '140px',
     paddingX: ddsBaseTokens.spacing.SizesDdsSpacingX05,
   },
   tiny: {
-    minWidth: '125px',
+    width: '125px',
     paddingX: ddsBaseTokens.spacing.SizesDdsSpacingX025,
   },
   disabled: {
@@ -87,7 +87,6 @@ const datefield = {
 
 export const datePickerTokens = {
   gap: ddsBaseTokens.spacing.SizesDdsSpacingX025,
-  labelGap: ddsBaseTokens.spacing.SizesDdsSpacingX0125,
   datefield,
   calendarButton,
 };

--- a/packages/components/src/components/date-inputs/DatePicker/DatePicker.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/DatePicker.tsx
@@ -43,7 +43,7 @@ export function _DatePicker(
   );
   const ref = useRef<HTMLElement>(null);
   const combinedRef = useCombinedRef(ref, domRef);
-  const { buttonProps, calendarProps, fieldProps } = useDatePicker(
+  const { buttonProps, calendarProps, fieldProps, groupProps } = useDatePicker(
     { ...props, granularity: 'day' },
     state,
     ref,
@@ -54,6 +54,7 @@ export function _DatePicker(
       <CalendarPopoverAnchor>
         <DateField
           {...fieldProps}
+          groupProps={groupProps}
           ref={combinedRef}
           componentSize={componentSize}
           tip={tip}

--- a/packages/components/src/components/date-inputs/common/DateInput.tsx
+++ b/packages/components/src/components/date-inputs/common/DateInput.tsx
@@ -1,13 +1,19 @@
-import { type useDateField } from '@react-aria/datepicker';
+import { type useDateField, type useDatePicker } from '@react-aria/datepicker';
 import type * as CSS from 'csstype';
-import { type ReactNode, type Ref, forwardRef } from 'react';
-import styled, { css } from 'styled-components';
+import {
+  type ForwardRefExoticComponent,
+  type ReactNode,
+  type Ref,
+  type RefAttributes,
+  forwardRef,
+} from 'react';
+import styled from 'styled-components';
 
 import { cn } from '../../../utils';
 import {
   type InputProps,
+  OuterInputContainer,
   StatefulInput,
-  type StyledInputProps,
 } from '../../helpers';
 import { InputMessage } from '../../InputMessage';
 import { Label } from '../../Typography';
@@ -21,6 +27,7 @@ export type DateInputProps = {
   label?: ReactNode;
   internalRef: Ref<HTMLDivElement>;
   width?: CSS.Properties['width'];
+  groupProps?: ReturnType<typeof useDatePicker>['groupProps'];
 } & Pick<ReturnType<typeof useDateField>, 'fieldProps' | 'labelProps'> &
   Pick<
     InputProps,
@@ -33,23 +40,7 @@ export type DateInputProps = {
     | 'readOnly'
   >;
 
-const DateFieldContainer = styled.div`
-  display: inline-flex;
-  flex-direction: column;
-  gap: ${datePickerTokens.labelGap};
-`;
-
-const InputDiv = styled(StatefulInput).attrs({
-  as: 'div',
-})<StyledInputProps & { $width: CSS.Properties['width'] }>`
-  ${({ $width, componentSize = 'medium' }) =>
-    $width
-      ? css`
-          width: ${$width};
-        `
-      : css`
-          min-width: ${datePickerTokens.datefield[componentSize].minWidth};
-        `}
+const InputDiv = styled(StatefulInput)`
   display: inline-flex;
   flex-direction: row;
   gap: ${datePickerTokens.gap};
@@ -65,66 +56,74 @@ const DateSegmentContainer = styled.div`
   flex-direction: row;
 `;
 
-export const DateInput = forwardRef<HTMLDivElement, DateInputProps>(
-  (
-    {
-      errorMessage,
-      tip,
-      componentSize = 'medium',
-      style,
-      className,
-      disabled,
-      active,
-      internalRef,
-      readOnly,
-      required,
-      children,
-      prefix: button,
-      labelProps,
-      fieldProps,
-      width,
-      ...props
-    },
-    forwardedRef,
-  ) => {
-    const hasErrorMessage = !!errorMessage;
-    const hasTip = !!tip;
-    const hasLabel = props.label != null;
-    const hasMessage = hasErrorMessage || hasTip;
+function _DateInput(
+  {
+    errorMessage,
+    tip,
+    componentSize = 'medium',
+    style,
+    className,
+    disabled,
+    active,
+    internalRef,
+    readOnly,
+    required,
+    children,
+    prefix: button,
+    labelProps,
+    fieldProps,
+    groupProps,
+    width = datePickerTokens.datefield[componentSize].width,
+    ...props
+  }: DateInputProps,
+  forwardedRef: Ref<HTMLDivElement>,
+) {
+  const hasErrorMessage = !!errorMessage;
+  const hasTip = !!tip;
+  const hasLabel = props.label != null;
+  const hasMessage = hasErrorMessage || hasTip;
 
-    return (
-      <DateFieldContainer className={className} ref={forwardedRef}>
-        {hasLabel && (
-          <Label {...labelProps} showRequiredStyling={required}>
-            {props.label}
-          </Label>
+  return (
+    <OuterInputContainer
+      {...groupProps}
+      $width={width}
+      className={className}
+      ref={forwardedRef}
+    >
+      {hasLabel && (
+        <Label {...labelProps} showRequiredStyling={required}>
+          {props.label}
+        </Label>
+      )}
+      <InputDiv
+        {...fieldProps}
+        as="div"
+        style={style}
+        disabled={disabled}
+        componentSize={componentSize}
+        ref={internalRef}
+        hasErrorMessage={hasErrorMessage}
+        className={cn(
+          disabled && 'disabled',
+          active && 'active',
+          readOnly && 'read-only',
         )}
-        <InputDiv
-          {...fieldProps}
-          $width={width}
-          style={style}
-          disabled={disabled}
-          componentSize={componentSize}
-          ref={internalRef}
-          hasErrorMessage={hasErrorMessage}
-          className={cn(
-            disabled && 'disabled',
-            active && 'active',
-            readOnly && 'read-only',
-          )}
-        >
-          {button}
-          <DateSegmentContainer>{children}</DateSegmentContainer>
-        </InputDiv>
-        {hasMessage && (
-          <InputMessage
-            messageType={hasErrorMessage ? 'error' : 'tip'}
-            message={errorMessage ?? tip ?? ''}
-          />
-        )}
-      </DateFieldContainer>
-    );
-  },
-);
+      >
+        {button}
+        <DateSegmentContainer>{children}</DateSegmentContainer>
+      </InputDiv>
+      {hasMessage && (
+        <InputMessage
+          messageType={hasErrorMessage ? 'error' : 'tip'}
+          message={errorMessage ?? tip ?? ''}
+        />
+      )}
+    </OuterInputContainer>
+  );
+}
+
+export const DateInput: ForwardRefExoticComponent<
+  DateInputProps & RefAttributes<HTMLDivElement>
+> = forwardRef(_DateInput);
 
 DateInput.displayName = 'DateInput';

--- a/packages/components/src/components/helpers/Input/Input.styles.tsx
+++ b/packages/components/src/components/helpers/Input/Input.styles.tsx
@@ -14,7 +14,7 @@ import {
 
 import { type StyledInputProps } from '.';
 
-const { input, container } = tokens;
+const { input } = tokens;
 
 export const Input = styled.input`
   position: relative;
@@ -122,13 +122,12 @@ export const StatefulInput = styled(Input).withConfig({
 `;
 
 interface OuterInputContainerProps {
-  width?: Property.Width;
+  $width?: Property.Width;
 }
 
 export const OuterInputContainer = styled.div<OuterInputContainerProps>`
   position: relative;
-  gap: ${container.gap};
-  width: ${({ width }) => width};
+  width: ${({ $width }) => $width};
 `;
 
 /**Brukes som container til input og ikon for posisjonering. */

--- a/packages/components/src/components/helpers/Input/Input.tokens.tsx
+++ b/packages/components/src/components/helpers/Input/Input.tokens.tsx
@@ -47,11 +47,6 @@ const input = {
   },
 };
 
-const container = {
-  gap: spacing.SizesDdsSpacingX0125,
-};
-
 export const inputTokens = {
   input,
-  container,
 };


### PR DESCRIPTION
`<DatePicker>` var `1px` lavere enn andre input-kilder. Bruker nå mer lik implementasjon som `<TextInput>`, så da burde oppførsel være mer konsistent også.