### PR TITLE
Slå av at changeset oppdatere egne pakker automatisk

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,5 @@
   "linked": [],
   "ignore": [],
   "access": "public",
-  "baseBranch": "main",
-  "updateInternalDependencies": "patch",
-  "onlyUpdatePeerDependentsWhenOutOfRange": true
+  "baseBranch": "main"
 }


### PR DESCRIPTION
Dette dekkes uansett av pnpm, og fører nå bare til at peer-dependencies endres uten at vi ønsker det.