### PR TITLE
ELSA1-306 fikse at input/textarea i disabled/readonly hadde hover-effekt

### DIFF
--- a/.changeset/friendly-scissors-smile.md
+++ b/.changeset/friendly-scissors-smile.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Fikser bug i input og textarea hvor disabled og read-only varianter hadde hover-effekt

--- a/packages/components/src/components/helpers/Input/Input.styles.tsx
+++ b/packages/components/src/components/helpers/Input/Input.styles.tsx
@@ -49,7 +49,7 @@ export const Input = styled.input`
     ${selection}
   }
 
-  &:not(.disabled):not(.read-only):not(.active):hover,
+  &:not(input):not(textarea):not(.disabled):not(.read-only):not(.active):hover,
   &:hover:enabled:read-write {
     ${hoverInputfield}
   }


### PR DESCRIPTION
Regelen som ble brukt for DatePicker kan ikke brukes for input/textarea.