### PR TITLE
ELSA1-308 storybook forbedringer

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -6,6 +6,8 @@ const config: StorybookConfig = {
     '../stories/**/*.@(md|mdx)',
     '../packages/*/src/**/*.stories.@(js|jsx|ts|tsx)',
     '../packages/*/src/**/*.mdx',
+    '../packages/*/stories/**/*.stories.@(js|jsx|ts|tsx)',
+    '../packages/*/stories/**/*.mdx',
   ],
   staticDirs: ['./images', '../packages/components/dist/assets/fonts'],
   addons: [

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,7 +13,14 @@ const config: StorybookConfig = {
   addons: [
     '@storybook/addon-a11y',
     '@storybook/addon-essentials',
-    '@storybook/addon-storysource',
+    {
+      name: '@storybook/addon-storysource',
+      options: {
+        loaderOptions: {
+          injectStoryParameters: true,
+        },
+      },
+    },
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -34,6 +34,9 @@ const config: StorybookConfig = {
         prop.parent ? !/node_modules/.test(prop.parent.fileName) : true,
     },
   },
+  docs: {
+    autodocs: true,
+  },
 };
 
 export default config;

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -11,6 +11,7 @@ const config: StorybookConfig = {
   ],
   staticDirs: ['./images', '../packages/components/dist/assets/fonts'],
   addons: [
+    '@storybook/addon-links',
     '@storybook/addon-a11y',
     '@storybook/addon-essentials',
     {

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -30,19 +30,8 @@ const config: StorybookConfig = {
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
       shouldExtractLiteralValuesFromEnum: true,
-      propFilter: prop => {
-        if (
-          prop.declarations === undefined ||
-          prop.declarations === null ||
-          prop.declarations.every(dec =>
-            /node_modules\/@types\/react(-dom)?/.test(dec.fileName),
-          )
-        ) {
-          return false;
-        }
-
-        return true;
-      },
+      propFilter: prop =>
+        prop.parent ? !/node_modules/.test(prop.parent.fileName) : true,
     },
   },
 };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -11,7 +11,12 @@ const preview: Preview = {
     options: {
       storySort: {
         method: 'alphabetical',
-        order: ['Introduction', 'dds-components', 'dds-page-generator'],
+        order: [
+          'Introduction',
+          'dds-components',
+          '*',
+          ['Introduction', 'Changelog'],
+        ],
       },
     },
     actions: { argTypesRegex: '^on[A-Z].*' },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@storybook/addon-a11y": "7.6.10",
     "@storybook/addon-docs": "7.6.10",
     "@storybook/addon-essentials": "7.6.10",
+    "@storybook/addon-links": "^7.6.10",
     "@storybook/addon-storysource": "7.6.10",
     "@storybook/blocks": "7.6.10",
     "@storybook/core-common": "7.6.10",

--- a/packages/components/src/components/AppShell/AppShell.mdx
+++ b/packages/components/src/components/AppShell/AppShell.mdx
@@ -1,9 +1,8 @@
-import { Canvas, Story, Meta, ArgTypes } from '@storybook/blocks';
+import { Meta, ArgTypes, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as AppShellStories from './AppShell.stories';
 
@@ -19,13 +18,9 @@ import * as AppShellStories from './AppShell.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={AppShellStories.Default} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-backbutton`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/AppShell" story="Default">Storybook</LinkTo>.
 
 ## Bruk i koden
 

--- a/packages/components/src/components/AppShell/AppShell.stories.tsx
+++ b/packages/components/src/components/AppShell/AppShell.stories.tsx
@@ -1,4 +1,4 @@
-import { type ComponentProps } from 'react';
+import { type Meta, type StoryObj } from '@storybook/react';
 
 import {
   BarChartIcon,
@@ -12,18 +12,31 @@ import { AppShell } from '.';
 export default {
   title: 'dds-components/AppShell',
   component: AppShell,
-};
+  argTypes: {
+    title: { control: 'text' },
+    version: { control: 'text' },
+  },
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourseState: 'shown' },
+    },
+  },
+} satisfies Meta<typeof AppShell>;
 
-export const Default = (args: Partial<ComponentProps<typeof AppShell>>) => (
-  <AppShell
-    version="1.0.0"
-    user={{
+type Story = StoryObj<typeof AppShell>;
+
+export const Default: Story = {
+  args: {
+    title: 'Lovisa',
+    version: '1.0.0',
+    user: {
       embete: { name: 'Borgarting Lagmannsrett', type: 'høyesterett' },
       name: 'Kari Nordmann',
-    }}
-    environment="PROD"
-    userMenuItems={[{ title: 'Bytt embete' }, { title: 'Logg ut' }]}
-    navigation={{
+    },
+    environment: 'PROD',
+    userMenuItems: [{ title: 'Bytt embete' }, { title: 'Logg ut' }],
+    navigation: {
       internal: [
         <AppShell.NavItem active href="#" icon={FolderIcon}>
           Saker
@@ -52,7 +65,6 @@ export const Default = (args: Partial<ComponentProps<typeof AppShell>>) => (
           Statistikk
         </AppShell.NavItem>,
       ],
-    }}
-    {...args}
-  />
-);
+    },
+  },
+};

--- a/packages/components/src/components/BackLink/BackLink.mdx
+++ b/packages/components/src/components/BackLink/BackLink.mdx
@@ -1,10 +1,6 @@
-import { Canvas, Story, Meta, ArgTypes } from '@storybook/blocks';
-import {
-  Source,
-  ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
-} from '@norges-domstoler/storybook-components';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as BackLinkStories from './BackLink.stories';
 
 <Meta of={BackLinkStories} />
@@ -14,28 +10,16 @@ import * as BackLinkStories from './BackLink.stories';
 <ComponentLinkRow
   docsHref="https://design.domstol.no/987b33f71/p/72c4bc-backlink"
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/DDS-Komponenter?node-id=12825-221439&t=H2ZVa4PDdz4UMfma-0"
-  githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Breadcrumbs/BackLink"
+  githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/BackLink"
 />
 
 ## Demo
 
-<Canvas>
-  <Story of={BackLinkStories.Default} />
-</Canvas>
+<Canvas of={BackLinkStories.Default} sourceState="hidden" />
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-backbutton`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/BackLink" story="Default">Storybook</LinkTo>.
 
-## Bruk i koden
+## Props
 
-<Source
-  code={`
-  import { BackLink } from '@norges-domstoler/dds-components'
-
-<BackLink label="Forrige nivå" href="https://domstol.no/" />
-`} />
-
-## API
-
-<ArgTypes of={BackLinkStories.Default} />
+<Canvas of={BackLinkStories.Default} />
+<Controls of={BackLinkStories.Default} />

--- a/packages/components/src/components/BackLink/BackLink.stories.tsx
+++ b/packages/components/src/components/BackLink/BackLink.stories.tsx
@@ -1,10 +1,17 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { BackLink, type BackLinkProps } from '.';
+import { BackLink } from '.';
 
 export default {
   title: 'dds-components/BackLink',
   component: BackLink,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'shown' },
+    },
+  },
   argTypes: {
     label: {
       control: 'text',
@@ -15,8 +22,13 @@ export default {
   },
 };
 
-export const Default = (args: Partial<BackLinkProps>) => (
-  <StoryTemplate title="BackLink - default">
-    <BackLink label="Forrige nivå" href="?" {...args} />
-  </StoryTemplate>
-);
+type Story = StoryObj<typeof BackLink>;
+
+export const Default: Story = {
+  args: { label: 'Forrige nivå', href: '?' },
+  decorators: Story => (
+    <StoryTemplate title="BackLink - default">
+      <Story />
+    </StoryTemplate>
+  ),
+};

--- a/packages/components/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/packages/components/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -1,17 +1,6 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { Breadcrumb, Breadcrumbs } from '.';
-import {
-  Source,
-  ComponentLinkRow,
-  LinkToInteractiveStory,
-  SB_DESIGNSYSTEM_URL,
-} from '@norges-domstoler/storybook-components';
+import { Canvas, Controls, Meta, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as BreadcrumbsStories from './Breadcrumbs.stories';
 
 <Meta of={BreadcrumbsStories} />
@@ -26,13 +15,9 @@ import * as BreadcrumbsStories from './Breadcrumbs.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={BreadcrumbsStories.Default} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-breadcrumbs`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/Breadcrumbs" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -43,26 +28,14 @@ Komponenten består av to subkomponenter:
 
 Siste `<Breadcrumb />` skal være den siden brukeren er på, uten oppgitt URL.
 
-## Bruk i koden
-
-<Source
-  code={`
-  import { Breadcrumb, Breadcrumbs } from '@norges-domstoler/dds-components';
-
-<Breadcrumbs>
-  <Breadcrumb href="#">Side 1</Breadcrumb>
-  <Breadcrumb href="#">Side 2</Breadcrumb>
-  <Breadcrumb>Side 3</Breadcrumb>
-</Breadcrumbs>
-`} />
-
-## API
+## Props
 
 ### Breadcrumbs
 
-Selve brødsmulestien. Skal ha `<Breadcrumb />` som barn.
+<Canvas of={BreadcrumbsStories.Default} sourceState="shown" />
+<Controls of={BreadcrumbsStories.Default} />
 
-<ArgTypes of={BreadcrumbsStories.Default} />
+Selve brødsmulestien. Skal ha `<Breadcrumb />` som barn.
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,20 +1,32 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type Meta, type StoryObj } from '@storybook/react';
 
-import { Breadcrumb, Breadcrumbs, type BreadcrumbsProps } from '.';
+import { Breadcrumb, Breadcrumbs } from '.';
 
 export default {
   title: 'dds-components/Breadcrumbs',
   component: Breadcrumbs,
-};
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
+} satisfies Meta<typeof Breadcrumbs>;
 
-export const Default = (args: BreadcrumbsProps) => {
-  return (
-    <StoryTemplate title="Breadcrumbs - default" gap="0">
-      <Breadcrumbs {...args}>
-        <Breadcrumb href="#">Side 1</Breadcrumb>
-        <Breadcrumb href="#">Side 2</Breadcrumb>
-        <Breadcrumb>Side 3</Breadcrumb>
-      </Breadcrumbs>
+type Story = StoryObj<typeof Breadcrumbs>;
+
+export const Default: Story = {
+  decorators: Story => (
+    <StoryTemplate title="Breadcrumbs - default">
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  args: {
+    children: [
+      <Breadcrumb href="#">Side 1</Breadcrumb>,
+      <Breadcrumb href="#">Side 2</Breadcrumb>,
+      <Breadcrumb>Side 3</Breadcrumb>,
+    ],
+  },
 };

--- a/packages/components/src/components/Button/Button.mdx
+++ b/packages/components/src/components/Button/Button.mdx
@@ -1,10 +1,6 @@
-import { Story, Canvas, Meta, ArgTypes } from '@storybook/blocks';
-import {
-  Source,
-  ComponentLinkRow,
-  LinkToInteractiveStory,
-  SB_DESIGNSYSTEM_URL,
-} from '@norges-domstoler/storybook-components';
+import { Canvas, Controls, Meta, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as ButtonStories from './Button.stories';
 
 <Meta of={ButtonStories} />
@@ -19,24 +15,14 @@ import * as ButtonStories from './Button.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={ButtonStories.Default} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-button`} />
+Se stories med kontrollere i <LinkTo title="dds-components/Button" story="Default">Storybook</LinkTo>.
 
-## Bruk i koden
+## Props
 
-<Source
-  code={`
-  import { Button } from '@norges-domstoler/dds-components';
-
-<Button>Knapp</Button>
-`} />
-
-## API
-
-<ArgTypes of={ButtonStories.Default} />
+<Canvas of={ButtonStories.Default} sourceState="shown" />
+<Controls of={ButtonStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `ButtonHTMLAttributes<HTMLButtonElement>`-interface i `htmlProps`. `type`, `onClick`, `onFocus` og `onBlur` er tilgjengelige på rotnivå.
 

--- a/packages/components/src/components/Button/Button.stories.tsx
+++ b/packages/components/src/components/Button/Button.stories.tsx
@@ -1,28 +1,47 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { icons } from '../..';
 
-import { Button, type ButtonProps } from '.';
+import { Button } from '.';
 
 export default {
   title: 'dds-components/Button',
   component: Button,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
   argTypes: {
     loading: { control: { type: 'boolean' } },
     fullWidth: { control: { type: 'boolean' } },
     href: { control: { type: 'text' } },
     children: { control: { type: 'text' } },
-  },
-  parameters: {
-    controls: {
-      exclude: ['style', 'className', 'target', 'Icon', 'label'],
-    },
+    label: { table: { disable: true } },
   },
 };
 
-export const OverviewWithText = (args: ButtonProps) => {
-  return (
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {
+  args: { children: 'Tekst' },
+  decorators: Story => (
+    <StoryTemplate title="Button - default">
+      <Story />
+    </StoryTemplate>
+  ),
+};
+
+export const OverviewWithText: Story = {
+  decorators: Story => (
     <StoryTemplate title="Button overview - with text" display="grid">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <Button {...args} purpose="primary" appearance="filled">
         Primary
       </Button>
@@ -167,96 +186,47 @@ export const OverviewWithText = (args: ButtonProps) => {
       >
         Danger
       </Button>
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const OverviewJustIcon = (args: ButtonProps) => {
-  return (
+export const OverviewJustIcon: Story = {
+  args: { icon: icons.CloseIcon },
+  decorators: Story => (
     <StoryTemplate title="Button overview - just icon" display="grid">
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="filled"
-        icon={icons.CloseIcon}
-      />
-      <Button
-        {...args}
-        purpose="secondary"
-        appearance="filled"
-        icon={icons.CloseIcon}
-      />
-      <Button
-        {...args}
-        purpose="danger"
-        appearance="filled"
-        icon={icons.CloseIcon}
-      />
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="ghost"
-        icon={icons.CloseIcon}
-      />
-      <Button
-        {...args}
-        purpose="secondary"
-        appearance="ghost"
-        icon={icons.CloseIcon}
-      />
-      <Button
-        {...args}
-        purpose="danger"
-        appearance="ghost"
-        icon={icons.CloseIcon}
-      />
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="borderless"
-        icon={icons.CloseIcon}
-      />
-      <Button
-        {...args}
-        purpose="secondary"
-        appearance="borderless"
-        icon={icons.CloseIcon}
-      />
-      <Button
-        {...args}
-        purpose="danger"
-        appearance="borderless"
-        icon={icons.CloseIcon}
-      />
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="rounded"
-        icon={icons.CloseIcon}
-      />
-      <Button
-        {...args}
-        purpose="secondary"
-        appearance="rounded"
-        icon={icons.CloseIcon}
-      />
-      <Button
-        {...args}
-        purpose="danger"
-        appearance="rounded"
-        icon={icons.CloseIcon}
-      />
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <>
+      <Button {...args} purpose="primary" appearance="filled" />
+      <Button {...args} purpose="secondary" appearance="filled" />
+      <Button {...args} purpose="danger" appearance="filled" />
+      <Button {...args} purpose="primary" appearance="ghost" />
+      <Button {...args} purpose="secondary" appearance="ghost" />
+      <Button {...args} purpose="danger" appearance="ghost" />
+      <Button {...args} purpose="primary" appearance="borderless" />
+      <Button {...args} purpose="secondary" appearance="borderless" />
+      <Button {...args} purpose="danger" appearance="borderless" />
+      <Button {...args} purpose="primary" appearance="rounded" />
+      <Button {...args} purpose="secondary" appearance="rounded" />
+      <Button {...args} purpose="danger" appearance="rounded" />
+    </>
+  ),
 };
 
-export const OverviewSizes = (args: ButtonProps) => {
-  return (
+export const OverviewSizes: Story = {
+  decorators: Story => (
     <StoryTemplate
       title="Button overview - sizes"
       display="grid"
       $columnsAmount={4}
     >
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <Button {...args} purpose="primary" appearance="filled" size="tiny">
         Primary
       </Button>
@@ -337,199 +307,204 @@ export const OverviewSizes = (args: ButtonProps) => {
         size="large"
         icon={icons.CloseIcon}
       />
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const OverviewLoading = (args: ButtonProps) => {
-  return (
+export const OverviewLoading: Story = {
+  decorators: Story => (
     <StoryTemplate
       title="Button overview - loading"
       display="grid"
       $columnsAmount={4}
     >
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="filled"
-        size="tiny"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="filled"
-        size="small"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="filled"
-        size="medium"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="filled"
-        size="large"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="secondary"
-        appearance="filled"
-        size="tiny"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="secondary"
-        appearance="filled"
-        size="small"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="secondary"
-        appearance="filled"
-        size="medium"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="secondary"
-        appearance="filled"
-        size="large"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="danger"
-        appearance="filled"
-        size="tiny"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="danger"
-        appearance="filled"
-        size="small"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="danger"
-        appearance="filled"
-        size="medium"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="danger"
-        appearance="filled"
-        size="large"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="ghost"
-        size="tiny"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="ghost"
-        size="small"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="ghost"
-        size="medium"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="ghost"
-        size="large"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="secondary"
-        appearance="ghost"
-        size="tiny"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="secondary"
-        appearance="ghost"
-        size="small"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="secondary"
-        appearance="ghost"
-        size="medium"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="secondary"
-        appearance="ghost"
-        size="large"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="danger"
-        appearance="ghost"
-        size="tiny"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="danger"
-        appearance="ghost"
-        size="small"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="danger"
-        appearance="ghost"
-        size="medium"
-        loading
-      />
-      <Button
-        {...args}
-        purpose="danger"
-        appearance="ghost"
-        size="large"
-        loading
-      />
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <>
+      <Button
+        {...args}
+        purpose="primary"
+        appearance="filled"
+        size="tiny"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="primary"
+        appearance="filled"
+        size="small"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="primary"
+        appearance="filled"
+        size="medium"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="primary"
+        appearance="filled"
+        size="large"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="secondary"
+        appearance="filled"
+        size="tiny"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="secondary"
+        appearance="filled"
+        size="small"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="secondary"
+        appearance="filled"
+        size="medium"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="secondary"
+        appearance="filled"
+        size="large"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="danger"
+        appearance="filled"
+        size="tiny"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="danger"
+        appearance="filled"
+        size="small"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="danger"
+        appearance="filled"
+        size="medium"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="danger"
+        appearance="filled"
+        size="large"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="primary"
+        appearance="ghost"
+        size="tiny"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="primary"
+        appearance="ghost"
+        size="small"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="primary"
+        appearance="ghost"
+        size="medium"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="primary"
+        appearance="ghost"
+        size="large"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="secondary"
+        appearance="ghost"
+        size="tiny"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="secondary"
+        appearance="ghost"
+        size="small"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="secondary"
+        appearance="ghost"
+        size="medium"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="secondary"
+        appearance="ghost"
+        size="large"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="danger"
+        appearance="ghost"
+        size="tiny"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="danger"
+        appearance="ghost"
+        size="small"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="danger"
+        appearance="ghost"
+        size="medium"
+        loading
+      />
+      <Button
+        {...args}
+        purpose="danger"
+        appearance="ghost"
+        size="large"
+        loading
+      />
+    </>
+  ),
 };
 
-export const OverviewFullWidth = (args: ButtonProps) => {
-  return (
+export const OverviewFullWidth: Story = {
+  args: { fullWidth: true },
+  decorators: Story => (
     <StoryTemplate title="Button overview - full width">
-      <Button
-        {...args}
-        purpose="primary"
-        appearance="filled"
-        size="medium"
-        fullWidth
-      >
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
+      <Button {...args} purpose="primary" appearance="filled" size="medium">
         {args.children ?? 'Primary'}
       </Button>
       <Button
@@ -539,7 +514,6 @@ export const OverviewFullWidth = (args: ButtonProps) => {
         size="medium"
         iconPosition="left"
         icon={icons.PlusCircledIcon}
-        fullWidth
       >
         {args.children ?? 'Primary'}
       </Button>
@@ -550,7 +524,6 @@ export const OverviewFullWidth = (args: ButtonProps) => {
         size="medium"
         iconPosition="right"
         icon={icons.PlusCircledIcon}
-        fullWidth
       >
         {args.children ?? 'Primary'}
       </Button>
@@ -560,7 +533,6 @@ export const OverviewFullWidth = (args: ButtonProps) => {
         appearance="filled"
         size="medium"
         icon={icons.CloseIcon}
-        fullWidth
       />
       <Button
         {...args}
@@ -568,42 +540,44 @@ export const OverviewFullWidth = (args: ButtonProps) => {
         appearance="filled"
         size="medium"
         loading
-        fullWidth
       >
         label
       </Button>
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const Default = (args: ButtonProps) => {
-  return (
-    <StoryTemplate title="Button - default">
-      <Button {...args}>{args.children ?? 'Tekst'}</Button>
+export const TextWithIcon: Story = {
+  args: {
+    children: 'Tekst',
+    icon: icons.PlusCircledIcon,
+    iconPosition: 'left',
+  },
+  decorators: Story => (
+    <StoryTemplate title="Button - text with icon">
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const TextWithIcon = (args: ButtonProps) => {
-  return (
-    <StoryTemplate title="Button - default">
-      <Button {...args} icon={icons.PlusCircledIcon}>
-        {args.children ?? 'Tekst'}
-      </Button>
-    </StoryTemplate>
-  );
-};
-
-export const Icon = (args: ButtonProps) => {
-  return (
+export const Icon: Story = {
+  args: { icon: icons.CloseIcon },
+  decorators: Story => (
     <StoryTemplate title="Button - just icon">
-      <Button {...args} icon={icons.CloseIcon} />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
-export const Ghost = (args: ButtonProps) => {
-  return (
+
+export const Ghost: Story = {
+  args: { children: 'Tekst' },
+  decorators: Story => (
     <StoryTemplate title="Button - ghost">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <Button {...args} purpose="primary" appearance="ghost">
         {args.children ?? 'tekst'}
       </Button>
@@ -613,38 +587,38 @@ export const Ghost = (args: ButtonProps) => {
       <Button {...args} purpose="danger" appearance="ghost">
         {args.children ?? 'tekst'}
       </Button>
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const Borderless = (args: ButtonProps) => {
-  return (
+export const Borderless: Story = {
+  args: { children: 'Tekst' },
+  decorators: Story => (
     <StoryTemplate title="Button - borderless">
-      <Button {...args} purpose="primary" appearance="borderless">
-        {args.children ?? 'tekst'}
-      </Button>
-      <Button {...args} purpose="secondary" appearance="borderless">
-        {args.children ?? 'tekst'}
-      </Button>
-      <Button {...args} purpose="danger" appearance="borderless">
-        {args.children ?? 'tekst'}
-      </Button>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <>
+      <Button {...args} purpose="primary" appearance="borderless" />
+      <Button {...args} purpose="secondary" appearance="borderless" />
+      <Button {...args} purpose="danger" appearance="borderless" />
+    </>
+  ),
 };
 
-export const Rounded = (args: ButtonProps) => {
-  return (
+export const Rounded: Story = {
+  args: { children: 'Tekst' },
+  decorators: Story => (
     <StoryTemplate title="Button - rounded">
-      <Button {...args} purpose="primary" appearance="rounded">
-        {args.children ?? 'tekst'}
-      </Button>
-      <Button {...args} purpose="secondary" appearance="rounded">
-        {args.children ?? 'tekst'}
-      </Button>
-      <Button {...args} purpose="danger" appearance="rounded">
-        {args.children ?? 'tekst'}
-      </Button>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <>
+      <Button {...args} purpose="primary" appearance="rounded" />
+      <Button {...args} purpose="secondary" appearance="rounded" />
+      <Button {...args} purpose="danger" appearance="rounded" />
+    </>
+  ),
 };

--- a/packages/components/src/components/Card/Card.mdx
+++ b/packages/components/src/components/Card/Card.mdx
@@ -1,10 +1,9 @@
-import { Canvas, Meta, ArgTypes } from '@storybook/blocks';
+import { ArgTypes, Canvas, Controls, Meta, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import { CardAccordion, CardAccordionBody } from '.';
 import {
   Source,
   ComponentLinkRow,
-  LinkToInteractiveStory,
-  SB_DESIGNSYSTEM_URL,
 } from '@norges-domstoler/storybook-components';
 import * as CardStories from './Card.stories';
 
@@ -20,9 +19,9 @@ import * as CardStories from './Card.stories';
 
 ## Demo
 
-<Canvas of={CardStories.Default} />
+<Primary />
 
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-card`} />
+Se stories med kontrollere i <LinkTo title="dds-components/Card" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -47,7 +46,7 @@ Det finnes følgene typer `<Card />`:
   CardAccordionHeader
   } from '@norges-domstoler/dds-components';
 
-<Card cardType="info"> Content </Card>
+<Card cardType="info">Content</Card>
 
 <Card cardType="expandable">
   <CardAccordion>
@@ -57,13 +56,14 @@ Det finnes følgene typer `<Card />`:
 </Card>
 `} />
 
-## API
+## Props
 
 ### <a id="card" /> Card
 
 Wrapper for innhold i et kort. Bruk design-tokens for spacing og annet styling der relevant. Har default typografi. Ved bruk av `<Typography />` som barn må du sørge for å bruke `color='onDark'` på mørk bakgrunn.
 
-<ArgTypes of={CardStories.Default} />
+<Canvas of={CardStories.Default} sourceState="shown" />
+<Controls of={CardStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>` eller `AnchorHTMLAttributes<HTMLAnchorElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/Card/Card.stories.tsx
+++ b/packages/components/src/components/Card/Card.stories.tsx
@@ -1,5 +1,6 @@
 import { ddsBaseTokens } from '@norges-domstoler/dds-design-tokens';
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import styled from 'styled-components';
 
@@ -11,19 +12,20 @@ import {
 import { Divider } from '../Divider';
 import { Typography } from '../Typography';
 
-import {
-  Card,
-  CardAccordion,
-  CardAccordionBody,
-  CardAccordionHeader,
-  type CardProps,
-  type ExpandableCardProps,
-} from '.';
+import { Card, CardAccordion, CardAccordionBody, CardAccordionHeader } from '.';
 
 export default {
   title: 'dds-components/Card',
   component: Card,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
+
+type Story = StoryObj<typeof Card>;
 
 const body = (
   <Typography>
@@ -41,100 +43,113 @@ const ContentContainer = styled.div`
   padding: ${ddsBaseTokens.spacing.SizesDdsSpacingX075};
 `;
 
-export const Overview = () => {
-  return (
+export const Overview: Story = {
+  decorators: Story => (
     <StoryTemplate title="Card - overview" display="grid" $columnsAmount={4}>
-      <Card cardType="info">
-        <ContentContainer>
-          <Typography typographyType="headingSans03">Title</Typography>
-          {body}
-        </ContentContainer>
-      </Card>
-      <Card cardType="info" color="filledDark">
-        <ContentContainer>
-          <Typography color="onDark" typographyType="headingSans03">
-            Title
-          </Typography>
-          {bodyOnDark}
-        </ContentContainer>
-      </Card>
-      <Card cardType="info" color="strokeDark">
-        <ContentContainer>
-          <Typography typographyType="headingSans03">Title</Typography>
-          {body}
-        </ContentContainer>
-      </Card>
-      <Card cardType="info" color="strokeLight">
-        <ContentContainer>
-          <Typography typographyType="headingSans03">Title</Typography>
-          {body}
-        </ContentContainer>
-      </Card>
-      <Card cardType="navigation" href="#">
-        <ContentContainer>
-          <Typography typographyType="headingSans03">Title</Typography>
-          {body}
-        </ContentContainer>
-      </Card>
-      <Card color="filledDark" cardType="navigation" href="#">
-        <ContentContainer>
-          <Typography color="onDark" typographyType="headingSans03">
-            Title
-          </Typography>
-          {bodyOnDark}
-        </ContentContainer>
-      </Card>
-      <Card color="strokeDark" cardType="navigation" href="#">
-        <ContentContainer>
-          <Typography typographyType="headingSans03">Title</Typography>
-          {body}
-        </ContentContainer>
-      </Card>
-      <Card color="strokeLight" cardType="navigation" href="#">
-        <ContentContainer>
-          <Typography typographyType="headingSans03">Title</Typography>
-          {body}
-        </ContentContainer>
-      </Card>
-      <Card cardType="info" color="filledLight">
-        <CardAccordion>
-          <CardAccordionHeader> Title </CardAccordionHeader>
-          <CardAccordionBody>Content</CardAccordionBody>
-        </CardAccordion>
-      </Card>
-      <Card cardType="info" color="filledDark">
-        <CardAccordion>
-          <CardAccordionHeader> Title </CardAccordionHeader>
-          <CardAccordionBody>Content</CardAccordionBody>
-        </CardAccordion>
-      </Card>
-      <Card cardType="info" color="strokeDark">
-        <CardAccordion>
-          <CardAccordionHeader> Title </CardAccordionHeader>
-          <CardAccordionBody>Content</CardAccordionBody>
-        </CardAccordion>
-      </Card>
-      <Card cardType="info" color="strokeLight">
-        <CardAccordion>
-          <CardAccordionHeader> Title </CardAccordionHeader>
-          <CardAccordionBody>Content</CardAccordionBody>
-        </CardAccordion>
-      </Card>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  render: (args: any) => (
+    <>
+      <Card {...args} cardType="info">
+        <ContentContainer>
+          <Typography typographyType="headingSans03">Title</Typography>
+          {body}
+        </ContentContainer>
+      </Card>
+      <Card {...args} cardType="info" color="filledDark">
+        <ContentContainer>
+          <Typography color="onDark" typographyType="headingSans03">
+            Title
+          </Typography>
+          {bodyOnDark}
+        </ContentContainer>
+      </Card>
+      <Card {...args} cardType="info" color="strokeDark">
+        <ContentContainer>
+          <Typography typographyType="headingSans03">Title</Typography>
+          {body}
+        </ContentContainer>
+      </Card>
+      <Card {...args} cardType="info" color="strokeLight">
+        <ContentContainer>
+          <Typography typographyType="headingSans03">Title</Typography>
+          {body}
+        </ContentContainer>
+      </Card>
+      <Card {...args} cardType="navigation" href="#">
+        <ContentContainer>
+          <Typography typographyType="headingSans03">Title</Typography>
+          {body}
+        </ContentContainer>
+      </Card>
+      <Card {...args} color="filledDark" cardType="navigation" href="#">
+        <ContentContainer>
+          <Typography color="onDark" typographyType="headingSans03">
+            Title
+          </Typography>
+          {bodyOnDark}
+        </ContentContainer>
+      </Card>
+      <Card {...args} color="strokeDark" cardType="navigation" href="#">
+        <ContentContainer>
+          <Typography typographyType="headingSans03">Title</Typography>
+          {body}
+        </ContentContainer>
+      </Card>
+      <Card {...args} color="strokeLight" cardType="navigation" href="#">
+        <ContentContainer>
+          <Typography typographyType="headingSans03">Title</Typography>
+          {body}
+        </ContentContainer>
+      </Card>
+      <Card {...args} cardType="info" color="filledLight">
+        <CardAccordion>
+          <CardAccordionHeader> Title </CardAccordionHeader>
+          <CardAccordionBody>Content</CardAccordionBody>
+        </CardAccordion>
+      </Card>
+      <Card {...args} cardType="info" color="filledDark">
+        <CardAccordion>
+          <CardAccordionHeader> Title </CardAccordionHeader>
+          <CardAccordionBody>Content</CardAccordionBody>
+        </CardAccordion>
+      </Card>
+      <Card {...args} cardType="info" color="strokeDark">
+        <CardAccordion>
+          <CardAccordionHeader> Title </CardAccordionHeader>
+          <CardAccordionBody>Content</CardAccordionBody>
+        </CardAccordion>
+      </Card>
+      <Card {...args} cardType="info" color="strokeLight">
+        <CardAccordion>
+          <CardAccordionHeader> Title </CardAccordionHeader>
+          <CardAccordionBody>Content</CardAccordionBody>
+        </CardAccordion>
+      </Card>
+    </>
+  ),
 };
 
-export const Default = (args: CardProps) => {
-  return (
+export const Default: Story = {
+  args: { children: 'Content' },
+  decorators: Story => (
     <StoryTemplate title="Card - default">
-      <Card {...args}>Content</Card>
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const Accordion = (args: ExpandableCardProps) => {
-  return (
+export const Accordion: Story = {
+  decorators: Story => (
     <StoryTemplate title="Card - accordion" gap="0">
+      <Story />
+    </StoryTemplate>
+  ),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  render: (args: any) => (
+    <>
       <Card {...args} cardType="expandable">
         <CardAccordion>
           <CardAccordionHeader>Dekning av reiseutgifter</CardAccordionHeader>
@@ -195,15 +210,21 @@ export const Accordion = (args: ExpandableCardProps) => {
           <CardAccordionBody>Content</CardAccordionBody>
         </CardAccordion>
       </Card>
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const AccordionControlled = (args: ExpandableCardProps) => {
-  const [isExpanded, setIsExpanded] = useState(true);
-
-  return (
+export const AccordionControlled: Story = {
+  decorators: Story => (
     <StoryTemplate title="Card - accordion" gap="0">
+      <Story />
+    </StoryTemplate>
+  ),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  render: (args: any) => {
+    const [isExpanded, setIsExpanded] = useState(true);
+
+    return (
       <Card {...args} cardType="expandable">
         <CardAccordion
           isExpanded={isExpanded}
@@ -213,65 +234,71 @@ export const AccordionControlled = (args: ExpandableCardProps) => {
           <CardAccordionBody>Content</CardAccordionBody>
         </CardAccordion>
       </Card>
-    </StoryTemplate>
-  );
+    );
+  },
 };
 
-export const AccordionCustom = (args: ExpandableCardProps) => {
-  return (
+export const AccordionCustom: Story = {
+  decorators: Story => (
     <StoryTemplate title="Card - accordion" gap="0">
-      <Card {...args} cardType="expandable" color="strokeLight">
-        <CardAccordion>
-          <CardAccordionHeader
-            typographyType="bodySans01"
-            padding="4px 12px"
-            bold
-          >
-            Dekning av reiseutgifter
-          </CardAccordionHeader>
-          <CardAccordionBody padding="16px 12px">
-            <Typography typographyType="bodySans01">
-              I sivile saker avtales dekning av utgifter med den part som
-              innkalte deg. I straffesaker har du krav på reise- og
-              kostgodtgjørelse (
-              <Typography typographyType="a" href="#">
-                særavtale om dekning av utgifter til reise og kost
-              </Typography>
-              ). Reisen skal foretas på raskeste og rimeligste måte for staten.
-              Offentlig transport må benyttes der det er tilgjengelig.
-              Godtgjørelse for bruk av egen bil godtas bare i den utstrekning
-              det er rimeligst for det offentlige, med mindre særlige grunner
-              tilsier at du må bruke bil.Reiseutgiftene må dokumenteres med
-              kvitteringer, unntatt for rimeligste offentlig transport, for
-              eksempel buss, tog og så videre. For reiser over 15 km og som
-              varer utover 6 timer, dekkes utgifter til måltider etter satsene i
-              særavtalen om dekning av utgifter til reise og kost. Dersom
-              enkeltmåltider er dekket av andre enn deg selv, må du registrere
-              måltidsfradrag.
-            </Typography>
-          </CardAccordionBody>
-        </CardAccordion>
-      </Card>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  render: (args: any) => (
+    <Card {...args} cardType="expandable" color="strokeLight">
+      <CardAccordion>
+        <CardAccordionHeader
+          typographyType="bodySans01"
+          padding="4px 12px"
+          bold
+        >
+          Dekning av reiseutgifter
+        </CardAccordionHeader>
+        <CardAccordionBody padding="16px 12px">
+          <Typography typographyType="bodySans01">
+            I sivile saker avtales dekning av utgifter med den part som innkalte
+            deg. I straffesaker har du krav på reise- og kostgodtgjørelse (
+            <Typography typographyType="a" href="#">
+              særavtale om dekning av utgifter til reise og kost
+            </Typography>
+            ). Reisen skal foretas på raskeste og rimeligste måte for staten.
+            Offentlig transport må benyttes der det er tilgjengelig.
+            Godtgjørelse for bruk av egen bil godtas bare i den utstrekning det
+            er rimeligst for det offentlige, med mindre særlige grunner tilsier
+            at du må bruke bil.Reiseutgiftene må dokumenteres med kvitteringer,
+            unntatt for rimeligste offentlig transport, for eksempel buss, tog
+            og så videre. For reiser over 15 km og som varer utover 6 timer,
+            dekkes utgifter til måltider etter satsene i særavtalen om dekning
+            av utgifter til reise og kost. Dersom enkeltmåltider er dekket av
+            andre enn deg selv, må du registrere måltidsfradrag.
+          </Typography>
+        </CardAccordionBody>
+      </CardAccordion>
+    </Card>
+  ),
 };
 
-export const Examples = (args: CardProps) => {
-  return (
+export const Examples: Story = {
+  decorators: Story => (
     <StoryTemplate title="Card - examples">
-      <Card {...args}>
-        <ContentContainer>
-          <DescriptionList>
-            <DescriptionListTerm>Title</DescriptionListTerm>
-            <DescriptionListDesc>Description</DescriptionListDesc>
-          </DescriptionList>
-          <Divider />
-          <DescriptionList>
-            <DescriptionListTerm>Title</DescriptionListTerm>
-            <DescriptionListDesc>Description</DescriptionListDesc>
-          </DescriptionList>
-        </ContentContainer>
-      </Card>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  render: (args: any) => (
+    <Card {...args}>
+      <ContentContainer>
+        <DescriptionList>
+          <DescriptionListTerm>Title</DescriptionListTerm>
+          <DescriptionListDesc>Description</DescriptionListDesc>
+        </DescriptionList>
+        <Divider />
+        <DescriptionList>
+          <DescriptionListTerm>Title</DescriptionListTerm>
+          <DescriptionListDesc>Description</DescriptionListDesc>
+        </DescriptionList>
+      </ContentContainer>
+    </Card>
+  ),
 };

--- a/packages/components/src/components/Chip/Chip.mdx
+++ b/packages/components/src/components/Chip/Chip.mdx
@@ -1,10 +1,6 @@
-import { Canvas, Story, Meta, ArgTypes } from '@storybook/blocks';
-import {
-  Source,
-  ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
-} from '@norges-domstoler/storybook-components';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as ChipStories from './Chip.stories';
 import * as ChipGroupStories from './ChipGroup.stories';
 
@@ -20,17 +16,11 @@ import * as ChipGroupStories from './ChipGroup.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={ChipStories.Default} />
-</Canvas>
+<Canvas of={ChipStories.Default} />
 
-<Canvas>
-  <Story of={ChipGroupStories.Default} />
-</Canvas>
+<Canvas of={ChipGroupStories.Default} />
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-chip-chip`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/Chip/Chip" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -39,30 +29,19 @@ Komponenten består av to subkomponenter:
 - `<Chip />` - hovedkomponenten
 - `<ChipGroup />` - en gruppe som rendrer en liste med `<Chip />`-barn
 
-## Bruk i koden
-
-<Source
-  code={`
-  import { Chip, ChipGroup } from '@norges-domstoler/dds-components';
-
-<Chip text="text" />
-
-<ChipGroup>
-  <Chip text="text" />
-</ChipGroup>
-`} />
-
-## API
+## Props
 
 ### Chip
 
-<ArgTypes of={ChipStories} />
+<Canvas of={ChipStories.Default} />
+<Controls of={ChipStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
 
 ### ChipGroup
 
-<ArgTypes of={ChipGroupStories} />
+<Canvas of={ChipGroupStories.Default} />
+<Controls of={ChipGroupStories.Default} />
 
 Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLUListElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/Chip/Chip.stories.tsx
+++ b/packages/components/src/components/Chip/Chip.stories.tsx
@@ -1,17 +1,29 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { Chip, type ChipProps } from '.';
+import { Chip } from '.';
 
 export default {
   title: 'dds-components/Chip/Chip',
   component: Chip,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
   argTypes: {
     text: { control: { type: 'text' } },
   },
 };
 
-export const Default = (args: ChipProps) => (
-  <StoryTemplate title="Chip - default">
-    <Chip {...args} text={args.text ?? 'Chip'} />
-  </StoryTemplate>
-);
+type Story = StoryObj<typeof Chip>;
+
+export const Default: Story = {
+  args: { text: 'Chip' },
+  decorators: Story => (
+    <StoryTemplate title="Chip - default">
+      <Story />
+    </StoryTemplate>
+  ),
+};

--- a/packages/components/src/components/Chip/ChipGroup.stories.tsx
+++ b/packages/components/src/components/Chip/ChipGroup.stories.tsx
@@ -1,17 +1,31 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { Chip, ChipGroup, type ChipGroupProps } from '.';
+import { Chip, ChipGroup } from '.';
 
 export default {
   title: 'dds-components/Chip/ChipGroup',
   component: ChipGroup,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Default = (args: ChipGroupProps) => (
-  <StoryTemplate title="ChipGroup - default">
+type Story = StoryObj<typeof ChipGroup>;
+
+export const Default: Story = {
+  decorators: Story => (
+    <StoryTemplate title="ChipGroup - default">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
     <ChipGroup {...args}>
       <Chip text="Chip 1" />
       <Chip text="Chip 2" />
     </ChipGroup>
-  </StoryTemplate>
-);
+  ),
+};

--- a/packages/components/src/components/DescriptionList/DescriptionList.mdx
+++ b/packages/components/src/components/DescriptionList/DescriptionList.mdx
@@ -1,16 +1,9 @@
-import {
-  Story,
-  Canvas,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
+import { Meta, ArgTypes, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import { DescriptionListDesc, DescriptionListGroup } from '.';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as DescriptionListStories from './DescriptionList.stories';
 
@@ -26,13 +19,9 @@ import * as DescriptionListStories from './DescriptionList.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={DescriptionListStories.Default} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-descriptionlist`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/DescriptionList" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 

--- a/packages/components/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/packages/components/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -1,5 +1,6 @@
 import { ddsBaseTokens as tokens } from '@norges-domstoler/dds-design-tokens';
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { CallIcon } from '../Icon/icons';
 import { Typography } from '../Typography';
@@ -8,159 +9,181 @@ import {
   DescriptionList,
   DescriptionListDesc,
   DescriptionListGroup,
-  type DescriptionListProps,
   DescriptionListTerm,
 } from '.';
 
 export default {
   title: 'dds-components/DescriptionList',
   component: DescriptionList,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Overview = () => {
-  return (
+type Story = StoryObj<typeof DescriptionList>;
+
+export const Overview: Story = {
+  decorators: Story => (
     <StoryTemplate
       display="grid"
       title="DescriptionList - overview"
       gap="30px"
       $columnsAmount={2}
     >
-      <DescriptionList>
-        <DescriptionListTerm>Tittel</DescriptionListTerm>
-        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-
-        <DescriptionListTerm>Tittel</DescriptionListTerm>
-        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-      </DescriptionList>
-      <DescriptionList appearance="small">
-        <DescriptionListTerm>Tittel</DescriptionListTerm>
-        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-
-        <DescriptionListTerm>Tittel</DescriptionListTerm>
-        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-      </DescriptionList>
-
-      <DescriptionList>
-        <DescriptionListTerm>Tittel</DescriptionListTerm>
-        <DescriptionListDesc icon={CallIcon}>
-          <Typography typographyType="a">+47 123 45 678</Typography>
-        </DescriptionListDesc>
-        <DescriptionListTerm>Tittel</DescriptionListTerm>
-        <DescriptionListDesc icon={CallIcon}>
-          <Typography typographyType="a">+47 123 45 678</Typography>
-        </DescriptionListDesc>
-      </DescriptionList>
-
-      <DescriptionList appearance="small">
-        <DescriptionListTerm>Tittel</DescriptionListTerm>
-        <DescriptionListDesc icon={CallIcon}>
-          <Typography typographyType="a">+47 123 45 678</Typography>
-        </DescriptionListDesc>
-        <DescriptionListTerm>Tittel</DescriptionListTerm>
-        <DescriptionListDesc icon={CallIcon}>
-          <Typography typographyType="a">+47 123 45 678</Typography>
-        </DescriptionListDesc>
-      </DescriptionList>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: () => (
+    <>
+      <DescriptionList>
+        <DescriptionListTerm>Tittel</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+
+        <DescriptionListTerm>Tittel</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+      </DescriptionList>
+      <DescriptionList appearance="small">
+        <DescriptionListTerm>Tittel</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+
+        <DescriptionListTerm>Tittel</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+      </DescriptionList>
+
+      <DescriptionList>
+        <DescriptionListTerm>Tittel</DescriptionListTerm>
+        <DescriptionListDesc icon={CallIcon}>
+          <Typography typographyType="a">+47 123 45 678</Typography>
+        </DescriptionListDesc>
+        <DescriptionListTerm>Tittel</DescriptionListTerm>
+        <DescriptionListDesc icon={CallIcon}>
+          <Typography typographyType="a">+47 123 45 678</Typography>
+        </DescriptionListDesc>
+      </DescriptionList>
+
+      <DescriptionList appearance="small">
+        <DescriptionListTerm>Tittel</DescriptionListTerm>
+        <DescriptionListDesc icon={CallIcon}>
+          <Typography typographyType="a">+47 123 45 678</Typography>
+        </DescriptionListDesc>
+        <DescriptionListTerm>Tittel</DescriptionListTerm>
+        <DescriptionListDesc icon={CallIcon}>
+          <Typography typographyType="a">+47 123 45 678</Typography>
+        </DescriptionListDesc>
+      </DescriptionList>
+    </>
+  ),
 };
 
-export const Default = (args: DescriptionListProps) => {
-  return (
+export const Default: Story = {
+  decorators: Story => (
     <StoryTemplate title="DescriptionList - default">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <DescriptionList {...args}>
+      <DescriptionListTerm>Tittel</DescriptionListTerm>
+      <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+      <DescriptionListTerm>Tittel</DescriptionListTerm>
+      <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+    </DescriptionList>
+  ),
+};
+
+export const Group: Story = {
+  decorators: Story => (
+    <StoryTemplate title="DescriptionList - group">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <div>
       <DescriptionList {...args}>
-        <DescriptionListTerm>Tittel</DescriptionListTerm>
-        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-        <DescriptionListTerm>Tittel</DescriptionListTerm>
-        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Tittel 1</DescriptionListTerm>
+          <DescriptionListDesc>Beskrivelse 1</DescriptionListDesc>
+          <DescriptionListDesc>Beskrivelse 1</DescriptionListDesc>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Tittel 2</DescriptionListTerm>
+          <DescriptionListDesc>Beskrivelse 2</DescriptionListDesc>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Tittel 3</DescriptionListTerm>
+          <DescriptionListDesc>Beskrivelse 3</DescriptionListDesc>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>Tittel 4</DescriptionListTerm>
+          <DescriptionListDesc>Beskrivelse 4</DescriptionListDesc>
+        </DescriptionListGroup>
       </DescriptionList>
-    </StoryTemplate>
-  );
+    </div>
+  ),
 };
 
-export const Group = (args: DescriptionListProps) => {
-  return (
-    <StoryTemplate title="DescriptionList - group" gap="0px">
-      <div>
-        <DescriptionList {...args}>
-          <DescriptionListGroup>
-            <DescriptionListTerm>Tittel 1</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse 1</DescriptionListDesc>
-            <DescriptionListDesc>Beskrivelse 1</DescriptionListDesc>
-          </DescriptionListGroup>
-          <DescriptionListGroup>
-            <DescriptionListTerm>Tittel 2</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse 2</DescriptionListDesc>
-          </DescriptionListGroup>
-          <DescriptionListGroup>
-            <DescriptionListTerm>Tittel 3</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse 3</DescriptionListDesc>
-          </DescriptionListGroup>
-          <DescriptionListGroup>
-            <DescriptionListTerm>Tittel 4</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse 4</DescriptionListDesc>
-          </DescriptionListGroup>
-        </DescriptionList>
-      </div>
-    </StoryTemplate>
-  );
-};
-
-export const WithIcon = (args: DescriptionListProps) => {
-  return (
+export const WithIcon: Story = {
+  decorators: Story => (
     <StoryTemplate title="DescriptionList - with icon">
-      <DescriptionList {...args}>
-        <DescriptionListTerm>Tittel</DescriptionListTerm>
-        <DescriptionListDesc icon={CallIcon}>
-          <Typography typographyType="a">+47 123 45 678</Typography>
-        </DescriptionListDesc>
-      </DescriptionList>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <DescriptionList {...args}>
+      <DescriptionListTerm>Tittel</DescriptionListTerm>
+      <DescriptionListDesc icon={CallIcon}>
+        <Typography typographyType="a">+47 123 45 678</Typography>
+      </DescriptionListDesc>
+    </DescriptionList>
+  ),
 };
 
-export const RowDirectionExample = (args: DescriptionListProps) => {
-  const margin = tokens.spacing.SizesDdsSpacingX1;
-  return (
-    <StoryTemplate title="DescriptionList - Flere kolonner">
-      <div>
-        <DescriptionList {...args} direction="row">
-          <DescriptionListGroup margin={margin}>
-            <DescriptionListTerm>Tittel 1</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse 1</DescriptionListDesc>
-          </DescriptionListGroup>
-          <DescriptionListGroup margin={margin}>
-            <DescriptionListTerm>Tittel 2</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse 2</DescriptionListDesc>
-          </DescriptionListGroup>
-          <DescriptionListGroup margin={margin}>
-            <DescriptionListTerm>Tittel 3</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse 3</DescriptionListDesc>
-          </DescriptionListGroup>
-          <DescriptionListGroup margin={margin}>
-            <DescriptionListTerm>Tittel 4</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse 4</DescriptionListDesc>
-          </DescriptionListGroup>
-          <DescriptionListGroup margin={margin}>
-            <DescriptionListTerm>Tittel 5</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse 5</DescriptionListDesc>
-          </DescriptionListGroup>
-          <DescriptionListGroup margin={margin}>
-            <DescriptionListTerm>Tittel 6</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse 6</DescriptionListDesc>
-          </DescriptionListGroup>
-          <DescriptionListGroup margin={margin}>
-            <DescriptionListTerm>Tittel 7</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse 7</DescriptionListDesc>
-          </DescriptionListGroup>
-          <DescriptionListGroup margin={margin}>
-            <DescriptionListTerm>Tittel 8</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse 8</DescriptionListDesc>
-          </DescriptionListGroup>
-        </DescriptionList>
-      </div>
+const margin = tokens.spacing.SizesDdsSpacingX1;
+export const RowDirectionExample: Story = {
+  decorators: Story => (
+    <StoryTemplate title="DescriptionList - flere kolonner">
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <DescriptionList {...args} direction="row">
+      <DescriptionListGroup margin={margin}>
+        <DescriptionListTerm>Tittel 1</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse 1</DescriptionListDesc>
+      </DescriptionListGroup>
+      <DescriptionListGroup margin={margin}>
+        <DescriptionListTerm>Tittel 2</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse 2</DescriptionListDesc>
+      </DescriptionListGroup>
+      <DescriptionListGroup margin={margin}>
+        <DescriptionListTerm>Tittel 3</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse 3</DescriptionListDesc>
+      </DescriptionListGroup>
+      <DescriptionListGroup margin={margin}>
+        <DescriptionListTerm>Tittel 4</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse 4</DescriptionListDesc>
+      </DescriptionListGroup>
+      <DescriptionListGroup margin={margin}>
+        <DescriptionListTerm>Tittel 5</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse 5</DescriptionListDesc>
+      </DescriptionListGroup>
+      <DescriptionListGroup margin={margin}>
+        <DescriptionListTerm>Tittel 6</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse 6</DescriptionListDesc>
+      </DescriptionListGroup>
+      <DescriptionListGroup margin={margin}>
+        <DescriptionListTerm>Tittel 7</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse 7</DescriptionListDesc>
+      </DescriptionListGroup>
+      <DescriptionListGroup margin={margin}>
+        <DescriptionListTerm>Tittel 8</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse 8</DescriptionListDesc>
+      </DescriptionListGroup>
+    </DescriptionList>
+  ),
 };

--- a/packages/components/src/components/Divider/Divider.mdx
+++ b/packages/components/src/components/Divider/Divider.mdx
@@ -1,16 +1,8 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { Divider } from '.';
+import { Canvas, Controls, Meta, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as DividerStories from './Divider.stories';
 
@@ -26,11 +18,9 @@ import * as DividerStories from './Divider.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={DividerStories.Default} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-divider`} />
+Se stories med kontrollere i <LinkTo title="dds-components/Divider" story="Default">Storybook</LinkTo>.
 
 ## Bruk i koden
 
@@ -43,6 +33,7 @@ import * as DividerStories from './Divider.stories';
 
 ## API
 
-<ArgTypes of={DividerStories} />
+<Canvas of={DividerStories.Default} sourceState="shown" />
+<Controls of={DividerStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLHRElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/Divider/Divider.stories.tsx
+++ b/packages/components/src/components/Divider/Divider.stories.tsx
@@ -1,56 +1,67 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { Typography } from '../Typography';
 
-import { Divider, type DividerProps } from '.';
+import { Divider } from '.';
 
 export default {
   title: 'dds-components/Divider',
   component: Divider,
-  argTypes: {},
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Overview = (args: DividerProps) => {
-  return (
+type Story = StoryObj<typeof Divider>;
+
+export const Overview: Story = {
+  decorators: Story => (
     <StoryTemplate title="Divider - overview" display="block">
-      <div>
-        <Divider {...args} />
-        <Divider {...args} color="primaryLighter" />
-      </div>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <div>
+      <Divider {...args} />
+      <Divider {...args} color="primaryLighter" />
+    </div>
+  ),
 };
 
-export const Default = (args: DividerProps) => {
-  return (
+export const Default: Story = {
+  decorators: Story => (
     <StoryTemplate title="Divider - default" display="block">
-      <div>
-        <Divider {...args} />
-      </div>
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const Example = (args: DividerProps) => {
-  return (
+export const Example: Story = {
+  decorators: Story => (
     <StoryTemplate title="Divider - example">
-      <div>
-        <Typography withMargins>
-          Vitner er svært viktige for rettssikkerheten i samfunnet. Du har fått
-          en innkalling (kalles stevning) til saken fordi partene eller retten
-          mener du kjenner til noe som kan være viktig for retten å vite. Du har
-          plikt til å møte opp i tråd med innkallingen og forklare deg for
-          retten.
-        </Typography>
-        <Divider {...args} />
-        <Typography withMargins>
-          En rettssak avgjøres med bakgrunn i det som er kommet fram i
-          rettssalen. Derfor må vitner forklare seg for retten slik at dommerne
-          hører vitneforklaringen. Det gjelder selv om man tidligere ha forklart
-          seg for politiet eller partenes advokat. En vitneforklaring kan
-          avgjøre utfallet av en sak, derfor har vitner plikt til å snakke sant.
-        </Typography>
-      </div>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <div>
+      <Typography withMargins>
+        Vitner er svært viktige for rettssikkerheten i samfunnet. Du har fått en
+        innkalling (kalles stevning) til saken fordi partene eller retten mener
+        du kjenner til noe som kan være viktig for retten å vite. Du har plikt
+        til å møte opp i tråd med innkallingen og forklare deg for retten.
+      </Typography>
+      <Divider {...args} />
+      <Typography withMargins>
+        En rettssak avgjøres med bakgrunn i det som er kommet fram i rettssalen.
+        Derfor må vitner forklare seg for retten slik at dommerne hører
+        vitneforklaringen. Det gjelder selv om man tidligere ha forklart seg for
+        politiet eller partenes advokat. En vitneforklaring kan avgjøre utfallet
+        av en sak, derfor har vitner plikt til å snakke sant.
+      </Typography>
+    </div>
+  ),
 };

--- a/packages/components/src/components/Drawer/Drawer.mdx
+++ b/packages/components/src/components/Drawer/Drawer.mdx
@@ -1,16 +1,9 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
+import { Canvas, Controls, Primary, Meta, ArgTypes } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import { DrawerGroup } from '.';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as DrawerStories from './Drawer.stories';
 
@@ -26,11 +19,9 @@ import * as DrawerStories from './Drawer.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={DrawerStories.Default} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-drawer`} />
+Se stories med kontrollere i <LinkTo title="dds-components/Drawer" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -82,13 +73,14 @@ const id = 'id';
   Innhold
 </Drawer>`} />
 
-## API
+## Props
 
 ### Drawer
 
 Hovedkomponenten `<Drawer/>`.
 
-<ArgTypes of={DrawerStories} />
+<Canvas of={DrawerStories.Default} sourceState="shown" />
+<Controls of={DrawerStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/components/Drawer/Drawer.stories.tsx
@@ -1,42 +1,81 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { Button } from '../Button';
 import { Typography } from '../Typography';
 
-import { Drawer, DrawerGroup, type DrawerProps } from '.';
+import { Drawer, DrawerGroup } from '.';
 
 export default {
   title: 'dds-components/Drawer',
   component: Drawer,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const OverviewPlacement = (args: DrawerProps) => {
-  return (
+type Story = StoryObj<typeof Drawer>;
+
+export const Default: Story = {
+  args: { header: 'Tittel' },
+  decorators: Story => (
+    <StoryTemplate title="Drawer - default">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <DrawerGroup>
+      <Button>Åpne</Button>
+      <Drawer {...args}>
+        Innhold
+        <Button>Gjør noe</Button>
+      </Drawer>
+    </DrawerGroup>
+  ),
+};
+
+export const OverviewPlacement: Story = {
+  args: { header: 'Tittel' },
+  decorators: Story => (
     <StoryTemplate title="Drawer - placement overview">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <DrawerGroup>
         <Button>Åpne høyre</Button>
-        <Drawer {...args} header="Tittel">
+        <Drawer {...args}>
           Innhold
           <Button>Gjør noe</Button>
         </Drawer>
       </DrawerGroup>
       <DrawerGroup>
         <Button>Åpne venstre</Button>
-        <Drawer {...args} header="Tittel" placement="left">
+        <Drawer {...args} placement="left">
           Innhold
           <Button>Gjør noe</Button>
         </Drawer>
       </DrawerGroup>
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const OverviewSizes = (args: DrawerProps) => {
-  return (
+export const OverviewSizes: Story = {
+  args: { header: 'Rettsmekling' },
+  decorators: Story => (
     <StoryTemplate title="Drawer - size overview">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <DrawerGroup>
         <Button>Åpne liten</Button>
-        <Drawer {...args} header="Rettsmekling">
+        <Drawer {...args}>
           <Typography>
             En sivil tvist kan løses ved hjelp av rettsmekling i stedet for
             hovedforhandling og dom. Det går ut på at partene kommer fram til en
@@ -58,7 +97,7 @@ export const OverviewSizes = (args: DrawerProps) => {
       </DrawerGroup>
       <DrawerGroup>
         <Button>Åpne medium</Button>
-        <Drawer {...args} header="Rettsmekling" size="medium">
+        <Drawer {...args} size="medium">
           <Typography>
             En sivil tvist kan løses ved hjelp av rettsmekling i stedet for
             hovedforhandling og dom. Det går ut på at partene kommer fram til en
@@ -80,7 +119,7 @@ export const OverviewSizes = (args: DrawerProps) => {
       </DrawerGroup>
       <DrawerGroup>
         <Button>Åpne stor</Button>
-        <Drawer {...args} header="Rettsmekling" size="large">
+        <Drawer {...args} size="large">
           <Typography>
             En sivil tvist kan løses ved hjelp av rettsmekling i stedet for
             hovedforhandling og dom. Det går ut på at partene kommer fram til en
@@ -100,87 +139,77 @@ export const OverviewSizes = (args: DrawerProps) => {
           <Button>Gjør noe</Button>
         </Drawer>
       </DrawerGroup>
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const Default = (args: DrawerProps) => {
-  return (
-    <StoryTemplate title="Drawer - default">
-      <DrawerGroup>
-        <Button>Åpne</Button>
-        <Drawer {...args} header="Tittel">
-          Innhold
-          <Button>Gjør noe</Button>
-        </Drawer>
-      </DrawerGroup>
-    </StoryTemplate>
-  );
-};
-
-export const LongContent = (args: DrawerProps) => {
-  return (
+export const LongContent: Story = {
+  args: { header: 'Rettsmekling' },
+  decorators: Story => (
     <StoryTemplate title="Drawer - long content">
-      <DrawerGroup>
-        <Button>Åpne</Button>
-        <Drawer {...args} header="Rettsmekling">
-          <Typography>
-            En sivil tvist kan løses ved hjelp av rettsmekling i stedet for
-            hovedforhandling og dom. Det går ut på at partene kommer fram til en
-            avtale, kalt rettsforlik, ved hjelp av en mekler. Dette er en
-            raskere, mer effektiv og billigere måte å løse konflikten på.
-          </Typography>
-          <Typography typographyType="headingSans02">
-            Hva er rettsmekling?
-          </Typography>
-          <Typography>
-            Rettsmekling går ut på at partene selv finner en løsning på
-            konflikten ved å bruke en mekler (vanligvis en dommer i domstolen
-            som behandler saken). Avtalen man kommer fram til, blir rettskraftig
-            på lik linje med en dom. Rettsmekling kan bare brukes i sivile
-            saker, ikke i straffesaker.
-          </Typography>
-          <Typography typographyType="headingSans02">
-            Hva er fordelene med rettsmekling?
-          </Typography>
-          <Typography>
-            Formålet med rettsmekling er at partene blir enige om en løsning som
-            alle partene kan leve med. En mekler hjelper partene til å komme
-            fram til enighet ved å få innblikk i hva slags interesser og behov
-            partene har, og vil prøve å skape en dialog preget av forståelse og
-            enighet. Det innebærer som regel at partene må være innstilt på et
-            kompromiss sammenlignet med sitt opprinnelige standpunkt.
-          </Typography>
-          <Typography>
-            I et meklingsresultat blir ingen av partene "vinner" eller "taper".
-            Hensikten er at begge parter skal vinne på denne metoden og at
-            resultatet blir lettere å leve med i ettertid.
-          </Typography>
-          <Typography>
-            Rettsmekling egner seg derfor særlig godt som metode hvis partene
-            fortsatt skal ha kontakt i tiden framover (for eksempel
-            forretningsforbindelser, naboer eller i arbeids- og husleieforhold).
-            Rettsmekling kan uansett være et godt alternativ også i de fleste
-            andre typer konflikter. En mekling er raskere, enklere og vanligvis
-            billigere for partene enn ordinær domstolsbehandling.
-          </Typography>
-          <Typography>
-            Gjennom meklingen bidrar dommeren til å sette partenes faktiske
-            interesser og behov i fokus, mer enn de rent juridiske argumentene.
-            Dermed blir det også lettere å finne en skreddersydd løsning på
-            tvisten. Andre tema enn det saken gjelder kan trekkes inn i
-            rettsmeklingen. Dette gjør at rettsmeklingen kan bidra til løsning
-            av flere konflikter mellom partene enn det saken i utgangspunktet
-            gjelder.
-          </Typography>
-          <Typography>
-            Rettsmekling foregår for lukkede dører og uten rettsmøte. Partene
-            unngår dermed den publisiteten som ordinær rettsbehandling kan
-            medføre.
-          </Typography>
-          <Button>Gjør noe</Button>
-        </Drawer>
-      </DrawerGroup>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <DrawerGroup>
+      <Button>Åpne</Button>
+      <Drawer {...args}>
+        <Typography>
+          En sivil tvist kan løses ved hjelp av rettsmekling i stedet for
+          hovedforhandling og dom. Det går ut på at partene kommer fram til en
+          avtale, kalt rettsforlik, ved hjelp av en mekler. Dette er en raskere,
+          mer effektiv og billigere måte å løse konflikten på.
+        </Typography>
+        <Typography typographyType="headingSans02">
+          Hva er rettsmekling?
+        </Typography>
+        <Typography>
+          Rettsmekling går ut på at partene selv finner en løsning på konflikten
+          ved å bruke en mekler (vanligvis en dommer i domstolen som behandler
+          saken). Avtalen man kommer fram til, blir rettskraftig på lik linje
+          med en dom. Rettsmekling kan bare brukes i sivile saker, ikke i
+          straffesaker.
+        </Typography>
+        <Typography typographyType="headingSans02">
+          Hva er fordelene med rettsmekling?
+        </Typography>
+        <Typography>
+          Formålet med rettsmekling er at partene blir enige om en løsning som
+          alle partene kan leve med. En mekler hjelper partene til å komme fram
+          til enighet ved å få innblikk i hva slags interesser og behov partene
+          har, og vil prøve å skape en dialog preget av forståelse og enighet.
+          Det innebærer som regel at partene må være innstilt på et kompromiss
+          sammenlignet med sitt opprinnelige standpunkt.
+        </Typography>
+        <Typography>
+          I et meklingsresultat blir ingen av partene "vinner" eller "taper".
+          Hensikten er at begge parter skal vinne på denne metoden og at
+          resultatet blir lettere å leve med i ettertid.
+        </Typography>
+        <Typography>
+          Rettsmekling egner seg derfor særlig godt som metode hvis partene
+          fortsatt skal ha kontakt i tiden framover (for eksempel
+          forretningsforbindelser, naboer eller i arbeids- og husleieforhold).
+          Rettsmekling kan uansett være et godt alternativ også i de fleste
+          andre typer konflikter. En mekling er raskere, enklere og vanligvis
+          billigere for partene enn ordinær domstolsbehandling.
+        </Typography>
+        <Typography>
+          Gjennom meklingen bidrar dommeren til å sette partenes faktiske
+          interesser og behov i fokus, mer enn de rent juridiske argumentene.
+          Dermed blir det også lettere å finne en skreddersydd løsning på
+          tvisten. Andre tema enn det saken gjelder kan trekkes inn i
+          rettsmeklingen. Dette gjør at rettsmeklingen kan bidra til løsning av
+          flere konflikter mellom partene enn det saken i utgangspunktet
+          gjelder.
+        </Typography>
+        <Typography>
+          Rettsmekling foregår for lukkede dører og uten rettsmøte. Partene
+          unngår dermed den publisiteten som ordinær rettsbehandling kan
+          medføre.
+        </Typography>
+        <Button>Gjør noe</Button>
+      </Drawer>
+    </DrawerGroup>
+  ),
 };

--- a/packages/components/src/components/EmptyContent/EmptyContent.mdx
+++ b/packages/components/src/components/EmptyContent/EmptyContent.mdx
@@ -1,10 +1,6 @@
-import { Canvas, Story, Meta, ArgTypes } from '@storybook/blocks';
-import {
-  Source,
-  ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
-} from '@norges-domstoler/storybook-components';
+import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as EmptyContentStories from './EmptyContent.stories';
 
 <Meta of={EmptyContentStories} />
@@ -19,25 +15,13 @@ import * as EmptyContentStories from './EmptyContent.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={EmptyContentStories.Overview} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-emptycontent`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/EmptyContent" story="Default">Storybook</LinkTo>.
 
-## Bruk i koden
+## Props
 
-<Source
-  code={`
-  import { EmptyContent } from '@norges-domstoler/dds-components';
-
-<EmptyContent message="Du har ikke gjort noen valg" />
-`} />
-
-## API
-
-<ArgTypes of={EmptyContentStories} />
+<Canvas of={EmptyContentStories.Default} sourceState="shown" />
+<Controls of={EmptyContentStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/EmptyContent/EmptyContent.stories.tsx
+++ b/packages/components/src/components/EmptyContent/EmptyContent.stories.tsx
@@ -1,6 +1,7 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { EmptyContent, type EmptyContentProps } from './EmptyContent';
+import { EmptyContent } from './EmptyContent';
 
 export default {
   title: 'dds-components/EmptyContent',
@@ -11,11 +12,34 @@ export default {
       type: { name: 'string', required: false },
     },
   },
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Overview = (args: EmptyContentProps) => {
-  return (
-    <StoryTemplate title="EmptyContent">
+type Story = StoryObj<typeof EmptyContent>;
+
+export const Default: Story = {
+  args: { title: 'Tittel', message: 'Dette er en tekst.' },
+  decorators: Story => (
+    <StoryTemplate title="EmptyContent - default">
+      <Story />
+    </StoryTemplate>
+  ),
+};
+
+export const Overview: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="EmptyContent - overview">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <EmptyContent {...args} title="Tittel" message="Dette er en tekst." />
 
       <EmptyContent {...args} message="Kort melding." />
@@ -39,6 +63,6 @@ export const Overview = (args: EmptyContentProps) => {
           message="Ligger inne i et element med definert høyde og bredde."
         />
       </div>
-    </StoryTemplate>
-  );
+    </>
+  ),
 };

--- a/packages/components/src/components/FavStar/FavStar.mdx
+++ b/packages/components/src/components/FavStar/FavStar.mdx
@@ -1,15 +1,8 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
+import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 
 import * as FavStarStories from './FavStar.stories';
@@ -26,11 +19,9 @@ import * as FavStarStories from './FavStar.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={FavStarStories.Default} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-favstar`} />
+Se stories med kontrollere i <LinkTo title="dds-components/FavStar" story="Default">Storybook</LinkTo>.
 
 ## Bruk i koden
 
@@ -44,6 +35,7 @@ const [checked, setChecked] = useState<boolean>(false);
 <FavStar checked={checked} onChange={setChecked} />
 `} />
 
-## API
+## Props
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={FavStarStories.Default} sourceState="shown" />
+<Controls of={FavStarStories.Default} />

--- a/packages/components/src/components/FavStar/FavStar.stories.tsx
+++ b/packages/components/src/components/FavStar/FavStar.stories.tsx
@@ -1,8 +1,8 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
-import { type Meta } from '@storybook/react';
+import { type Meta, type StoryObj } from '@storybook/react';
 import { useRef, useState } from 'react';
 
-import { FavStar, type FavStarProps } from './FavStar';
+import { FavStar } from './FavStar';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { AttachmentIcon } from '../Icon/icons';
@@ -15,6 +15,12 @@ import { Heading, Link } from '../Typography';
 const meta: Meta<typeof FavStar> = {
   title: 'dds-components/FavStar',
   component: FavStar,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
   argTypes: {
     size: {
       control: {
@@ -27,176 +33,211 @@ const meta: Meta<typeof FavStar> = {
 
 export default meta;
 
-export const Default = (args: Partial<FavStarProps>) => {
-  return (
+type Story = StoryObj<typeof FavStar>;
+
+export const Default: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate title="FavStar - default">
-      <FavStar {...args} />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const OverviewSizes = (args: Partial<FavStarProps>) => {
-  return (
+export const OverviewSizes: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate title="FavStar - overview sizes">
-      <VStack gap="x3" align="flex-start">
-        <VStack gap="x1" align="flex-start">
-          <Heading level={2} typographyType="headingSans03">
-            Medium
-          </Heading>
-          <FavStar {...args} size="medium" />
-        </VStack>
-        <VStack gap="x1" align="flex-start">
-          <Heading level={2} typographyType="headingSans03">
-            Large
-          </Heading>
-          <FavStar {...args} size="large" />
-        </VStack>
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <VStack gap="x3" align="flex-start">
+      <VStack gap="x1" align="flex-start">
+        <Heading level={2} typographyType="headingSans03">
+          Medium
+        </Heading>
+        <FavStar {...args} size="medium" />
       </VStack>
-    </StoryTemplate>
-  );
+      <VStack gap="x1" align="flex-start">
+        <Heading level={2} typographyType="headingSans03">
+          Large
+        </Heading>
+        <FavStar {...args} size="large" />
+      </VStack>
+    </VStack>
+  ),
 };
 
-export const Controlled = (args: Partial<FavStarProps>) => {
-  const [checked, setChecked] = useState(false);
-  return (
+export const Controlled: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate title="FavStar - controlled">
-      <FavStar {...args} checked={checked} onChange={setChecked} />
-      <Checkbox
-        checked={checked}
-        onChange={e => setChecked(e.target.checked)}
-        label="Er favoritt?"
-      />
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const [checked, setChecked] = useState(false);
+    return (
+      <>
+        <FavStar {...args} checked={checked} onChange={setChecked} />
+        <Checkbox
+          checked={checked}
+          onChange={e => setChecked(e.target.checked)}
+          label="Er favoritt?"
+        />
+      </>
+    );
+  },
 };
 
-export const UsingRef = (args: Partial<FavStarProps>) => {
-  const favstarRef = useRef<HTMLInputElement>(null);
-  return (
+export const UsingRef: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate title="FavStar - using ref">
-      <FavStar {...args} ref={favstarRef} />
-      <Button onClick={() => favstarRef.current?.focus()}>Focus</Button>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const favstarRef = useRef<HTMLInputElement>(null);
+    return (
+      <>
+        <FavStar {...args} ref={favstarRef} />
+        <Button onClick={() => favstarRef.current?.focus()}>Focus</Button>
+      </>
+    );
+  },
 };
 
-export const RealWorld = (args: Partial<FavStarProps>) => {
-  const documents = [
-    {
-      id: 1,
-      name: 'Krav om sak inkl. 1 vedlegg fra Petter Sæther Moen.pdf',
-      from: 'Ola Nordmann',
-      to: 'Trøndelag tingrett',
-      timestamp: '28.08.2023',
-      read: true,
-      numAttachments: 1,
-    },
-    {
-      id: 2,
-      name: 'Bekreftelse og inngangsgebyr - Selvprosederende',
-      from: 'Trøndelag tingrett',
-      to: 'Ola Nordmann',
-      timestamp: '31.08.2023',
-      read: false,
-      numAttachments: 2,
-    },
-    {
-      id: 3,
-      name: 'Forkynning av sak - med spørsmål om meddommere',
-      from: 'Trøndelag tingrett',
-      to: 'Ikke oppgitt',
-      timestamp: '04.09.2023',
-      read: false,
-      numAttachments: 0,
-    },
-    {
-      id: 4,
-      name: 'Oversendelse av dokument',
-      from: 'Trøndelag tingrett',
-      to: 'Ola Nordmann',
-      timestamp: '04.09.2023',
-      read: false,
-      numAttachments: 1,
-    },
-  ];
-  const [favoriteDocuments, setFavoriteDocuments] = useState(new Set<number>());
-  console.log(favoriteDocuments);
-  return (
-    <StoryTemplate title="FavStar - real world example">
-      <Heading level={2}>Saksdokumenter</Heading>
-      <Table.Wrapper>
-        <Table>
-          <Table.Head>
-            <Table.Row>
-              <Table.Cell></Table.Cell>
-              <Table.Cell>Nr.</Table.Cell>
-              <Table.Cell></Table.Cell>
-              <Table.Cell>Dokumentnavn</Table.Cell>
-              <Table.Cell>Avsender</Table.Cell>
-              <Table.Cell>Mottakere</Table.Cell>
-              <Table.Cell>Sendt</Table.Cell>
-              <Table.Cell>Vedlegg</Table.Cell>
-            </Table.Row>
-          </Table.Head>
-          <Table.Body>
-            {documents.map(document => (
-              <Table.Row key={document.id}>
-                <Table.Cell>
-                  <FavStar
-                    {...args}
-                    checked={favoriteDocuments.has(document.id)}
-                    onChange={newChecked =>
-                      setFavoriteDocuments(prev => {
-                        const newSet = new Set(prev);
-                        console.log(newChecked);
-
-                        if (newChecked) {
-                          newSet.add(document.id);
-                        } else {
-                          newSet.delete(document.id);
-                        }
-
-                        return newSet;
-                      })
-                    }
-                  />
-                </Table.Cell>
-                <Table.Cell>{document.id}</Table.Cell>
-                <Table.Cell>
-                  {!document.read && (
-                    <Tooltip text="Ulest">
-                      <div
-                        style={{
-                          backgroundColor: 'var(--dds-color-interactive-light)',
-                          border: '1px solid var(--dds-color-interactive-base)',
-                          width: '10px',
-                          height: '10px',
-                          borderRadius: '10px',
-                        }}
-                      />
-                    </Tooltip>
-                  )}
-                </Table.Cell>
-                <Table.Cell>
-                  <Link
-                    href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-                    external
-                  >
-                    {document.name}
-                  </Link>
-                </Table.Cell>
-                <Table.Cell>{document.from}</Table.Cell>
-                <Table.Cell>{document.to}</Table.Cell>
-                <Table.Cell>{document.timestamp}</Table.Cell>
-                <Table.Cell>
-                  <Icon icon={AttachmentIcon} />
-                  {document.numAttachments}
-                </Table.Cell>
-              </Table.Row>
-            ))}
-          </Table.Body>
-        </Table>
-      </Table.Wrapper>
+export const RealWorld: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="FavStar - real world">
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const documents = [
+      {
+        id: 1,
+        name: 'Krav om sak inkl. 1 vedlegg fra Petter Sæther Moen.pdf',
+        from: 'Ola Nordmann',
+        to: 'Trøndelag tingrett',
+        timestamp: '28.08.2023',
+        read: true,
+        numAttachments: 1,
+      },
+      {
+        id: 2,
+        name: 'Bekreftelse og inngangsgebyr - Selvprosederende',
+        from: 'Trøndelag tingrett',
+        to: 'Ola Nordmann',
+        timestamp: '31.08.2023',
+        read: false,
+        numAttachments: 2,
+      },
+      {
+        id: 3,
+        name: 'Forkynning av sak - med spørsmål om meddommere',
+        from: 'Trøndelag tingrett',
+        to: 'Ikke oppgitt',
+        timestamp: '04.09.2023',
+        read: false,
+        numAttachments: 0,
+      },
+      {
+        id: 4,
+        name: 'Oversendelse av dokument',
+        from: 'Trøndelag tingrett',
+        to: 'Ola Nordmann',
+        timestamp: '04.09.2023',
+        read: false,
+        numAttachments: 1,
+      },
+    ];
+    const [favoriteDocuments, setFavoriteDocuments] = useState(
+      new Set<number>(),
+    );
+
+    return (
+      <VStack>
+        <Heading level={2}>Saksdokumenter</Heading>
+        <Table.Wrapper>
+          <Table>
+            <Table.Head>
+              <Table.Row>
+                <Table.Cell></Table.Cell>
+                <Table.Cell>Nr.</Table.Cell>
+                <Table.Cell></Table.Cell>
+                <Table.Cell>Dokumentnavn</Table.Cell>
+                <Table.Cell>Avsender</Table.Cell>
+                <Table.Cell>Mottakere</Table.Cell>
+                <Table.Cell>Sendt</Table.Cell>
+                <Table.Cell>Vedlegg</Table.Cell>
+              </Table.Row>
+            </Table.Head>
+            <Table.Body>
+              {documents.map(document => (
+                <Table.Row key={document.id}>
+                  <Table.Cell>
+                    <FavStar
+                      {...args}
+                      checked={favoriteDocuments.has(document.id)}
+                      onChange={newChecked =>
+                        setFavoriteDocuments(prev => {
+                          const newSet = new Set(prev);
+                          console.log(newChecked);
+
+                          if (newChecked) {
+                            newSet.add(document.id);
+                          } else {
+                            newSet.delete(document.id);
+                          }
+
+                          return newSet;
+                        })
+                      }
+                    />
+                  </Table.Cell>
+                  <Table.Cell>{document.id}</Table.Cell>
+                  <Table.Cell>
+                    {!document.read && (
+                      <Tooltip text="Ulest">
+                        <div
+                          style={{
+                            backgroundColor:
+                              'var(--dds-color-interactive-light)',
+                            border:
+                              '1px solid var(--dds-color-interactive-base)',
+                            width: '10px',
+                            height: '10px',
+                            borderRadius: '10px',
+                          }}
+                        />
+                      </Tooltip>
+                    )}
+                  </Table.Cell>
+                  <Table.Cell>
+                    <Link
+                      href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+                      external
+                    >
+                      {document.name}
+                    </Link>
+                  </Table.Cell>
+                  <Table.Cell>{document.from}</Table.Cell>
+                  <Table.Cell>{document.to}</Table.Cell>
+                  <Table.Cell>{document.timestamp}</Table.Cell>
+                  <Table.Cell>
+                    <Icon icon={AttachmentIcon} />
+                    {document.numAttachments}
+                  </Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table>
+        </Table.Wrapper>
+      </VStack>
+    );
+  },
 };

--- a/packages/components/src/components/Feedback/Feedback.mdx
+++ b/packages/components/src/components/Feedback/Feedback.mdx
@@ -1,16 +1,6 @@
-import {
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-  Story,
-  Canvas,
-} from '@storybook/blocks';
-import {
-  Source,
-  ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
-} from '@norges-domstoler/storybook-components';
+import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as FeedbackStories from './Feedback.stories';
 
 <Meta of={FeedbackStories} />
@@ -29,22 +19,11 @@ Denne feedback-komponenten kan brukes sammen med den [fellese tilbakemeldingskli
 
 ## Demo
 
-<Canvas>
-  <Story of={FeedbackStories.Default} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-feedback`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/" story="Default">Storybook</LinkTo>.
 
-## Bruk i koden
+## Props
 
-<Source
-  code={`import { Feedback } from '@norges-domstoler/dds-components';
-
-<Feedback ratingLabel="Hvordan opplevdes innsendingen?" />
-`} />
-
-## API
-
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={FeedbackStories.Default} sourceState="shown" />
+<Controls of={FeedbackStories.Default} />

--- a/packages/components/src/components/Feedback/Feedback.stories.tsx
+++ b/packages/components/src/components/Feedback/Feedback.stories.tsx
@@ -1,6 +1,9 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { Feedback, type FeedbackProps } from '.';
+import { Divider } from '../Divider';
+
+import { Feedback } from '.';
 
 export default {
   title: 'dds-components/Feedback',
@@ -54,183 +57,94 @@ export default {
     },
   },
   parameters: {
-    controls: {
-      exclude: ['style', 'className'],
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
     },
   },
 };
 
-export const Default = (args: FeedbackProps) => {
-  return (
-    <StoryTemplate title="Feedback - Default">
-      <Feedback
-        {...args}
-        ratingLabel={args.ratingLabel ?? 'Hva syns du om tjenesten?'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-      />
+type Story = StoryObj<typeof Feedback>;
+
+export const Default: Story = {
+  args: { ratingLabel: 'Hva syns du om tjenesten?' },
+  decorators: Story => (
+    <StoryTemplate title="Feedback - default">
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const HorizontalLayout = (args: FeedbackProps) => {
-  return (
-    <StoryTemplate title="Feedback - Horizontal Layout">
-      <Feedback
-        {...args}
-        ratingLabel={args.ratingLabel ?? 'Hva syns du om tjenesten?'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-        layout="horizontal"
-      />
+export const HorizontalLayout: Story = {
+  args: { ratingLabel: 'Hva syns du om tjenesten?', layout: 'horizontal' },
+  decorators: Story => (
+    <StoryTemplate title="Feedback - horizontal layout">
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const WithoutTextArea = (args: FeedbackProps) => {
-  return (
-    <StoryTemplate title="Feedback - Without Text Area">
-      <Feedback
-        {...args}
-        ratingLabel={args.ratingLabel ?? 'Hva syns du om tjenesten?'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-        feedbackTextAreaExcluded
-      />
+export const WithoutTextArea: Story = {
+  args: {
+    ratingLabel: 'Hva syns du om tjenesten?',
+    feedbackTextAreaExcluded: true,
+  },
+  decorators: Story => (
+    <StoryTemplate title="Feedback - without text area">
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const CustomLabels = (args: FeedbackProps) => {
-  return (
-    <StoryTemplate title="Feedback - Custom Labels">
-      <Feedback
-        {...args}
-        ratingLabel={'Min egne label'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-      />
-      <hr style={{ width: '100%' }} />
-      <Feedback
-        {...args}
-        ratingLabel={'Min egne label'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-        positiveFeedbackLabel={'Min egne positive label'}
-        ratingValue="positive"
-      />
-      <hr style={{ width: '100%' }} />
-      <Feedback
-        {...args}
-        ratingLabel={'Min egne label'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-        negativeFeedbackLabel={'Min egne negative label'}
-        ratingValue="negative"
-      />
+export const CustomLabels: Story = {
+  args: {
+    ratingLabel: 'Min egen label',
+    positiveFeedbackLabel: 'Min egen positive label',
+    negativeFeedbackLabel: 'Min egen negative label',
+  },
+  decorators: Story => (
+    <StoryTemplate title="Feedback - custom labels">
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <>
+      <Feedback {...args} />
+      <Divider />
+      <Feedback {...args} ratingValue="positive" />
+      <Divider />
+      <Feedback {...args} ratingValue="negative" />
+    </>
+  ),
 };
 
-export const CustomButtonTooltips = (args: FeedbackProps) => {
-  return (
-    <StoryTemplate title="Feedback - Custom Button Tooltips">
-      <Feedback
-        {...args}
-        ratingLabel={args.ratingLabel ?? 'Hva syns du om tjenesten?'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-        thumbUpTooltip={'Liker'}
-        thumbDownTooltip={'Liker ikke'}
-      />
+export const CustomButtonTooltip: Story = {
+  args: {
+    ratingLabel: 'Hva syns du om tjenesten?',
+    thumbUpTooltip: 'Liker',
+    thumbDownTooltip: 'Liker ikke',
+  },
+  decorators: Story => (
+    <StoryTemplate title="Feedback - custom button tooltip">
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const LoadingState = (args: FeedbackProps) => {
-  return (
-    <StoryTemplate title="Feedback - Loading">
-      <Feedback
-        {...args}
-        ratingLabel={args.ratingLabel ?? 'Hva syns du om tjenesten?'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-        loading
-      />
-      <hr style={{ width: '100%' }} />
-      <Feedback
-        {...args}
-        ratingLabel={args.ratingLabel ?? 'Hva syns du om tjenesten?'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-        ratingValue="positive"
-        loading
-      />
+export const LoadingState: Story = {
+  args: {
+    ratingLabel: 'Hva synes du om tjenesten?',
+  },
+  decorators: Story => (
+    <StoryTemplate title="Feedback - loading">
+      <Story />
     </StoryTemplate>
-  );
-};
-
-export const ControlledComponent = (args: FeedbackProps) => {
-  return (
-    <StoryTemplate title="Feedback - Controlled Component">
-      Komponenten kan også brukes som en "controlled component", altså at
-      verdiene styres helt fra utsiden av komponenten.
-      <hr style={{ width: '100%' }} />
-      Kontrollert rating:
-      <Feedback
-        {...args}
-        ratingLabel={args.ratingLabel ?? 'Hva syns du om tjenesten?'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-        ratingValue={null}
-      />
-      <Feedback
-        {...args}
-        ratingLabel={args.ratingLabel ?? 'Hva syns du om tjenesten?'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-        ratingValue="positive"
-      />
-      <Feedback
-        {...args}
-        ratingLabel={args.ratingLabel ?? 'Hva syns du om tjenesten?'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-        ratingValue="negative"
-      />
-      <hr style={{ width: '100%' }} />
-      Kontrollert tekstfelt:
-      <Feedback
-        {...args}
-        ratingLabel={args.ratingLabel ?? 'Hva syns du om tjenesten?'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-        ratingValue="positive"
-        feedbackTextValue="Dette var ekstremt bra; Tommel opp!"
-      />
-      <hr style={{ width: '100%' }} />
-      Kontrollert at tilbakemelding er sendt inn:
-      <Feedback
-        {...args}
-        ratingLabel={args.ratingLabel ?? 'Hva syns du om tjenesten?'}
-        onSubmit={undefined}
-        onRating={undefined}
-        onFeedbackTextChange={undefined}
-        isSubmitted
-      />
-    </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <>
+      <Feedback {...args} loading />
+      <Divider />
+      <Feedback {...args} ratingValue="positive" loading />
+    </>
+  ),
 };

--- a/packages/components/src/components/FileUploader/FileUploader.mdx
+++ b/packages/components/src/components/FileUploader/FileUploader.mdx
@@ -1,9 +1,8 @@
-import { Story, Canvas, Meta, ArgTypes } from '@storybook/blocks';
+import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  LinkToInteractiveStory,
-  SB_DESIGNSYSTEM_URL,
 } from '@norges-domstoler/storybook-components';
 import * as FileUploaderStories from './FileUploader.stories';
 
@@ -19,13 +18,9 @@ import * as FileUploaderStories from './FileUploader.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={FileUploaderStories.Overview} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-fileuploader-beta`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/FileUploader" story="Default">Storybook</LinkTo>.
 
 ## Bruk i koden
 
@@ -37,6 +32,7 @@ import { FileUploader } from '@norges-domstoler/dds-components';
 `}
 />
 
-## API
+## Props
 
-<ArgTypes of={FileUploaderStories} />
+<Canvas of={FileUploaderStories.Default} sourceState="shown" />
+<Controls of={FileUploaderStories.Default} />

--- a/packages/components/src/components/FileUploader/FileUploader.stories.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.stories.tsx
@@ -1,7 +1,9 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 import { useEffect, useState } from 'react';
 
 import { FileUploader } from './FileUploader';
+import { VStack } from '../Stack';
 
 export default {
   title: 'dds-components/FileUploader',
@@ -10,6 +12,23 @@ export default {
     color: { control: { type: 'text' } },
     size: { control: { type: 'text' } },
   },
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
+};
+
+type Story = StoryObj<typeof FileUploader>;
+
+export const Default: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="FileUploader - default">
+      <Story />
+    </StoryTemplate>
+  ),
 };
 
 const SingleFileUploader = () => {
@@ -72,12 +91,18 @@ const WithErrorMessage = () => {
   );
 };
 
-export const Overview = () => {
-  return (
-    <StoryTemplate title="FileUploader - overview">
+export const Overview: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="FileUploader - default">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: () => (
+    <VStack>
       <SingleFileUploader />
       <PdfUploader />
       <WithErrorMessage />
-    </StoryTemplate>
-  );
+    </VStack>
+  ),
 };

--- a/packages/components/src/components/GlobalMessage/GlobalMessage.mdx
+++ b/packages/components/src/components/GlobalMessage/GlobalMessage.mdx
@@ -1,16 +1,8 @@
-import {
-  Story,
-  Canvas,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { GlobalMessage } from '.';
+import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as GlobalMessageStories from './GlobalMessage.stories';
 
@@ -26,27 +18,13 @@ import * as GlobalMessageStories from './GlobalMessage.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-globalmessage--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-globalmessage--default" />
-</Canvas>
+Se stories med kontrollere i <LinkTo title="dds-components/GlobalMessage" story="Default">Storybook</LinkTo>.
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-globalmessage`}
-/>
+## Props
 
-## Bruk i koden
-
-<Source
-  code={`
-  import { GlobalMessage } from '@norges-domstoler/dds-components';
-
-<GlobalMessage message="Dette er en global melding" />
-`} />
-
-## API
-
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={GlobalMessageStories.Default} sourceState="shown" />
+<Controls of={GlobalMessageStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/GlobalMessage/GlobalMessage.stories.tsx
+++ b/packages/components/src/components/GlobalMessage/GlobalMessage.stories.tsx
@@ -1,6 +1,8 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { GlobalMessage, type GlobalMessageProps } from './GlobalMessage';
+import { GlobalMessage } from './GlobalMessage';
+import { VStack } from '../Stack';
 
 export default {
   title: 'dds-components/GlobalMessage',
@@ -9,11 +11,37 @@ export default {
     message: { control: { type: 'text' } },
     closable: { control: { type: 'boolean' } },
   },
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Overview = (args: GlobalMessageProps) => {
-  return (
+type Story = StoryObj<typeof GlobalMessage>;
+
+export const Default: Story = {
+  args: {
+    purpose: 'info',
+    message: 'En tilfeldig melding',
+  },
+  decorators: Story => (
+    <StoryTemplate title="GlobalMessage - default">
+      <Story />
+    </StoryTemplate>
+  ),
+};
+
+export const Overview: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate title="GlobalMessage - overview">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <VStack>
       <GlobalMessage {...args} purpose="info" message="En tilfeldig melding" />
       <GlobalMessage
         {...args}
@@ -43,30 +71,19 @@ export const Overview = (args: GlobalMessageProps) => {
         message="En tilfeldig melding"
         closable
       />
-    </StoryTemplate>
-  );
+    </VStack>
+  ),
 };
 
-export const Default = (args: GlobalMessageProps) => {
-  return (
+export const Closable: Story = {
+  args: {
+    purpose: 'info',
+    message: 'En tilfeldig melding',
+    closable: true,
+  },
+  decorators: Story => (
     <StoryTemplate title="GlobalMessage - default">
-      <GlobalMessage
-        {...args}
-        message={args.message ?? 'En tilfeldig melding'}
-      />
+      <Story />
     </StoryTemplate>
-  );
-};
-
-export const Closable = (args: GlobalMessageProps) => {
-  return (
-    <StoryTemplate title="GlobalMessage - closable">
-      <GlobalMessage
-        {...args}
-        purpose={args.purpose ?? 'info'}
-        message={args.message ?? 'En tilfeldig melding'}
-        closable
-      />
-    </StoryTemplate>
-  );
+  ),
 };

--- a/packages/components/src/components/Grid/Grid.mdx
+++ b/packages/components/src/components/Grid/Grid.mdx
@@ -1,16 +1,9 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
+import { Meta, ArgTypes, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import { GridChild } from '.';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import { Link } from '../Typography';
 import * as GridStories from './Grid.stories';
@@ -26,13 +19,9 @@ import * as GridStories from './Grid.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-grid--page-example" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-grid--page-example" />
-</Canvas>
-
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-grid`} />
+Se stories med kontrollere i <LinkTo title="dds-components/Grid" story="PageExample">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -83,7 +72,7 @@ Grid består av to subkomponenter:
 
 En container-komponent for `<GridChild>` barn. Den håndterer grid layout basert på skjermstørrelse med hensyn til brekkpunkter.
 
-<ArgTypes story={PRIMARY_STORY} />
+<ArgTypes of={GridStories} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface eller `HTMLAttributes<HTMLFormElement>`-interface i `htmlProps`.
 `style` støtte både på rotnivå og i `htmlProps`.

--- a/packages/components/src/components/Grid/Grid.stories.tsx
+++ b/packages/components/src/components/Grid/Grid.stories.tsx
@@ -1,4 +1,5 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { ScreenSize, useScreenSize } from '../../hooks';
 import { Button } from '../Button';
@@ -11,99 +12,116 @@ import { Tag } from '../Tag';
 import { TextInput } from '../TextInput';
 import { Heading } from '../Typography';
 
-import { Grid, GridChild, type GridProps } from '.';
+import { Grid, GridChild } from '.';
 
 export default {
   title: 'dds-components/Grid',
   component: Grid,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const PageExample = (args: GridProps) => {
-  const screenSize = useScreenSize();
-  const isXSmall = screenSize === ScreenSize.XSmall;
-  const smallScreenVersion = isXSmall ? true : undefined;
-  return (
-    <>
-      <InternalHeader
-        applicationName="Applikasjon"
-        applicationDesc="Beskrivelse"
-        navigationElements={[
-          { title: 'Advokater', href: '/' },
-          { title: 'Saker', href: '/' },
-        ]}
-        smallScreen={smallScreenVersion}
-      />
-      <Grid {...args} style={{ marginTop: isXSmall ? '16px' : '32px' }}>
-        <GridChild
-          columnsOccupied={{
-            xs: '1/-1',
-            sm: '1/7',
-            md: '1/11',
-            lg: '1/11',
-            xl: '1/9',
-          }}
-        >
-          <Search buttonProps={{ onClick: () => null }} />
-        </GridChild>
-        <GridChild
-          columnsOccupied={{
-            xs: '1/-1',
-            sm: '7/9',
-            md: '11/13',
-            lg: '11/13',
-            xl: '9/13',
-          }}
-        >
-          <Button
-            icon={FilterIcon}
-            label="Filter"
-            appearance="borderless"
-            purpose="secondary"
-          />
-        </GridChild>
-        <GridChild columnsOccupied="all">
-          <Table.Wrapper>
-            <Table style={{ width: '100%' }}>
-              <Table.Head>
-                <Table.Row type="head">
-                  <Table.Cell type="head">Navn</Table.Cell>
-                  <Table.Cell type="head">Firma</Table.Cell>
-                  <Table.Cell type="head">Status</Table.Cell>
-                </Table.Row>
-              </Table.Head>
-              <Table.Body>
-                <Table.Row type="body">
-                  <Table.Cell> Marie Bjerke </Table.Cell>
-                  <Table.Cell>Advokat Firma </Table.Cell>
-                  <Table.Cell>
-                    <Tag text="Møterett" purpose="success" />
-                  </Table.Cell>
-                </Table.Row>
-                <Table.Row type="body">
-                  <Table.Cell>Sandra-Katrine Ingvaldsen Lovsetter</Table.Cell>
-                  <Table.Cell>Advokatene AS</Table.Cell>
-                  <Table.Cell>
-                    <Tag text="Ikke møterett" purpose="danger" />
-                  </Table.Cell>
-                </Table.Row>
-              </Table.Body>
-            </Table>
-          </Table.Wrapper>
-        </GridChild>
-        <GridChild columnsOccupied="all">
-          <Pagination
-            itemsAmount={20}
-            withCounter
-            smallScreen={smallScreenVersion}
-          />
-        </GridChild>
-      </Grid>
-    </>
-  );
+type Story = StoryObj<typeof Grid>;
+
+export const PageExample: Story = {
+  args: {},
+  render: args => {
+    const screenSize = useScreenSize();
+    const isXSmall = screenSize === ScreenSize.XSmall;
+    const smallScreenVersion = isXSmall ? true : undefined;
+    return (
+      <>
+        <InternalHeader
+          applicationName="Applikasjon"
+          applicationDesc="Beskrivelse"
+          navigationElements={[
+            { title: 'Advokater', href: '/' },
+            { title: 'Saker', href: '/' },
+          ]}
+          smallScreen={smallScreenVersion}
+        />
+        <Grid {...args} style={{ marginTop: isXSmall ? '16px' : '32px' }}>
+          <GridChild
+            columnsOccupied={{
+              xs: '1/-1',
+              sm: '1/7',
+              md: '1/11',
+              lg: '1/11',
+              xl: '1/9',
+            }}
+          >
+            <Search buttonProps={{ onClick: () => null }} />
+          </GridChild>
+          <GridChild
+            columnsOccupied={{
+              xs: '1/-1',
+              sm: '7/9',
+              md: '11/13',
+              lg: '11/13',
+              xl: '9/13',
+            }}
+          >
+            <Button
+              icon={FilterIcon}
+              label="Filter"
+              appearance="borderless"
+              purpose="secondary"
+            />
+          </GridChild>
+          <GridChild columnsOccupied="all">
+            <Table.Wrapper>
+              <Table style={{ width: '100%' }}>
+                <Table.Head>
+                  <Table.Row type="head">
+                    <Table.Cell type="head">Navn</Table.Cell>
+                    <Table.Cell type="head">Firma</Table.Cell>
+                    <Table.Cell type="head">Status</Table.Cell>
+                  </Table.Row>
+                </Table.Head>
+                <Table.Body>
+                  <Table.Row type="body">
+                    <Table.Cell> Marie Bjerke </Table.Cell>
+                    <Table.Cell>Advokat Firma </Table.Cell>
+                    <Table.Cell>
+                      <Tag text="Møterett" purpose="success" />
+                    </Table.Cell>
+                  </Table.Row>
+                  <Table.Row type="body">
+                    <Table.Cell>Sandra-Katrine Ingvaldsen Lovsetter</Table.Cell>
+                    <Table.Cell>Advokatene AS</Table.Cell>
+                    <Table.Cell>
+                      <Tag text="Ikke møterett" purpose="danger" />
+                    </Table.Cell>
+                  </Table.Row>
+                </Table.Body>
+              </Table>
+            </Table.Wrapper>
+          </GridChild>
+          <GridChild columnsOccupied="all">
+            <Pagination
+              itemsAmount={20}
+              withCounter
+              smallScreen={smallScreenVersion}
+            />
+          </GridChild>
+        </Grid>
+      </>
+    );
+  },
 };
 
-export const JustRelativeColumns = (args: GridProps) => (
-  <StoryTemplate title="Grid - default" display="block">
+export const JustRelativeColumns: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="Grid - just relative columns" display="block">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
     <Grid {...args}>
       <GridChild columnsOccupied="all">
         <Heading level={2} withMargins>
@@ -123,5 +141,5 @@ export const JustRelativeColumns = (args: GridProps) => (
         <Button label="Legg til" icon={PlusIcon} purpose="secondary" />
       </GridChild>
     </Grid>
-  </StoryTemplate>
-);
+  ),
+};

--- a/packages/components/src/components/Icon/Icon.mdx
+++ b/packages/components/src/components/Icon/Icon.mdx
@@ -1,17 +1,6 @@
-import {
-  Story,
-  Canvas,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { Icon } from '.';
-import {
-  Source,
-  ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
-} from '@norges-domstoler/storybook-components';
+import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import { Link } from '../Typography';
 import * as IconStories from './Icon.stories';
 
@@ -30,31 +19,15 @@ import * as IconStories from './Icon.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-icon--overview" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-icon--overview" />
-</Canvas>
+<Canvas of={IconStories.Overview} />
 
-<Canvas>
-  {/* <Story id="dds-components-icon--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+Se stories med kontrollere i <LinkTo title="dds-components/Icon" story="Default">Storybook</LinkTo>.
 
-  <Story id="dds-components-icon--default" />
-</Canvas>
+## Props
 
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-icon`} />
-
-## Bruk i koden
-
-<Source
-  code={`
-  import { Icon, CloseIcon } from '@norges-domstoler/dds-components';
-
-<Icon icon={CloseIcon} />
-`} />
-
-## API
-
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={IconStories.Default} sourceState="shown" />
+<Controls of={IconStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLSVGElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/Icon/Icon.stories.tsx
+++ b/packages/components/src/components/Icon/Icon.stories.tsx
@@ -1,8 +1,9 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { OpenExternalIcon as OpenExternal } from './icons/openExternal';
 
-import { Icon, type IconProps } from '.';
+import { Icon } from '.';
 
 export default {
   title: 'dds-components/Icon',
@@ -11,38 +12,59 @@ export default {
     color: { control: { type: 'text' } },
   },
   parameters: {
-    controls: {
-      exclude: ['className'],
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
     },
   },
 };
 
-export const Overview = (args: IconProps) => {
-  return (
-    <StoryTemplate title="Icon - overview" display="grid" $columnsAmount={4}>
-      <Icon {...args} iconSize="inherit" icon={OpenExternal} />
-      <Icon {...args} iconSize="small" icon={OpenExternal} />
-      <Icon {...args} iconSize="medium" icon={OpenExternal} />
-      <Icon {...args} iconSize="large" icon={OpenExternal} />
-    </StoryTemplate>
-  );
-};
+type Story = StoryObj<typeof Icon>;
 
-export const Default = (args: IconProps) => {
-  return (
+export const Default: Story = {
+  args: {
+    icon: OpenExternal,
+  },
+  decorators: Story => (
     <StoryTemplate title="Icon - default">
-      <Icon {...args} icon={OpenExternal} />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const Inherit = (args: IconProps) => {
-  return (
-    <StoryTemplate title="Icon - inherit">
-      <p style={{ display: 'flex', alignItems: 'center', fontSize: '20px' }}>
-        <Icon {...args} icon={OpenExternal} iconSize="inherit" />
-        Tekst
-      </p>
+export const Overview: Story = {
+  args: {
+    icon: OpenExternal,
+  },
+  decorators: Story => (
+    <StoryTemplate title="Icon - overview" display="grid" $columnsAmount={4}>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <>
+      <Icon {...args} iconSize="inherit" />
+      <Icon {...args} iconSize="small" />
+      <Icon {...args} iconSize="medium" />
+      <Icon {...args} iconSize="large" />
+    </>
+  ),
+};
+
+export const Inherit: Story = {
+  args: {
+    icon: OpenExternal,
+    iconSize: 'inherit',
+  },
+  decorators: Story => (
+    <StoryTemplate title="Icon - inherit">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <p style={{ display: 'flex', alignItems: 'center', fontSize: '20px' }}>
+      <Icon {...args} />
+      Tekst
+    </p>
+  ),
 };

--- a/packages/components/src/components/InlineEdit/InlineEdit.mdx
+++ b/packages/components/src/components/InlineEdit/InlineEdit.mdx
@@ -1,18 +1,12 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { InlineEditInput, InlineEditTextArea } from '.';
+import { Primary, Meta, Canvas, Controls } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as InlineEditStories from './InlineEdit.stories';
+import * as InlineEditInputStories from './InlineEditInput.stories';
+import * as InlineEditTextAreaStories from './InlineEditTextArea.stories';
 
 <Meta of={InlineEditStories} />
 
@@ -26,21 +20,9 @@ import * as InlineEditStories from './InlineEdit.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-inlineedit-inlineeditinput--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-inlineedit-inlineeditinput--default" />
-</Canvas>
-
-<Canvas>
-  {/* <Story id="dds-components-inlineedit-inlineedittextarea--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-inlineedit-inlineedittextarea--default" />
-</Canvas>
-
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-inlineedit`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/InlineEdit" story="OverviewInputTypes">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -62,13 +44,14 @@ const [value, setValue] = useState('');
 `}
 />
 
-## API
+## Props
 
 ### InlineEditTextArea
 
 Inputfeltet. Returnerer `<textarea>`.
 
-<ArgTypes of={InlineEditTextArea} />
+<Canvas of={InlineEditTextAreaStories.Default} sourceState="shown" />
+<Controls of={InlineEditTextAreaStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `TextareaHTMLAttributes<HTMLTextAreaElement>`-interface.
 
@@ -76,6 +59,7 @@ I tillegg støttes alle native HTML-attributter som er en del av `TextareaHTMLAt
 
 Inputfeltet. Returnerer `<input>`.
 
-<ArgTypes of={InlineEditInput} />
+<Canvas of={InlineEditInputStories.Default} sourceState="shown" />
+<Controls of={InlineEditInputStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLInputElement>`-interface.

--- a/packages/components/src/components/InputMessage/InputMessage.mdx
+++ b/packages/components/src/components/InputMessage/InputMessage.mdx
@@ -1,16 +1,8 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { InputMessage } from '.';
+import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as InputMessageStories from './InputMessage.stories';
 
@@ -26,15 +18,9 @@ import * as InputMessageStories from './InputMessage.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-inputmessage--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-inputmessage--default" />
-</Canvas>
-
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-inputmessage`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -42,16 +28,9 @@ import * as InputMessageStories from './InputMessage.stories';
 
 **OBS!** Komponenten brukes kun i corner cases der custom inputelementer må brukes istedenfor komponentene fra Elsa.
 
-## Bruk i koden
+## Props
 
-<Source
-  code={`import { InputMessage } fra '@norges-domstoler/dds-components';
-
-<InputMessage messageType="tip" message="hjelpetekst" />
-`} />
-
-## API
-
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={InputMessageStories.Default} sourceState="shown" />
+<Controls of={InputMessageStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/InputMessage/InputMessage.stories.tsx
+++ b/packages/components/src/components/InputMessage/InputMessage.stories.tsx
@@ -1,6 +1,7 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { InputMessage, type InputMessageProps } from '.';
+import { InputMessage } from '.';
 
 export default {
   title: 'dds-components/InputMessage',
@@ -8,21 +9,38 @@ export default {
   argTypes: {
     message: { control: { type: 'text' } },
   },
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Overview = () => (
-  <StoryTemplate title="InputMessage - overview">
-    <InputMessage messageType="error" message="feilmelding" />
-    <InputMessage messageType="tip" message="hjelpetekst" />
-  </StoryTemplate>
-);
+type Story = StoryObj<typeof InputMessage>;
 
-export const Default = (args: InputMessageProps) => (
-  <StoryTemplate title="InputMessage - default">
-    <InputMessage
-      {...args}
-      messageType={args.messageType || 'error'}
-      message={args.message || 'feilmelding'}
-    />
-  </StoryTemplate>
-);
+export const Default: Story = {
+  args: {
+    messageType: 'error',
+    message: 'feilmelding',
+  },
+  decorators: Story => (
+    <StoryTemplate title="InputMessage - default">
+      <Story />
+    </StoryTemplate>
+  ),
+};
+
+export const Overview: Story = {
+  decorators: Story => (
+    <StoryTemplate title="InputMessage - overview">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
+      <InputMessage {...args} messageType="error" message="feilmelding" />
+      <InputMessage {...args} messageType="tip" message="hjelpetekst" />
+    </>
+  ),
+};

--- a/packages/components/src/components/InternalHeader/InternalHeader.mdx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.mdx
@@ -1,16 +1,8 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { InternalHeader } from '.';
+import { Canvas, Controls, Meta, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as InternalHeaderStories from './InternalHeader.stories';
 
@@ -26,27 +18,16 @@ import * as InternalHeaderStories from './InternalHeader.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-internalheader--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-internalheader--default" />
-</Canvas>
+<Canvas of={InternalHeaderStories.WithNavigationAndContextMenu} />
 
-<Canvas>
-  {/* <Story id="dds-components-internalheader--with-navigation-and-context-menu" height="350px" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-internalheader--with-navigation-and-context-menu" height="350px" />
-</Canvas>
-
-<Canvas>
-  {/* <Story id="dds-components-internalheader--small-screen-with-navigation-and-context-menu" height="650px" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-internalheader--small-screen-with-navigation-and-context-menu" height="650px" />
-</Canvas>
-
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-internalheader`}
+<Canvas
+  of={InternalHeaderStories.SmallScreenWithNavigationAndContextMenu}
+  height="650px"
 />
+
+Se stories med kontrollere i <LinkTo title="dds-components/InternalHeader" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -82,9 +63,10 @@ name: 'Name'
 />
 `} />
 
-## API
+## Props
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={InternalHeaderStories.Default} sourceState="shown" />
+<Controls of={InternalHeaderStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/InternalHeader/InternalHeader.stories.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.stories.tsx
@@ -69,8 +69,8 @@ type Story = StoryObj<typeof InternalHeader>;
 
 export const Default: Story = {
   args: {
-    applicationName: 'Navn på applikasjon',
-    applicationDesc: 'Beskrivelse/tittel på underside',
+    applicationName: 'Lovisa',
+    applicationDesc: 'Produktnavn',
   },
   decorators: Story => (
     <StoryTemplate title="InternalHeader - default" display="block">
@@ -81,8 +81,8 @@ export const Default: Story = {
 
 export const Overview: Story = {
   args: {
-    applicationName: 'Navn på applikasjon',
-    applicationDesc: 'Beskrivelse/tittel på underside',
+    applicationName: 'Lovisa',
+    applicationDesc: 'Produktnavn',
   },
   decorators: Story => (
     <StoryTemplate
@@ -144,8 +144,8 @@ export const Overview: Story = {
 
 export const WithNavigationAndContextMenu: Story = {
   args: {
-    applicationName: 'Navn på applikasjon',
-    applicationDesc: 'Beskrivelse/tittel på underside',
+    applicationName: 'Lovisa',
+    applicationDesc: 'Produktnavn',
     navigationElements: navigationLinks,
     contextMenuElements: menuElements,
     userProps: user,
@@ -162,8 +162,8 @@ export const WithNavigationAndContextMenu: Story = {
 
 export const WithCurrentPage: Story = {
   args: {
-    applicationName: 'Navn på applikasjon',
-    applicationDesc: 'Beskrivelse/tittel på underside',
+    applicationName: 'Lovisa',
+    applicationDesc: 'Produktnavn',
     navigationElements: [navigationLink, uniqueNavigationLink],
     contextMenuElements: menuElements,
     userProps: user,
@@ -178,8 +178,8 @@ export const WithCurrentPage: Story = {
 
 export const SmallScreenWithNavigation: Story = {
   args: {
-    applicationName: 'Navn på applikasjon',
-    applicationDesc: 'Beskrivelse/tittel på underside',
+    applicationName: 'Lovisa',
+    applicationDesc: 'Produktnavn',
     navigationElements: navigationLinks,
     smallScreen: true,
   },
@@ -195,8 +195,8 @@ export const SmallScreenWithNavigation: Story = {
 
 export const SmallScreenWithContextMenu: Story = {
   args: {
-    applicationName: 'Navn på applikasjon',
-    applicationDesc: 'Beskrivelse/tittel på underside',
+    applicationName: 'Lovisa',
+    applicationDesc: 'Produktnavn',
     contextMenuElements: menuElements,
     smallScreen: true,
   },
@@ -212,8 +212,8 @@ export const SmallScreenWithContextMenu: Story = {
 
 export const SmallScreenWithNavigationAndContextMenu: Story = {
   args: {
-    applicationName: 'Navn på applikasjon',
-    applicationDesc: 'Beskrivelse/tittel på underside',
+    applicationName: 'Lovisa',
+    applicationDesc: 'Produktnavn',
     contextMenuElements: menuElements,
     navigationElements: navigationLinks,
     userProps: user,
@@ -231,8 +231,8 @@ export const SmallScreenWithNavigationAndContextMenu: Story = {
 
 export const NonInteractiveUserOnly: Story = {
   args: {
-    applicationName: 'Navn på applikasjon',
-    applicationDesc: 'Beskrivelse/tittel på underside',
+    applicationName: 'Lovisa',
+    applicationDesc: 'Produktnavn',
     userProps: user,
   },
   decorators: Story => (

--- a/packages/components/src/components/InternalHeader/InternalHeader.stories.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.stories.tsx
@@ -1,8 +1,9 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { EditIcon } from '../Icon/icons';
 
-import { InternalHeader, type InternalHeaderProps } from '.';
+import { InternalHeader } from '.';
 
 export default {
   title: 'dds-components/InternalHeader',
@@ -14,13 +15,9 @@ export default {
     smallScreen: { control: { type: 'boolean' } },
   },
   parameters: {
-    controls: {
-      exclude: [
-        'style',
-        'contextMenuElements',
-        'navigationElements',
-        'userProps',
-      ],
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
     },
   },
 };
@@ -47,8 +44,6 @@ const navigationLinks = [
   longNavigationLink,
 ];
 
-const shortNavigationLinks = [navigationLink, navigationLink, navigationLink];
-
 const user = {
   name: 'Navn Navnesen',
 };
@@ -70,206 +65,182 @@ const menuElement = {
 
 const menuElements = [menuElement, menuElementWithIcon, menuElement];
 
-export const Overview = () => (
-  <StoryTemplate
-    title="InternalHeader - overview"
-    gap="40px"
-    containerStyle={{ alignItems: 'stretch' }}
-  >
-    <InternalHeader
-      applicationDesc="Beskrivelse/tittel på underside"
-      applicationName="Navn på applikasjon"
-    />
-    <InternalHeader
-      applicationDesc="Beskrivelse/tittel på underside"
-      applicationName="Navn på applikasjon"
-      navigationElements={navigationLinks}
-      contextMenuElements={menuElements}
-      userProps={user}
-    />
-    <InternalHeader
-      applicationDesc="Beskrivelse/tittel på underside"
-      applicationName="Navn på applikasjon"
-      navigationElements={[navigationLink, uniqueNavigationLink]}
-      contextMenuElements={menuElements}
-      userProps={user}
-      currentPageHref="#"
-    />
-    <InternalHeader
-      applicationDesc="Beskrivelse/tittel på underside"
-      applicationName="Navn på applikasjon"
-      navigationElements={navigationLinks}
-      userProps={userWithHref}
-    />
-    <InternalHeader
-      applicationDesc="Beskrivelse/tittel på underside"
-      applicationName="Navn på applikasjon"
-      navigationElements={navigationLinks}
-      contextMenuElements={menuElements}
-      userProps={userWithHref}
-    />
-    <InternalHeader
-      applicationDesc="Beskrivelse/tittel på underside"
-      applicationName="Navn på applikasjon"
-      contextMenuElements={menuElements}
-      userProps={user}
-    />
-    <InternalHeader
-      applicationDesc="Beskrivelse/tittel på underside"
-      applicationName="Navn på applikasjon"
-      navigationElements={navigationLinks}
-      contextMenuElements={menuElements}
-      userProps={user}
-      smallScreen
-    />
-    <InternalHeader
-      applicationDesc="Beskrivelse/tittel på underside"
-      applicationName="Navn på applikasjon"
-      navigationElements={navigationLinks}
-      userProps={user}
-      smallScreen
-    />
-  </StoryTemplate>
-);
+type Story = StoryObj<typeof InternalHeader>;
 
-export const Default = (args: InternalHeaderProps) => (
-  <StoryTemplate title="InternalHeader - default" display="block">
-    <InternalHeader
-      applicationName="Navn på applikasjon"
-      applicationDesc="Beskrivelse/tittel på underside"
-      {...args}
-    />
-  </StoryTemplate>
-);
+export const Default: Story = {
+  args: {
+    applicationName: 'Navn på applikasjon',
+    applicationDesc: 'Beskrivelse/tittel på underside',
+  },
+  decorators: Story => (
+    <StoryTemplate title="InternalHeader - default" display="block">
+      <Story />
+    </StoryTemplate>
+  ),
+};
 
-export const WithNavigationAndContextMenu = (args: InternalHeaderProps) => (
-  <StoryTemplate
-    title="InternalHeader - with nav and context menu"
-    display="block"
-  >
-    <InternalHeader
-      applicationName="Navn på applikasjon"
-      applicationDesc="Beskrivelse/tittel på underside"
-      {...args}
-      navigationElements={navigationLinks}
-      contextMenuElements={menuElements}
-      userProps={user}
-    />
-  </StoryTemplate>
-);
-
-export const WithCurrentPage = (args: InternalHeaderProps) => {
-  return (
-    <StoryTemplate title="InternalHeader - with current page" display="block">
+export const Overview: Story = {
+  args: {
+    applicationName: 'Navn på applikasjon',
+    applicationDesc: 'Beskrivelse/tittel på underside',
+  },
+  decorators: Story => (
+    <StoryTemplate
+      title="InternalHeader - overview"
+      gap="40px"
+      containerStyle={{ alignItems: 'stretch' }}
+    >
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
+      <InternalHeader {...args} />
       <InternalHeader
-        applicationName="Navn på applikasjon"
-        applicationDesc="Beskrivelse/tittel på underside"
+        {...args}
+        navigationElements={navigationLinks}
+        contextMenuElements={menuElements}
+        userProps={user}
+      />
+      <InternalHeader
         {...args}
         navigationElements={[navigationLink, uniqueNavigationLink]}
         contextMenuElements={menuElements}
         userProps={user}
         currentPageHref="#"
       />
-    </StoryTemplate>
-  );
-};
-
-export const SmallScreenWithNavigation = (args: InternalHeaderProps) => (
-  <StoryTemplate
-    title="InternalHeader - small screen with navigation"
-    display="block"
-  >
-    <InternalHeader
-      applicationName="Navn på applikasjon"
-      applicationDesc="Beskrivelse/tittel på underside"
-      {...args}
-      navigationElements={navigationLinks}
-      smallScreen
-    />
-  </StoryTemplate>
-);
-
-export const SmallScreenWithContextMenu = (args: InternalHeaderProps) => {
-  return (
-    <StoryTemplate
-      title="InternalHeader - small screen with context menu"
-      display="block"
-    >
       <InternalHeader
-        applicationName="Navn på applikasjon"
-        applicationDesc="Beskrivelse/tittel på underside"
+        {...args}
+        navigationElements={navigationLinks}
+        userProps={userWithHref}
+      />
+      <InternalHeader
+        {...args}
+        navigationElements={navigationLinks}
+        contextMenuElements={menuElements}
+        userProps={userWithHref}
+      />
+      <InternalHeader
         {...args}
         contextMenuElements={menuElements}
         userProps={user}
       />
-    </StoryTemplate>
-  );
+      <InternalHeader
+        {...args}
+        navigationElements={navigationLinks}
+        contextMenuElements={menuElements}
+        userProps={user}
+        smallScreen
+      />
+      <InternalHeader
+        {...args}
+        navigationElements={navigationLinks}
+        userProps={user}
+        smallScreen
+      />
+    </>
+  ),
 };
 
-export const SmallScreenWithNavigationAndContextMenu = (
-  args: InternalHeaderProps,
-) => (
-  <StoryTemplate
-    title="InternalHeader - small screen with navigation and context menu"
-    display="block"
-  >
-    <InternalHeader
-      applicationName="Navn på applikasjon"
-      applicationDesc="Beskrivelse/tittel på underside"
-      {...args}
-      userProps={user}
-      navigationElements={navigationLinks}
-      contextMenuElements={menuElements}
-      smallScreen
-    />
-  </StoryTemplate>
-);
+export const WithNavigationAndContextMenu: Story = {
+  args: {
+    applicationName: 'Navn på applikasjon',
+    applicationDesc: 'Beskrivelse/tittel på underside',
+    navigationElements: navigationLinks,
+    contextMenuElements: menuElements,
+    userProps: user,
+  },
+  decorators: Story => (
+    <StoryTemplate
+      title="InternalHeader - with nav and context menu"
+      display="block"
+    >
+      <Story />
+    </StoryTemplate>
+  ),
+};
 
-export const NoStoryHeading = (args: InternalHeaderProps) => (
-  <InternalHeader
-    applicationName="Navn på applikasjon"
-    applicationDesc="Beskrivelse/tittel på underside"
-    {...args}
-    userProps={user}
-    navigationElements={shortNavigationLinks}
-    contextMenuElements={menuElements}
-  />
-);
+export const WithCurrentPage: Story = {
+  args: {
+    applicationName: 'Navn på applikasjon',
+    applicationDesc: 'Beskrivelse/tittel på underside',
+    navigationElements: [navigationLink, uniqueNavigationLink],
+    contextMenuElements: menuElements,
+    userProps: user,
+    currentPageHref: '#',
+  },
+  decorators: Story => (
+    <StoryTemplate title="InternalHeader - with current page" display="block">
+      <Story />
+    </StoryTemplate>
+  ),
+};
 
-export const NoStoryHeadingSmallScreen = (args: InternalHeaderProps) => (
-  <InternalHeader
-    applicationName="Navn på applikasjon"
-    applicationDesc="Beskrivelse/tittel på underside"
-    {...args}
-    navigationElements={navigationLinks}
-    contextMenuElements={menuElements}
-    userProps={user}
-    smallScreen
-  />
-);
+export const SmallScreenWithNavigation: Story = {
+  args: {
+    applicationName: 'Navn på applikasjon',
+    applicationDesc: 'Beskrivelse/tittel på underside',
+    navigationElements: navigationLinks,
+    smallScreen: true,
+  },
+  decorators: Story => (
+    <StoryTemplate
+      title="InternalHeader - small screen with navigation"
+      display="block"
+    >
+      <Story />
+    </StoryTemplate>
+  ),
+};
 
-export const NoStoryHeadingSmallScreenLong = (args: InternalHeaderProps) => (
-  <InternalHeader
-    applicationName="Navn på applikasjon"
-    applicationDesc="Beskrivelse/tittel på underside"
-    {...args}
-    navigationElements={[...navigationLinks, ...navigationLinks]}
-    contextMenuElements={[...navigationLinks, ...navigationLinks]}
-    userProps={user}
-    smallScreen
-  />
-);
+export const SmallScreenWithContextMenu: Story = {
+  args: {
+    applicationName: 'Navn på applikasjon',
+    applicationDesc: 'Beskrivelse/tittel på underside',
+    contextMenuElements: menuElements,
+    smallScreen: true,
+  },
+  decorators: Story => (
+    <StoryTemplate
+      title="InternalHeader - small screen with context menu"
+      display="block"
+    >
+      <Story />
+    </StoryTemplate>
+  ),
+};
 
-export const NonInteractiveUserOnly = (args: InternalHeaderProps) => (
-  <StoryTemplate
-    title="InternalHeader - non-interactive user only"
-    display="block"
-  >
-    <InternalHeader
-      applicationName="Navn på applikasjon"
-      applicationDesc="Beskrivelse/tittel på underside"
-      {...args}
-      userProps={user}
-    />
-  </StoryTemplate>
-);
+export const SmallScreenWithNavigationAndContextMenu: Story = {
+  args: {
+    applicationName: 'Navn på applikasjon',
+    applicationDesc: 'Beskrivelse/tittel på underside',
+    contextMenuElements: menuElements,
+    navigationElements: navigationLinks,
+    userProps: user,
+    smallScreen: true,
+  },
+  decorators: Story => (
+    <StoryTemplate
+      title="InternalHeader - small screen with navigation and context menu"
+      display="block"
+    >
+      <Story />
+    </StoryTemplate>
+  ),
+};
+
+export const NonInteractiveUserOnly: Story = {
+  args: {
+    applicationName: 'Navn på applikasjon',
+    applicationDesc: 'Beskrivelse/tittel på underside',
+    userProps: user,
+  },
+  decorators: Story => (
+    <StoryTemplate
+      title="InternalHeader - non-interactive user only"
+      display="block"
+    >
+      <Story />
+    </StoryTemplate>
+  ),
+};

--- a/packages/components/src/components/List/List.mdx
+++ b/packages/components/src/components/List/List.mdx
@@ -1,16 +1,8 @@
-import {
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-  Canvas,
-  Story,
-} from '@storybook/blocks';
-import { List, ListItem } from '.';
+import { Meta, ArgTypes, Canvas, Controls, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as ListStories from './List.stories';
 
@@ -26,13 +18,9 @@ import * as ListStories from './List.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-list--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-list--default" />
-</Canvas>
-
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-list`} />
+Se stories med kontrollere i <LinkTo title="dds-components/List" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -41,25 +29,14 @@ Lister bygges med to subkomponenter som tilsvarer native HTML-elementer:
 - `<List />`
 - `<ListItem />`
 
-## Bruk i koden
-
-<Source
-  code={`
-  import { List, ListItem } from '@norges-domstoler/dds-components';
-
-<List>
-  <ListItem> Item </ListItem>
-  <ListItem> Item </ListItem>
-</List>
-`} />
-
-## API
+## Props
 
 ### List
 
 Tilsvarer `<ul>` eller `<ol>`.
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={ListStories.Default} sourceState="shown" />
+<Controls of={ListStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLOListElement>` og `HTMLAttributes<HTMLUListElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/List/List.stories.tsx
+++ b/packages/components/src/components/List/List.stories.tsx
@@ -1,17 +1,46 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { Typography } from '../Typography';
 
-import { List, ListItem, type ListProps } from '.';
+import { List, ListItem } from '.';
 
 export default {
   title: 'dds-components/List',
   component: List,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Overview = (args: ListProps) => {
-  return (
+type Story = StoryObj<typeof List>;
+
+export const Default: Story = {
+  decorators: Story => (
+    <StoryTemplate title="List - default">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <List {...args}>
+      <ListItem>Item</ListItem>
+      <ListItem>Item</ListItem>
+      <ListItem>Item</ListItem>
+    </List>
+  ),
+};
+
+export const Overview: Story = {
+  decorators: Story => (
     <StoryTemplate title="List - overview" display="grid" $columnsAmount={4}>
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <List {...args} typographyType="bodySans01">
         <ListItem>Item</ListItem>
         <ListItem>Item</ListItem>
@@ -155,75 +184,70 @@ export const Overview = (args: ListProps) => {
           </List>
         </ListItem>
       </List>
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const Default = (args: ListProps) => {
-  return (
-    <StoryTemplate title="List - default">
-      <List {...args}>
-        <ListItem>Item</ListItem>
-        <ListItem>Item</ListItem>
-      </List>
-    </StoryTemplate>
-  );
-};
-
-export const Nested = (args: ListProps) => {
-  return (
+export const Nested: Story = {
+  decorators: Story => (
     <StoryTemplate title="List - nested">
-      <List {...args}>
-        <ListItem>Item</ListItem>
-        <ListItem>Item</ListItem>
-        <ListItem>
-          Item
-          <List {...args}>
-            <ListItem>Item</ListItem>
-            <ListItem>
-              Item
-              <List {...args}>
-                <ListItem>Item</ListItem>
-                <ListItem>Item</ListItem>
-              </List>
-            </ListItem>
-          </List>
-        </ListItem>
-      </List>
+      <Story />
     </StoryTemplate>
-  );
-};
-
-export const Example = (args: ListProps) => {
-  return (
-    <StoryTemplate title="List - example">
-      <div style={{ maxWidth: '700px' }}>
-        <Typography withMargins>
-          Første gang du gjør tjeneste som arbeidslivskyndig meddommer, vil
-          rettens leder be deg om:
-        </Typography>
+  ),
+  render: args => (
+    <List {...args}>
+      <ListItem>Item</ListItem>
+      <ListItem>Item</ListItem>
+      <ListItem>
+        Item
         <List {...args}>
-          <ListItem>å følge nøye med i forhandlingen</ListItem>
+          <ListItem>Item</ListItem>
           <ListItem>
-            merke deg forklaringene som blir gitt og bevisene som blir fremlagt
-          </ListItem>
-          <ListItem>
-            å gi uttrykk for hvordan du vurderer saken etter at bevisene er lagt
-            frem
-          </ListItem>
-          <ListItem>
-            å ikke legge vekt på andre forhold enn bevisene som er ført i saken
+            Item
+            <List {...args}>
+              <ListItem>Item</ListItem>
+              <ListItem>Item</ListItem>
+            </List>
           </ListItem>
         </List>
-        <Typography withMargins>
-          Første gang du er i retten må du også avgi en forsikring. Den sier at
-          du både i den aktuelle saken og i fremtidige saker vil gi vel akt på
-          alt som fremkommer gjennom forhandlingene i retten, og at du vil dømme
-          slik du finner sannest å rettest å være etter loven og sakens
-          bevisligheter. På oppfordring fra dommeren, skal du til dette svare:
-          «Det forsikrer jeg.»
-        </Typography>
-      </div>
+      </ListItem>
+    </List>
+  ),
+};
+
+export const Example: Story = {
+  decorators: Story => (
+    <StoryTemplate title="List - example">
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <div style={{ maxWidth: '700px' }}>
+      <Typography withMargins>
+        Første gang du gjør tjeneste som arbeidslivskyndig meddommer, vil
+        rettens leder be deg om:
+      </Typography>
+      <List {...args}>
+        <ListItem>å følge nøye med i forhandlingen</ListItem>
+        <ListItem>
+          merke deg forklaringene som blir gitt og bevisene som blir fremlagt
+        </ListItem>
+        <ListItem>
+          å gi uttrykk for hvordan du vurderer saken etter at bevisene er lagt
+          frem
+        </ListItem>
+        <ListItem>
+          å ikke legge vekt på andre forhold enn bevisene som er ført i saken
+        </ListItem>
+      </List>
+      <Typography withMargins>
+        Første gang du er i retten må du også avgi en forsikring. Den sier at du
+        både i den aktuelle saken og i fremtidige saker vil gi vel akt på alt
+        som fremkommer gjennom forhandlingene i retten, og at du vil dømme slik
+        du finner sannest å rettest å være etter loven og sakens bevisligheter.
+        På oppfordring fra dommeren, skal du til dette svare: «Det forsikrer
+        jeg.»
+      </Typography>
+    </div>
+  ),
 };

--- a/packages/components/src/components/LocalMessage/LocalMessage.mdx
+++ b/packages/components/src/components/LocalMessage/LocalMessage.mdx
@@ -1,17 +1,6 @@
-import {
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-  Canvas,
-  Story,
-} from '@storybook/blocks';
-import { LocalMessage } from '.';
-import {
-  Source,
-  ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
-} from '@norges-domstoler/storybook-components';
+import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as LocalMessageStories from './LocalMessage.stories';
 
 <Meta of={LocalMessageStories} />
@@ -26,26 +15,13 @@ import * as LocalMessageStories from './LocalMessage.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-localmessage--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-localmessage--default" />
-</Canvas>
+Se stories med kontrollere i <LinkTo title="dds-components/LocalMessage" story="Default">Storybook</LinkTo>.
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-localmessage`}
-/>
+## Props
 
-## Bruk i koden
-
-<Source
-  code={`import { LocalMessage } from '@norges-domstoler/dds-components';
-
-<LocalMessage message="Dette er en lokal melding" />
-`} />
-
-## API
-
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={LocalMessageStories.Default} sourceState="shown" />
+<Controls of={LocalMessageStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`. `children` kan brukes istedenfor `message`.

--- a/packages/components/src/components/LocalMessage/LocalMessage.stories.tsx
+++ b/packages/components/src/components/LocalMessage/LocalMessage.stories.tsx
@@ -1,6 +1,7 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { LocalMessage, type LocalMessageProps } from './LocalMessage';
+import { LocalMessage } from './LocalMessage';
 import { List, ListItem } from '../List';
 import { Typography } from '../Typography';
 
@@ -15,11 +16,38 @@ export default {
     width: { control: { type: 'text' } },
     closable: { control: { type: 'boolean' } },
   },
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Overview = (args: LocalMessageProps) => {
-  return (
+type Story = StoryObj<typeof LocalMessage>;
+
+export const Default: Story = {
+  args: {
+    children: 'Dette er en lokal melding',
+  },
+  decorators: Story => (
+    <StoryTemplate title="LocalMessage - default">
+      <Story />
+    </StoryTemplate>
+  ),
+};
+
+export const Overview: Story = {
+  args: {
+    children: 'Dette er en lokal melding',
+  },
+  decorators: Story => (
     <StoryTemplate title="LocalMessage - overview">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <LocalMessage {...args} purpose="info" />
       <LocalMessage {...args} purpose="warning" />
       <LocalMessage {...args} purpose="danger" />
@@ -34,45 +62,40 @@ export const Overview = (args: LocalMessageProps) => {
       <LocalMessage {...args} purpose="success" closable />
       <LocalMessage {...args} purpose="tips" closable />
       <LocalMessage {...args} layout="vertical" closable />
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const Default = (args: LocalMessageProps) => {
-  return (
-    <StoryTemplate title="LocalMessage - default">
-      <LocalMessage {...args} message={args.message} />
-    </StoryTemplate>
-  );
-};
-
-export const Closable = (args: LocalMessageProps) => {
-  return (
+export const Closable: Story = {
+  args: {
+    children: 'Dette er en lokal melding',
+    closable: true,
+  },
+  decorators: Story => (
     <StoryTemplate title="LocalMessage - closable">
-      <LocalMessage
-        {...args}
-        purpose={args.purpose}
-        message={args.message}
-        closable
-      />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const ComplexContent = (args: LocalMessageProps) => {
-  return (
+export const ComplexContent: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate title="LocalMessage - complex content">
-      <LocalMessage {...args} purpose={args.purpose} layout="vertical" closable>
-        <Typography typographyType="headingSans03" withMargins>
-          Dette er en viktig melding
-        </Typography>
-        <Typography withMargins>Meldingen har en liste i seg:</Typography>
-        <List>
-          <ListItem>Noe her</ListItem>
-          <ListItem>Og også her</ListItem>
-          <ListItem>Og litt mer info her</ListItem>
-        </List>
-      </LocalMessage>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <LocalMessage {...args} purpose={args.purpose} layout="vertical" closable>
+      <Typography typographyType="headingSans03" withMargins>
+        Dette er en viktig melding
+      </Typography>
+      <Typography withMargins>Meldingen har en liste i seg:</Typography>
+      <List>
+        <ListItem>Noe her</ListItem>
+        <ListItem>Og også her</ListItem>
+        <ListItem>Og litt mer info her</ListItem>
+      </List>
+    </LocalMessage>
+  ),
 };

--- a/packages/components/src/components/Modal/Modal.mdx
+++ b/packages/components/src/components/Modal/Modal.mdx
@@ -1,11 +1,6 @@
-import {
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-  Canvas,
-  Story,
-} from '@storybook/blocks';
-import { Modal, ModalBody, ModalActions } from '.';
+import { Meta, Canvas, Controls, Primary, ArgTypes } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { ModalBody } from '.';
 import {
   Source,
   ComponentLinkRow,
@@ -26,11 +21,9 @@ import * as ModalStories from './Modal.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={ModalStories.Default} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-modal`} />
+Se stories med kontrollere i <LinkTo title="dds-components/Modal" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -111,13 +104,14 @@ const buttonRef = useRef(null);
 </Modal>
 `} />
 
-## API
+## Props
 
 ### Modal
 
 Hovedkomponenten for modal. Kan ha `<ModalBody />`, `<ModalActions />` og ellers fritt valgt innhold som barn. Legger vertikal spacing mellom barn.
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={ModalStories.Default} sourceState="shown" />
+<Controls of={ModalStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/Modal/Modal.stories.tsx
+++ b/packages/components/src/components/Modal/Modal.stories.tsx
@@ -1,10 +1,11 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
-import { useEffect, useRef, useState } from 'react';
+import { type StoryObj } from '@storybook/react';
+import { useRef, useState } from 'react';
 
 import { Button } from '../Button';
 import { Search } from '../Search';
 
-import { Modal, ModalActions, ModalBody, type ModalProps } from '.';
+import { Modal, ModalActions, ModalBody } from '.';
 
 export default {
   title: 'dds-components/Modal',
@@ -12,198 +13,226 @@ export default {
   argTypes: {
     header: { control: { type: 'text' } },
   },
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Overview = () => {
-  const [closed, setClosed] = useState(true);
-  const show = () => setClosed(false);
-  const close = () => setClosed(true);
+type Story = StoryObj<typeof Modal>;
 
-  const [closed2, setClosed2] = useState(true);
-  const show2 = () => setClosed2(false);
-  const close2 = () => setClosed2(true);
-
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const buttonRef2 = useRef<HTMLButtonElement>(null);
-
-  return (
-    <StoryTemplate title="Modal - overview">
-      <Button aria-haspopup="dialog" onClick={show} ref={buttonRef}>
-        Åpne lukkbar
-      </Button>
-      <Modal
-        isOpen={!closed}
-        triggerRef={buttonRef}
-        onClose={close}
-        header="Tittel"
-      >
-        <ModalBody>Lukkbar modal</ModalBody>
-        <ModalActions>
-          <Button onClick={close}>OK</Button>
-          <Button purpose="secondary" onClick={close}>
-            Avbryt
-          </Button>
-        </ModalActions>
-      </Modal>
-      <Button aria-haspopup="dialog" onClick={show2} ref={buttonRef2}>
-        Åpne ikke lukkbar
-      </Button>
-      <Modal isOpen={!closed2} triggerRef={buttonRef2} header="Tittel">
-        <ModalBody>Ikke lukkbar modal</ModalBody>
-        <ModalActions>
-          <Button onClick={close2}>OK</Button>
-
-          <Button purpose="secondary" onClick={close2}>
-            Avbryt
-          </Button>
-        </ModalActions>
-      </Modal>
-    </StoryTemplate>
-  );
-};
-
-export const Default = (args: ModalProps) => {
-  const [closed, setClosed] = useState(true);
-  const show = () => setClosed(false);
-  const close = () => setClosed(true);
-
-  const buttonRef = useRef<HTMLButtonElement>(null);
-
-  return (
+export const Default: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate title="Modal - default">
-      <Button aria-haspopup="dialog" onClick={show} ref={buttonRef}>
-        Åpne
-      </Button>
-      <Modal {...args} triggerRef={buttonRef} isOpen={!closed} onClose={close}>
-        <ModalBody>Modal</ModalBody>
-        <ModalActions>
-          <Button onClick={close}>OK</Button>
-          <Button purpose="secondary" onClick={close}>
-            Avbryt
-          </Button>
-        </ModalActions>
-      </Modal>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const [closed, setClosed] = useState(true);
+    const show = () => setClosed(false);
+    const close = () => setClosed(true);
+
+    const buttonRef = useRef<HTMLButtonElement>(null);
+
+    return (
+      <>
+        <Button aria-haspopup="dialog" onClick={show} ref={buttonRef}>
+          Åpne
+        </Button>
+        <Modal
+          {...args}
+          triggerRef={buttonRef}
+          isOpen={!closed}
+          onClose={close}
+        >
+          <ModalBody>Modal</ModalBody>
+          <ModalActions>
+            <Button onClick={close}>OK</Button>
+            <Button purpose="secondary" onClick={close}>
+              Avbryt
+            </Button>
+          </ModalActions>
+        </Modal>
+      </>
+    );
+  },
 };
 
-export const NoActionButtons = (args: ModalProps) => {
-  const [closed, setClosed] = useState(true);
-  const show = () => setClosed(false);
-  const close = () => setClosed(true);
+export const Overview: Story = {
+  args: { header: 'Tittel' },
+  decorators: Story => (
+    <StoryTemplate title="Modal - overview">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => {
+    const [closed, setClosed] = useState(true);
+    const show = () => setClosed(false);
+    const close = () => setClosed(true);
 
-  const buttonRef = useRef<HTMLButtonElement>(null);
+    const [closed2, setClosed2] = useState(true);
+    const show2 = () => setClosed2(false);
+    const close2 = () => setClosed2(true);
 
-  return (
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const buttonRef2 = useRef<HTMLButtonElement>(null);
+
+    return (
+      <>
+        <Button aria-haspopup="dialog" onClick={show} ref={buttonRef}>
+          Åpne lukkbar
+        </Button>
+        <Modal
+          {...args}
+          isOpen={!closed}
+          triggerRef={buttonRef}
+          onClose={close}
+        >
+          <ModalBody>Lukkbar modal</ModalBody>
+          <ModalActions>
+            <Button onClick={close}>OK</Button>
+            <Button purpose="secondary" onClick={close}>
+              Avbryt
+            </Button>
+          </ModalActions>
+        </Modal>
+        <Button aria-haspopup="dialog" onClick={show2} ref={buttonRef2}>
+          Åpne ikke lukkbar
+        </Button>
+        <Modal {...args} isOpen={!closed2} triggerRef={buttonRef2}>
+          <ModalBody>Ikke lukkbar modal</ModalBody>
+          <ModalActions>
+            <Button onClick={close2}>OK</Button>
+
+            <Button purpose="secondary" onClick={close2}>
+              Avbryt
+            </Button>
+          </ModalActions>
+        </Modal>
+      </>
+    );
+  },
+};
+
+export const NoActionButtons: Story = {
+  args: { header: 'Info' },
+  decorators: Story => (
     <StoryTemplate title="Modal - no action buttons">
-      <Button aria-haspopup="dialog" onClick={show} ref={buttonRef}>
-        Åpne
-      </Button>
-      <Modal
-        {...args}
-        isOpen={!closed}
-        triggerRef={buttonRef}
-        onClose={close}
-        header="Info"
-      >
-        <ModalBody>Infotekst</ModalBody>
-      </Modal>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const [closed, setClosed] = useState(true);
+    const show = () => setClosed(false);
+    const close = () => setClosed(true);
+
+    const buttonRef = useRef<HTMLButtonElement>(null);
+
+    return (
+      <>
+        <Button aria-haspopup="dialog" onClick={show} ref={buttonRef}>
+          Åpne
+        </Button>
+        <Modal
+          {...args}
+          isOpen={!closed}
+          triggerRef={buttonRef}
+          onClose={close}
+        >
+          <ModalBody>Infotekst</ModalBody>
+        </Modal>
+      </>
+    );
+  },
 };
 
-export const Scrollable = (args: ModalProps) => {
-  const [closed, setClosed] = useState(true);
-  const show = () => setClosed(false);
-  const close = () => setClosed(true);
-
-  const buttonRef = useRef<HTMLButtonElement>(null);
-
-  return (
+export const Scrollable: Story = {
+  args: { header: 'Fritt valg av forsvarer' },
+  decorators: Story => (
     <StoryTemplate title="Modal - scrollable">
-      <Button aria-haspopup="dialog" onClick={show} ref={buttonRef}>
-        Åpne scrollable
-      </Button>
-      <Modal
-        {...args}
-        isOpen={!closed}
-        triggerRef={buttonRef}
-        onClose={close}
-        htmlProps={{
-          style: { width: '300px' },
-        }}
-        header="Fritt valg av forsvarer"
-      >
-        <ModalBody scrollable height="100px">
-          Du kan vanligvis fritt velge hvilken advokat du vil ha som forsvarer i
-          saken. Det må spesielle grunner til for at du ikke skal få oppfylt
-          ditt ønske, for eksempel at advokaten er opptatt i lang tid slik at
-          rettssaken din vil bli veldig forsinket.
-        </ModalBody>
-        <ModalActions>
-          <Button onClick={close}>OK</Button>
-          <Button purpose="secondary" onClick={close}>
-            Avbryt
-          </Button>
-        </ModalActions>
-      </Modal>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const [closed, setClosed] = useState(true);
+    const show = () => setClosed(false);
+    const close = () => setClosed(true);
+
+    const buttonRef = useRef<HTMLButtonElement>(null);
+
+    return (
+      <>
+        <Button aria-haspopup="dialog" onClick={show} ref={buttonRef}>
+          Åpne scrollable
+        </Button>
+        <Modal
+          {...args}
+          isOpen={!closed}
+          triggerRef={buttonRef}
+          onClose={close}
+          htmlProps={{
+            style: { width: '300px' },
+          }}
+        >
+          <ModalBody scrollable height="100px">
+            Du kan vanligvis fritt velge hvilken advokat du vil ha som forsvarer
+            i saken. Det må spesielle grunner til for at du ikke skal få oppfylt
+            ditt ønske, for eksempel at advokaten er opptatt i lang tid slik at
+            rettssaken din vil bli veldig forsinket.
+          </ModalBody>
+          <ModalActions>
+            <Button onClick={close}>OK</Button>
+            <Button purpose="secondary" onClick={close}>
+              Avbryt
+            </Button>
+          </ModalActions>
+        </Modal>
+      </>
+    );
+  },
 };
 
-export const WithInitialFocusRef = (args: ModalProps) => {
-  const [closed, setClosed] = useState(true);
-  const show = () => setClosed(false);
-  const close = () => setClosed(true);
-
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const initialFocusRef = useRef<HTMLInputElement>(null);
-
-  return (
+export const WithInitialFocus: Story = {
+  args: { header: 'Søk etter sak' },
+  decorators: Story => (
     <StoryTemplate title="Modal - with initial focus">
-      <Button aria-haspopup="dialog" onClick={show} ref={buttonRef}>
-        Åpne
-      </Button>
-      <Modal
-        {...args}
-        isOpen={!closed}
-        triggerRef={buttonRef}
-        initialFocusRef={initialFocusRef}
-        onClose={close}
-        header="Søk etter sak"
-      >
-        <ModalBody>
-          <Search ref={initialFocusRef} label="Saksnummer" />
-        </ModalBody>
-        <ModalActions>
-          <Button onClick={close}>OK</Button>
-          <Button purpose="secondary" onClick={close}>
-            Avbryt
-          </Button>
-        </ModalActions>
-      </Modal>
+      <Story />
     </StoryTemplate>
-  );
-};
+  ),
+  render: args => {
+    const [closed, setClosed] = useState(true);
+    const show = () => setClosed(false);
+    const close = () => setClosed(true);
 
-const TestComponent = () => {
-  useEffect(() => {
-    console.log('mounted');
-  }, []);
-  console.log('render');
-  return <div></div>;
-};
+    const buttonRef = useRef<HTMLButtonElement>(null);
+    const initialFocusRef = useRef<HTMLInputElement>(null);
 
-export const Test = () => {
-  const [isOpen, setOpen] = useState(false);
-  return (
-    <>
-      <Button onClick={() => setOpen(true)}>Åpne</Button>
-      <Modal isOpen={isOpen} onClose={() => setOpen(false)}>
-        <ModalBody>
-          <TestComponent />
-        </ModalBody>
-      </Modal>
-    </>
-  );
+    return (
+      <>
+        <Button aria-haspopup="dialog" onClick={show} ref={buttonRef}>
+          Åpne
+        </Button>
+        <Modal
+          {...args}
+          isOpen={!closed}
+          triggerRef={buttonRef}
+          initialFocusRef={initialFocusRef}
+          onClose={close}
+        >
+          <ModalBody>
+            <Search ref={initialFocusRef} label="Saksnummer" />
+          </ModalBody>
+          <ModalActions>
+            <Button onClick={close}>OK</Button>
+            <Button purpose="secondary" onClick={close}>
+              Avbryt
+            </Button>
+          </ModalActions>
+        </Modal>
+      </>
+    );
+  },
 };

--- a/packages/components/src/components/OverflowMenu/OverflowMenu.mdx
+++ b/packages/components/src/components/OverflowMenu/OverflowMenu.mdx
@@ -1,16 +1,9 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { OverflowMenu, OverflowMenuGroup } from '.';
+import { Canvas, Controls, Primary, Meta, ArgTypes } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { OverflowMenuGroup } from '.';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as OverflowMenuStories from './OverflowMenu.stories';
 
@@ -26,27 +19,11 @@ import * as OverflowMenuStories from './OverflowMenu.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-overflowmenu--default" height="400px" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary height="600px" />
 
-  <Story id="dds-components-overflowmenu--default" height="400px" />
-</Canvas>
+<Canvas of={OverflowMenuStories.WithInteractiveUser} height="450px" />
 
-<Canvas>
-  {/* <Story id="dds-components-overflowmenu--with-navigation" height="600px" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-overflowmenu--with-navigation" height="600px" />
-</Canvas>
-
-<Canvas>
-  {/* <Story id="dds-components-overflowmenu--with-interactive-user" height="450px" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-overflowmenu--with-interactive-user" height="450px" />
-</Canvas>
-
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-overflowmenu`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/OverflowMenu" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -103,13 +80,14 @@ const items = [
 />
 `} />
 
-## API
+## Props
 
 ### OverflowMenu
 
 Hovedkomponenten `<OverflowMenu/>`.
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={OverflowMenuStories.Default} sourceState="shown" />
+<Controls of={OverflowMenuStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -1,4 +1,5 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { Button } from '../Button';
 import { MenuIcon, PlusCircledIcon } from '../Icon/icons';
@@ -8,12 +9,17 @@ import {
   type OverflowMenuContextItem,
   OverflowMenuGroup,
   type OverflowMenuNavItem,
-  type OverflowMenuProps,
 } from '.';
 
 export default {
   title: 'dds-components/OverflowMenu',
   component: OverflowMenu,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
 const items: Array<OverflowMenuContextItem> = [
@@ -43,82 +49,106 @@ const navItems: Array<OverflowMenuNavItem> = [
   },
 ];
 
-export const Default = (args: OverflowMenuProps) => {
-  return (
+type Story = StoryObj<typeof OverflowMenu>;
+
+export const Default: Story = {
+  args: {
+    items,
+  },
+  decorators: Story => (
     <StoryTemplate title="OverflowMenu - default" display="flex-centered">
-      <OverflowMenuGroup>
-        <Button icon={MenuIcon} aria-label="Åpne meny" />
-        <OverflowMenu {...args} items={items} />
-      </OverflowMenuGroup>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <OverflowMenuGroup>
+      <Button icon={MenuIcon} aria-label="Åpne meny" />
+      <OverflowMenu {...args} />
+    </OverflowMenuGroup>
+  ),
 };
 
-export const WithStaticUser = (args: OverflowMenuProps) => {
-  return (
+export const WithStaticUser: Story = {
+  args: {
+    items,
+    userProps: { name: 'Brukernavn' },
+  },
+  decorators: Story => (
     <StoryTemplate
       title="OverflowMenu - with static user"
       display="flex-centered"
     >
-      <OverflowMenuGroup>
-        <Button icon={MenuIcon} aria-label="Åpne meny" />
-        <OverflowMenu
-          {...args}
-          items={items}
-          userProps={{ name: 'Brukernavn' }}
-        />
-      </OverflowMenuGroup>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <OverflowMenuGroup>
+      <Button icon={MenuIcon} aria-label="Åpne meny" />
+      <OverflowMenu {...args} />
+    </OverflowMenuGroup>
+  ),
 };
 
-export const WithInteractiveUser = (args: OverflowMenuProps) => {
-  return (
+export const WithInteractiveUser: Story = {
+  args: {
+    items,
+    userProps: { name: 'Brukernavn', onClick: () => null },
+  },
+  decorators: Story => (
     <StoryTemplate
       title="OverflowMenu - with interactive user"
       display="flex-centered"
     >
-      <OverflowMenuGroup>
-        <Button icon={MenuIcon} aria-label="Åpne meny" />
-        <OverflowMenu
-          {...args}
-          items={items}
-          userProps={{ name: 'Brukernavn', onClick: () => null }}
-        />
-      </OverflowMenuGroup>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <OverflowMenuGroup>
+      <Button icon={MenuIcon} aria-label="Åpne meny" />
+      <OverflowMenu {...args} />
+    </OverflowMenuGroup>
+  ),
 };
 
-export const WithNavigation = (args: OverflowMenuProps) => {
-  return (
+export const WithNavigation: Story = {
+  args: {
+    items,
+    navItems,
+  },
+  decorators: Story => (
     <StoryTemplate
       title="OverflowMenu - with navigation"
       display="flex-centered"
     >
-      <OverflowMenuGroup>
-        <Button icon={MenuIcon} aria-label="Åpne meny" />
-        <OverflowMenu {...args} items={items} navItems={navItems} />
-      </OverflowMenuGroup>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <OverflowMenuGroup>
+      <Button icon={MenuIcon} aria-label="Åpne meny" />
+      <OverflowMenu {...args} />
+    </OverflowMenuGroup>
+  ),
 };
 
-export const WithNavigationAndInteractiveUser = (args: OverflowMenuProps) => {
-  return (
+export const WithNavigationAndInteractiveUser: Story = {
+  args: {
+    items,
+    navItems,
+    userProps: { name: 'Brukernavn', onClick: () => null },
+  },
+  decorators: Story => (
     <StoryTemplate
       title="OverflowMenu - with navigation and interactive user"
       display="flex-centered"
     >
-      <OverflowMenuGroup>
-        <Button icon={MenuIcon} aria-label="Åpne meny" />
-        <OverflowMenu
-          {...args}
-          items={items}
-          navItems={navItems}
-          userProps={{ name: 'Brukernavn', onClick: () => null }}
-        ></OverflowMenu>
-      </OverflowMenuGroup>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <OverflowMenuGroup>
+      <Button icon={MenuIcon} aria-label="Åpne meny" />
+      <OverflowMenu {...args} />
+    </OverflowMenuGroup>
+  ),
 };

--- a/packages/components/src/components/Pagination/Pagination.mdx
+++ b/packages/components/src/components/Pagination/Pagination.mdx
@@ -1,16 +1,8 @@
-import {
-  Story,
-  Canvas,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { Pagination } from '.';
+import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as PaginationStories from './Pagination.stories';
 
@@ -26,27 +18,14 @@ import * as PaginationStories from './Pagination.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-pagination--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-pagination--default" />
-</Canvas>
+Se stories med kontrollere i <LinkTo title="dds-components/Pagination" story="Default">Storybook</LinkTo>.
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-pagination`}
-/>
+## Props
 
-## Bruk i koden
-
-<Source
-  code={`import { Pagination } from '@norges-domstoler/dds-components';
-
-<Pagination itemsAmount={100} withCounter />
-`} />
-
-## API
-
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={PaginationStories.Default} sourceState="shown" />
+<Controls of={PaginationStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/components/src/components/Pagination/Pagination.stories.tsx
@@ -1,6 +1,9 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { Pagination, type PaginationProps } from '.';
+import { VStack } from '../Stack';
+
+import { Pagination } from '.';
 
 export default {
   title: 'dds-components/Pagination',
@@ -14,8 +17,9 @@ export default {
     defaultActivePage: { control: 'number' },
   },
   parameters: {
-    controls: {
-      exclude: ['onChange', 'selectOptions'],
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
     },
   },
 };
@@ -26,70 +30,87 @@ const customOptions = [17, 32, customOptionsItemsAmount].map(o => ({
   value: o,
 }));
 
-export const Overview = (args: PaginationProps) => (
-  <StoryTemplate
-    title="Pagination - overview"
-    gap="50px"
-    containerStyle={{ alignItems: 'stretch' }}
-  >
-    <Pagination {...args} itemsAmount={70} />
-    <Pagination {...args} itemsAmount={100} />
-    <Pagination {...args} defaultActivePage={6} itemsAmount={100} />
-    <Pagination {...args} withCounter itemsAmount={100} />
-    <Pagination
-      {...args}
-      withCounter
-      defaultItemsPerPage={20}
-      itemsAmount={100}
-    />
-    <Pagination
-      {...args}
-      withPagination={false}
-      withCounter
-      itemsAmount={100}
-    />
-    <Pagination {...args} withSelect itemsAmount={100} />
-    <Pagination {...args} withCounter withSelect itemsAmount={100} />
-    <Pagination
-      {...args}
-      withCounter
-      withSelect
-      withPagination={false}
-      itemsAmount={100}
-    />
-    <Pagination
-      {...args}
-      withCounter
-      withSelect
-      defaultItemsPerPage={customOptions[0].value}
-      selectOptions={customOptions}
-      itemsAmount={customOptionsItemsAmount}
-    />
-  </StoryTemplate>
-);
+type Story = StoryObj<typeof Pagination>;
 
-export const OverviewMobile = (args: PaginationProps) => (
-  <StoryTemplate title="Pagination - mobile overview" gap="50px">
-    <Pagination {...args} smallScreen itemsAmount={100} />
-    <Pagination {...args} smallScreen withCounter itemsAmount={100} />
-    <Pagination
-      {...args}
-      smallScreen
-      withSelect
-      itemsAmount={args.itemsAmount || 100}
-    />
-    <Pagination
-      {...args}
-      smallScreen
-      withCounter
-      withSelect
-      itemsAmount={args.itemsAmount || 100}
-    />
-  </StoryTemplate>
-);
+export const Default: Story = {
+  args: { itemsAmount: 100 },
+  decorators: Story => (
+    <StoryTemplate title="Pagination - default">
+      <Story />
+    </StoryTemplate>
+  ),
+};
 
-export const Default = (args: PaginationProps) => (
-  <StoryTemplate title="Pagination - default" display="block">
-    <Pagination {...args} itemsAmount={args.itemsAmount || 100} />
-  </StoryTemplate>
-);
+export const Overview: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="Pagination - overview">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <VStack gap="x2">
+      <Pagination {...args} itemsAmount={70} />
+      <Pagination {...args} itemsAmount={100} />
+      <Pagination {...args} defaultActivePage={6} itemsAmount={100} />
+      <Pagination {...args} withCounter itemsAmount={100} />
+      <Pagination
+        {...args}
+        withCounter
+        defaultItemsPerPage={20}
+        itemsAmount={100}
+      />
+      <Pagination
+        {...args}
+        withPagination={false}
+        withCounter
+        itemsAmount={100}
+      />
+      <Pagination {...args} withSelect itemsAmount={100} />
+      <Pagination {...args} withCounter withSelect itemsAmount={100} />
+      <Pagination
+        {...args}
+        withCounter
+        withSelect
+        withPagination={false}
+        itemsAmount={100}
+      />
+      <Pagination
+        {...args}
+        withCounter
+        withSelect
+        defaultItemsPerPage={customOptions[0].value}
+        selectOptions={customOptions}
+        itemsAmount={customOptionsItemsAmount}
+      />
+    </VStack>
+  ),
+};
+
+export const OverviewMobile: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="Pagination - overview mobile">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <VStack gap="x2">
+      <Pagination {...args} smallScreen itemsAmount={100} />
+      <Pagination {...args} smallScreen withCounter itemsAmount={100} />
+      <Pagination
+        {...args}
+        smallScreen
+        withSelect
+        itemsAmount={args.itemsAmount || 100}
+      />
+      <Pagination
+        {...args}
+        smallScreen
+        withCounter
+        withSelect
+        itemsAmount={args.itemsAmount || 100}
+      />
+    </VStack>
+  ),
+};

--- a/packages/components/src/components/Popover/Popover.mdx
+++ b/packages/components/src/components/Popover/Popover.mdx
@@ -1,17 +1,10 @@
-import {
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-  Story,
-  Canvas,
-} from '@storybook/blocks';
-import { Popover, PopoverGroup } from '.';
+import { Meta, ArgTypes, Canvas, Controls, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
+import { PopoverGroup } from '.';
 import * as PopoverStories from './Popover.stories';
 
 <Meta of={PopoverStories} />
@@ -26,13 +19,9 @@ import * as PopoverStories from './Popover.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-popover--default" height="350px" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary height="350px" />
 
-  <Story id="dds-components-popover--default" height="350px" />
-</Canvas>
-
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-popover`} />
+Se stories med kontrollere i <LinkTo title="dds-components/Popover" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -53,7 +42,7 @@ Komponenten består av tre elementer:
 </PopoverGroup>
 `} />
 
-## API
+## Props
 
 ### PopoverGroup
 
@@ -72,7 +61,8 @@ Wrapper der anchor-elementet skal være første barnet og `<Popover />` skal væ
 
 Selve popover-elementet. Den åpnes når anchor-elementet trykkes, og den lukkes ved å trykke på anchor-elementet igjen, Esc-tast, lukkeknapptrykk og onBlur.
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={PopoverStories.Default} sourceState="shown" />
+<Controls of={PopoverStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`. **OBS!** `id` er ekskludert da den blir sendt som prop fra <PopoverGroup /> for å sørge for riktig oppførsel. `id` settes via `<PopoverGroup />` `popoverId`-prop.
 
@@ -81,12 +71,12 @@ I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes
 <Source
   code={`
   export type PopoverSizeProps = {
-  width?: CSS.Property.Width<string>;
-  height?: CSS.Property.Height<string>;
-  minWidth?: CSS.Property.MinWidth<string>;
-  minHeight?: CSS.Property.MinHeight<string>;
-  maxWidth?: CSS.Property.MaxWidth<string>;
-  maxHeight?: CSS.Property.MaxHeight<string>;
+    width?: CSS.Property.Width<string>;
+    height?: CSS.Property.Height<string>;
+    minWidth?: CSS.Property.MinWidth<string>;
+    minHeight?: CSS.Property.MinHeight<string>;
+    maxWidth?: CSS.Property.MaxWidth<string>;
+    maxHeight?: CSS.Property.MaxHeight<string>;
   };
   `}
 />
@@ -95,11 +85,7 @@ I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes
 
 Det kan være relevant å begrense størrelsen på Popover slik at ikke hele teksten vises ved overflow. Da bør den synlige teksten avsluttes med en ellipse:
 
-<Canvas>
-  {/* <Story height="350px" id="dds-components-popover--overflow" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story height="350px" id="dds-components-popover--overflow" />
-</Canvas>
+<Canvas height="350px" of={PopoverStories.Overflow} />
 
 For å oppnå det kan du sette sizeProps til ønskede verdier og gi tekstelementet som
 er barnet i `<Popover />` følgende CSS:

--- a/packages/components/src/components/Popover/Popover.stories.tsx
+++ b/packages/components/src/components/Popover/Popover.stories.tsx
@@ -3,14 +3,16 @@ import {
   ddsReferenceTokens,
 } from '@norges-domstoler/dds-design-tokens';
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 import styled from 'styled-components';
 
 import { type Placement } from '../../hooks';
 import { Button } from '../Button';
 import { removeButtonStyling } from '../helpers';
+import { VStack } from '../Stack';
 import { Typography } from '../Typography';
 
-import { Popover, PopoverGroup, type PopoverProps } from '.';
+import { Popover, PopoverGroup } from '.';
 
 export default {
   title: 'dds-components/Popover',
@@ -22,15 +24,46 @@ export default {
     offset: { control: { type: 'number' } },
   },
   parameters: {
-    controls: {
-      exclude: ['onCloseButton', 'anchorElement'],
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
     },
   },
 };
 
-export const ContentOverview = (args: PopoverProps) => {
-  return (
+type Story = StoryObj<typeof Popover>;
+
+export const Default: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="Popover - default">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <PopoverGroup>
+      <Button>Åpne</Button>
+      <Popover {...args}>
+        <VStack align="flex-start">
+          <Typography withMargins>
+            Dette er en popover med tekst og knapp
+          </Typography>
+          <Button>Klikk</Button>
+        </VStack>
+      </Popover>
+    </PopoverGroup>
+  ),
+};
+
+export const ContentOverview: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate title="Popover - content overview" display="grid">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <div>
         <PopoverGroup>
           <Button>Åpne</Button>
@@ -76,19 +109,13 @@ export const ContentOverview = (args: PopoverProps) => {
           </Popover>
         </PopoverGroup>
       </div>
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
-export const PlacementOverview = () => {
-  const popover = (placement: Placement) => (
-    <div>
-      <PopoverGroup>
-        <Button>Åpne</Button>
-        <Popover placement={placement}>{placement}</Popover>
-      </PopoverGroup>
-    </div>
-  );
-  return (
+
+export const PlacementOverview: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate
       title="Popover - placement overview"
       display="grid"
@@ -99,85 +126,91 @@ export const PlacementOverview = () => {
         padding: '150px 40px 200px 40px',
       }}
     >
-      {popover('top-start')}
-      {popover('bottom-start')}
-      {popover('left-start')}
-      {popover('right-start')}
-      {popover('top')}
-      {popover('bottom')}
-      {popover('right')}
-      {popover('left')}
-      {popover('top-end')}
-      {popover('bottom-end')}
-      {popover('right-end')}
-      {popover('left-end')}
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const popover = (placement: Placement) => (
+      <div>
+        <PopoverGroup>
+          <Button>Åpne</Button>
+          <Popover {...args} placement={placement}>
+            {placement}
+          </Popover>
+        </PopoverGroup>
+      </div>
+    );
+    return (
+      <>
+        {popover('top-start')}
+        {popover('bottom-start')}
+        {popover('left-start')}
+        {popover('right-start')}
+        {popover('top')}
+        {popover('bottom')}
+        {popover('right')}
+        {popover('left')}
+        {popover('top-end')}
+        {popover('bottom-end')}
+        {popover('right-end')}
+        {popover('left-end')}
+      </>
+    );
+  },
 };
 
-export const Default = (args: PopoverProps) => {
-  return (
-    <StoryTemplate title="Popover - default" display="block">
-      <PopoverGroup>
-        <Button>Åpne</Button>
-        <Popover {...args}>
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <Typography withMargins>
-              Dette er en popover med tekst og knapp
-            </Typography>
-            <Button>Klikk</Button>
-          </div>
-        </Popover>
-      </PopoverGroup>
-    </StoryTemplate>
-  );
-};
-
-export const Overflow = (args: PopoverProps) => {
-  return (
+export const Overflow: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate title="Popover - overflow" display="block">
-      <PopoverGroup>
-        <Button>Åpne</Button>
-        <Popover
-          {...args}
-          sizeProps={{ maxWidth: '150px', maxHeight: '200px' }}
-        >
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <Typography
-              withMargins
-              style={{
-                textOverflow: 'ellipsis',
-                overflow: 'hidden',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              Dette er en popover med tekst og knapp
-            </Typography>
-            <Button>Klikk</Button>
-          </div>
-        </Popover>
-      </PopoverGroup>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <PopoverGroup>
+      <Button>Åpne</Button>
+      <Popover {...args} sizeProps={{ maxWidth: '150px', maxHeight: '200px' }}>
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <Typography
+            withMargins
+            style={{
+              textOverflow: 'ellipsis',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Dette er en popover med tekst og knapp
+          </Typography>
+          <Button>Klikk</Button>
+        </div>
+      </Popover>
+    </PopoverGroup>
+  ),
 };
 
-export const InlineExample = (args: PopoverProps) => {
-  const Trigger = styled.button`
-    ${removeButtonStyling}
-    user-select: text;
-    text-decoration: underline;
-    color: ${ddsBaseTokens.colors.DdsColorInteractiveBase};
-    &:hover {
-      color: ${ddsBaseTokens.colors.DdsColorInteractiveDark};
-    }
-    &:focus {
-      color: ${ddsBaseTokens.colors.DdsColorNeutralsWhite};
-      background-color: ${ddsReferenceTokens.focus.colorDefault};
-      text-decoration: none;
-    }
-  `;
-  return (
+export const InlineExample: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate title="Popover - inline example" display="block">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => {
+    const Trigger = styled.button`
+      ${removeButtonStyling}
+      user-select: text;
+      text-decoration: underline;
+      color: ${ddsBaseTokens.colors.DdsColorInteractiveBase};
+      &:hover {
+        color: ${ddsBaseTokens.colors.DdsColorInteractiveDark};
+      }
+      &:focus {
+        color: ${ddsBaseTokens.colors.DdsColorNeutralsWhite};
+        background-color: ${ddsReferenceTokens.focus.colorDefault};
+        text-decoration: none;
+      }
+    `;
+    return (
       <Typography>
         Når du kommer til domstolen er det viktig at du finner rettssalen der
         innkallingen sier du skal møte. Vent utenfor salen, du blir hentet når
@@ -198,6 +231,6 @@ export const InlineExample = (args: PopoverProps) => {
         det vanskelig for deg å vente, så ta det opp på forhånd med den som har
         innkalt deg.
       </Typography>
-    </StoryTemplate>
-  );
+    );
+  },
 };

--- a/packages/components/src/components/ProgressTracker/ProgressTracker.mdx
+++ b/packages/components/src/components/ProgressTracker/ProgressTracker.mdx
@@ -1,18 +1,11 @@
-import {
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-  Canvas,
-  Story,
-} from '@storybook/blocks';
+import { ArgTypes, Meta, Canvas, Controls, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import * as ProgressTrackerStories from './ProgressTracker.stories';
 
 import { ProgressTracker } from '.';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 
 <Meta of={ProgressTrackerStories} />
@@ -27,15 +20,9 @@ import {
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-progresstracker--overview" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-progresstracker--overview" />
-</Canvas>
-
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-progresstracker`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/ProgressTracker" story="Overview">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -72,7 +59,8 @@ console.log(index)
 
 Ytterste container som styrer hvilket steg skal vises via indeks. Har to eller flere `<ProgressTracker.Item />` som barn.
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={ProgressTrackerStories.Overview} sourceState="shown" />
+<Controls of={ProgressTrackerStories.Overview} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/ProgressTracker/ProgressTracker.stories.tsx
+++ b/packages/components/src/components/ProgressTracker/ProgressTracker.stories.tsx
@@ -1,4 +1,5 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 import styled from 'styled-components';
 
@@ -22,218 +23,39 @@ import { Heading, Legend, Paragraph } from '../Typography';
 export default {
   title: 'dds-components/ProgressTracker',
   component: ProgressTracker,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Overview = () => {
-  const numSteps = 3;
+type Story = StoryObj<typeof ProgressTracker>;
 
-  const [activeStep, setActiveStep] = useState(0);
-  const [completedSteps, setCompletedSteps] = useState(new Set());
-
-  return (
-    <StoryTemplate title="ProgressTracker - overview" display="block">
-      <ProgressTracker
-        activeStep={activeStep}
-        onStepChange={step => setActiveStep(step)}
-        htmlProps={{ style: { maxWidth: '800px' } }}
-      >
-        <ProgressTracker.Item completed={completedSteps.has(0)}>
-          Partopplysninger
-        </ProgressTracker.Item>
-        <ProgressTracker.Item completed={completedSteps.has(1)}>
-          Slutning
-        </ProgressTracker.Item>
-        <ProgressTracker.Item completed={completedSteps.has(2)}>
-          Vedlegg
-        </ProgressTracker.Item>
-        <ProgressTracker.Item completed={completedSteps.has(3)} disabled>
-          Sammendrag
-        </ProgressTracker.Item>
-      </ProgressTracker>
-
-      <div style={{ margin: '10px' }}>
-        {activeStep === 0 && <div>Steg 1</div>}
-        {activeStep === 1 && <div>Steg 2</div>}
-        {activeStep === 2 && <div>Steg 3</div>}
-        {activeStep === 3 && <div>Steg 4</div>}
-      </div>
-
-      <Button
-        onClick={() => {
-          setCompletedSteps(s => new Set([...s, activeStep]));
-          if (activeStep < numSteps - 1) {
-            setActiveStep(s => s + 1);
-          }
-        }}
-      >
-        Sett som ferdig
-      </Button>
+export const Overview: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="ProgressTracker - overview">
+      <Story />
     </StoryTemplate>
-  );
-};
+  ),
+  render: args => {
+    const numSteps = 3;
 
-export const WithIcons = () => {
-  const numSteps = 3;
+    const [activeStep, setActiveStep] = useState(0);
+    const [completedSteps, setCompletedSteps] = useState(new Set());
 
-  const [activeStep, setActiveStep] = useState(0);
-  const [completedSteps, setCompletedSteps] = useState(new Set());
-
-  return (
-    <StoryTemplate title="ProgressTracker - with icons" display="block">
-      <ProgressTracker
-        activeStep={activeStep}
-        htmlProps={{ style: { maxWidth: '800px' } }}
-        onStepChange={step => setActiveStep(step)}
-      >
-        <ProgressTracker.Item
-          icon={PersonIcon}
-          completed={completedSteps.has(0)}
-        >
-          Partopplysninger
-        </ProgressTracker.Item>
-        <ProgressTracker.Item
-          icon={AttachmentIcon}
-          completed={completedSteps.has(1)}
-        >
-          Vedlegg
-        </ProgressTracker.Item>
-        <ProgressTracker.Item
-          icon={GavelIcon}
-          completed={completedSteps.has(2)}
-        >
-          Slutning
-        </ProgressTracker.Item>
-        <ProgressTracker.Item
-          icon={ChecklistIcon}
-          completed={completedSteps.has(3)}
-          disabled
-        >
-          Sammendrag
-        </ProgressTracker.Item>
-      </ProgressTracker>
-
-      <div style={{ margin: '10px' }}>
-        {activeStep === 0 && <div>Steg 1</div>}
-        {activeStep === 1 && <div>Steg 2</div>}
-        {activeStep === 2 && <div>Steg 3</div>}
-        {activeStep === 3 && <div>Steg 4</div>}
-      </div>
-
-      <Button
-        onClick={() => {
-          setCompletedSteps(s => new Set([...s, activeStep]));
-          if (activeStep < numSteps - 1) {
-            setActiveStep(s => s + 1);
-          }
-        }}
-      >
-        Sett som ferdig
-      </Button>
-    </StoryTemplate>
-  );
-};
-
-export const FutureStepsDisabled = () => {
-  const numSteps = 3;
-
-  const [activeStep, setActiveStep] = useState(0);
-  const [completedSteps, setCompletedSteps] = useState(new Set<number>());
-  const highestCompletedStep = Math.max(...Array.from(completedSteps), -1);
-
-  const handleSetFinishedButtonClick = () => {
-    setCompletedSteps(s => new Set([...s, activeStep]));
-    if (activeStep < numSteps - 1) {
-      setActiveStep(s => s + 1);
-    }
-  };
-
-  const isDisabled = (index: number) => index > highestCompletedStep + 1;
-
-  return (
-    <StoryTemplate title="ProgressTracker - disabled steps" display="block">
-      <ProgressTracker
-        activeStep={activeStep}
-        htmlProps={{ style: { maxWidth: '800px' } }}
-        onStepChange={step => setActiveStep(step)}
-      >
-        <ProgressTracker.Item
-          disabled={isDisabled(0)}
-          completed={completedSteps.has(0)}
-        >
-          Partopplysninger
-        </ProgressTracker.Item>
-        <ProgressTracker.Item
-          disabled={isDisabled(1)}
-          completed={completedSteps.has(1)}
-        >
-          Slutning
-        </ProgressTracker.Item>
-        <ProgressTracker.Item
-          disabled={isDisabled(2)}
-          completed={completedSteps.has(2)}
-        >
-          Vedlegg
-        </ProgressTracker.Item>
-      </ProgressTracker>
-      <div style={{ margin: '10px' }}>
-        {activeStep === 0 && <div>Steg 1</div>}
-        {activeStep === 1 && <div>Steg 2</div>}
-        {activeStep === 2 && <div>Steg 3</div>}
-      </div>
-
-      <Button onClick={() => activeStep > 0 && setActiveStep(s => s - 1)}>
-        Forrige steg
-      </Button>
-      <Button onClick={handleSetFinishedButtonClick}>Neste steg</Button>
-    </StoryTemplate>
-  );
-};
-
-export const Mobile = () => {
-  const numSteps = 3;
-
-  const [activeStep, setActiveStep] = useState(0);
-  const [completedSteps, setCompletedSteps] = useState(new Set());
-  const [isDrawerOpen, setDrawerOpen] = useState(false);
-
-  return (
-    <StoryTemplate title="ProgressTracker - mobile" display="block">
-      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
-        <div>
-          {activeStep === 0 && <div>Steg 1</div>}
-          {activeStep === 1 && <div>Steg 2</div>}
-          {activeStep === 2 && <div>Steg 3</div>}
-          {activeStep === 3 && <div>Steg 4</div>}
-          <Button
-            onClick={() => {
-              setCompletedSteps(s => new Set([...s, activeStep]));
-              if (activeStep < numSteps - 1) {
-                setActiveStep(s => s + 1);
-              }
-            }}
-          >
-            Sett som ferdig
-          </Button>
-        </div>
-        <Button
-          purpose="secondary"
-          onClick={() => setDrawerOpen(true)}
-          iconPosition="right"
-          icon={ChevronRightIcon}
-        >
-          Steg {activeStep + 1} av 4
-        </Button>
-      </div>
-      <Drawer isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)}>
+    return (
+      <>
         <ProgressTracker
+          {...args}
           activeStep={activeStep}
-          onStepChange={step => {
-            setDrawerOpen(false);
-            setActiveStep(step);
-          }}
+          onStepChange={step => setActiveStep(step)}
+          htmlProps={{ style: { maxWidth: '800px' } }}
         >
           <ProgressTracker.Item completed={completedSteps.has(0)}>
-            Partopplysninger med lang tekst
+            Partopplysninger
           </ProgressTracker.Item>
           <ProgressTracker.Item completed={completedSteps.has(1)}>
             Slutning
@@ -245,9 +67,232 @@ export const Mobile = () => {
             Sammendrag
           </ProgressTracker.Item>
         </ProgressTracker>
-      </Drawer>
+
+        <div style={{ margin: '10px' }}>
+          {activeStep === 0 && <div>Steg 1</div>}
+          {activeStep === 1 && <div>Steg 2</div>}
+          {activeStep === 2 && <div>Steg 3</div>}
+          {activeStep === 3 && <div>Steg 4</div>}
+        </div>
+
+        <Button
+          onClick={() => {
+            setCompletedSteps(s => new Set([...s, activeStep]));
+            if (activeStep < numSteps - 1) {
+              setActiveStep(s => s + 1);
+            }
+          }}
+        >
+          Sett som ferdig
+        </Button>
+      </>
+    );
+  },
+};
+
+export const WithIcons: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="ProgressTracker - with icons">
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const numSteps = 3;
+
+    const [activeStep, setActiveStep] = useState(0);
+    const [completedSteps, setCompletedSteps] = useState(new Set());
+
+    return (
+      <>
+        <ProgressTracker
+          {...args}
+          activeStep={activeStep}
+          htmlProps={{ style: { maxWidth: '800px' } }}
+          onStepChange={step => setActiveStep(step)}
+        >
+          <ProgressTracker.Item
+            icon={PersonIcon}
+            completed={completedSteps.has(0)}
+          >
+            Partopplysninger
+          </ProgressTracker.Item>
+          <ProgressTracker.Item
+            icon={AttachmentIcon}
+            completed={completedSteps.has(1)}
+          >
+            Vedlegg
+          </ProgressTracker.Item>
+          <ProgressTracker.Item
+            icon={GavelIcon}
+            completed={completedSteps.has(2)}
+          >
+            Slutning
+          </ProgressTracker.Item>
+          <ProgressTracker.Item
+            icon={ChecklistIcon}
+            completed={completedSteps.has(3)}
+            disabled
+          >
+            Sammendrag
+          </ProgressTracker.Item>
+        </ProgressTracker>
+
+        <div style={{ margin: '10px' }}>
+          {activeStep === 0 && <div>Steg 1</div>}
+          {activeStep === 1 && <div>Steg 2</div>}
+          {activeStep === 2 && <div>Steg 3</div>}
+          {activeStep === 3 && <div>Steg 4</div>}
+        </div>
+
+        <Button
+          onClick={() => {
+            setCompletedSteps(s => new Set([...s, activeStep]));
+            if (activeStep < numSteps - 1) {
+              setActiveStep(s => s + 1);
+            }
+          }}
+        >
+          Sett som ferdig
+        </Button>
+      </>
+    );
+  },
+};
+
+export const FutureStepsDisabled: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="ProgressTracker - future steps disabled">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => {
+    const numSteps = 3;
+
+    const [activeStep, setActiveStep] = useState(0);
+    const [completedSteps, setCompletedSteps] = useState(new Set<number>());
+    const highestCompletedStep = Math.max(...Array.from(completedSteps), -1);
+
+    const handleSetFinishedButtonClick = () => {
+      setCompletedSteps(s => new Set([...s, activeStep]));
+      if (activeStep < numSteps - 1) {
+        setActiveStep(s => s + 1);
+      }
+    };
+
+    const isDisabled = (index: number) => index > highestCompletedStep + 1;
+
+    return (
+      <>
+        <ProgressTracker
+          {...args}
+          activeStep={activeStep}
+          htmlProps={{ style: { maxWidth: '800px' } }}
+          onStepChange={step => setActiveStep(step)}
+        >
+          <ProgressTracker.Item
+            disabled={isDisabled(0)}
+            completed={completedSteps.has(0)}
+          >
+            Partopplysninger
+          </ProgressTracker.Item>
+          <ProgressTracker.Item
+            disabled={isDisabled(1)}
+            completed={completedSteps.has(1)}
+          >
+            Slutning
+          </ProgressTracker.Item>
+          <ProgressTracker.Item
+            disabled={isDisabled(2)}
+            completed={completedSteps.has(2)}
+          >
+            Vedlegg
+          </ProgressTracker.Item>
+        </ProgressTracker>
+        <div style={{ margin: '10px' }}>
+          {activeStep === 0 && <div>Steg 1</div>}
+          {activeStep === 1 && <div>Steg 2</div>}
+          {activeStep === 2 && <div>Steg 3</div>}
+        </div>
+
+        <Button onClick={() => activeStep > 0 && setActiveStep(s => s - 1)}>
+          Forrige steg
+        </Button>
+        <Button onClick={handleSetFinishedButtonClick}>Neste steg</Button>
+      </>
+    );
+  },
+};
+
+export const Mobile: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="ProgressTracker - mobile">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => {
+    const numSteps = 3;
+
+    const [activeStep, setActiveStep] = useState(0);
+    const [completedSteps, setCompletedSteps] = useState(new Set());
+    const [isDrawerOpen, setDrawerOpen] = useState(false);
+
+    return (
+      <>
+        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div>
+            {activeStep === 0 && <div>Steg 1</div>}
+            {activeStep === 1 && <div>Steg 2</div>}
+            {activeStep === 2 && <div>Steg 3</div>}
+            {activeStep === 3 && <div>Steg 4</div>}
+            <Button
+              onClick={() => {
+                setCompletedSteps(s => new Set([...s, activeStep]));
+                if (activeStep < numSteps - 1) {
+                  setActiveStep(s => s + 1);
+                }
+              }}
+            >
+              Sett som ferdig
+            </Button>
+          </div>
+          <Button
+            purpose="secondary"
+            onClick={() => setDrawerOpen(true)}
+            iconPosition="right"
+            icon={ChevronRightIcon}
+          >
+            Steg {activeStep + 1} av 4
+          </Button>
+        </div>
+        <Drawer isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)}>
+          <ProgressTracker
+            {...args}
+            activeStep={activeStep}
+            onStepChange={step => {
+              setDrawerOpen(false);
+              setActiveStep(step);
+            }}
+          >
+            <ProgressTracker.Item completed={completedSteps.has(0)}>
+              Partopplysninger med lang tekst
+            </ProgressTracker.Item>
+            <ProgressTracker.Item completed={completedSteps.has(1)}>
+              Slutning
+            </ProgressTracker.Item>
+            <ProgressTracker.Item completed={completedSteps.has(2)}>
+              Vedlegg
+            </ProgressTracker.Item>
+            <ProgressTracker.Item completed={completedSteps.has(3)} disabled>
+              Sammendrag
+            </ProgressTracker.Item>
+          </ProgressTracker>
+        </Drawer>
+      </>
+    );
+  },
 };
 
 const Layout = styled.div`
@@ -277,84 +322,94 @@ const DesktopOnly = styled.div`
   }
 `;
 
-export const RealWorldExample = () => {
-  const [activeStep, setActiveStep] = useState(0);
-  const [completedSteps, setCompletedSteps] = useState(new Set<number>());
-  const [progressTrackerDrawerOpen, setProgressTrackerDrawerOpen] =
-    useState(false);
+export const RealWorldExample: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="ProgressTracker - real world example">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => {
+    const [activeStep, setActiveStep] = useState(0);
+    const [completedSteps, setCompletedSteps] = useState(new Set<number>());
+    const [progressTrackerDrawerOpen, setProgressTrackerDrawerOpen] =
+      useState(false);
 
-  const steps = [
-    'Rolle- og saksnummer',
-    'Kontaktinformasjon',
-    'Fakturainformasjon',
-    'Salærberegning',
-    'Fravær',
-    'Utlegg',
-    'Oppsummering',
-  ];
-  const stepItems = steps.map((step, index) => (
-    <ProgressTracker.Item key={step} completed={completedSteps.has(index)}>
-      {step}
-    </ProgressTracker.Item>
-  ));
+    const steps = [
+      'Rolle- og saksnummer',
+      'Kontaktinformasjon',
+      'Fakturainformasjon',
+      'Salærberegning',
+      'Fravær',
+      'Utlegg',
+      'Oppsummering',
+    ];
+    const stepItems = steps.map((step, index) => (
+      <ProgressTracker.Item key={step} completed={completedSteps.has(index)}>
+        {step}
+      </ProgressTracker.Item>
+    ));
 
-  const completeStep = (step: number) => {
-    setCompletedSteps(s => new Set([...s, activeStep]));
-    setActiveStep(step + 1);
-  };
+    const completeStep = (step: number) => {
+      setCompletedSteps(s => new Set([...s, activeStep]));
+      setActiveStep(step + 1);
+    };
 
-  const formSteps = [
-    <RolleSaksnummerForm onSubmit={() => completeStep(0)} />,
-    <Kontaktinformasjon onSubmit={() => completeStep(1)} />,
-    <Fakturainformasjon onSubmit={() => completeStep(2)} />,
-    <Heading level={1}>Salærberegning</Heading>,
-    <Heading level={1}>Fravær</Heading>,
-    <Heading level={1}>Utlegg</Heading>,
-    <Heading level={1}>Oppsummering</Heading>,
-  ];
+    const formSteps = [
+      <RolleSaksnummerForm onSubmit={() => completeStep(0)} />,
+      <Kontaktinformasjon onSubmit={() => completeStep(1)} />,
+      <Fakturainformasjon onSubmit={() => completeStep(2)} />,
+      <Heading level={1}>Salærberegning</Heading>,
+      <Heading level={1}>Fravær</Heading>,
+      <Heading level={1}>Utlegg</Heading>,
+      <Heading level={1}>Oppsummering</Heading>,
+    ];
 
-  return (
-    <Layout>
-      <FormWrapper>
-        <MobileOnly>
-          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <Button
-              purpose="secondary"
-              onClick={() => setProgressTrackerDrawerOpen(true)}
-              iconPosition="right"
-              icon={ChevronRightIcon}
+    return (
+      <Layout>
+        <FormWrapper>
+          <MobileOnly>
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <Button
+                purpose="secondary"
+                onClick={() => setProgressTrackerDrawerOpen(true)}
+                iconPosition="right"
+                icon={ChevronRightIcon}
+              >
+                Steg {activeStep + 1} av {steps.length}
+              </Button>
+            </div>
+          </MobileOnly>
+          {formSteps[activeStep]}
+        </FormWrapper>
+        <ProgressTrackerWrapper>
+          <MobileOnly>
+            <Drawer
+              isOpen={progressTrackerDrawerOpen}
+              onClose={() => setProgressTrackerDrawerOpen(false)}
             >
-              Steg {activeStep + 1} av {steps.length}
-            </Button>
-          </div>
-        </MobileOnly>
-        {formSteps[activeStep]}
-      </FormWrapper>
-      <ProgressTrackerWrapper>
-        <MobileOnly>
-          <Drawer
-            isOpen={progressTrackerDrawerOpen}
-            onClose={() => setProgressTrackerDrawerOpen(false)}
-          >
+              <ProgressTracker
+                {...args}
+                activeStep={activeStep}
+                onStepChange={newStep => setActiveStep(newStep)}
+              >
+                {stepItems}
+              </ProgressTracker>
+            </Drawer>
+          </MobileOnly>
+          <DesktopOnly>
             <ProgressTracker
+              {...args}
               activeStep={activeStep}
               onStepChange={newStep => setActiveStep(newStep)}
             >
               {stepItems}
             </ProgressTracker>
-          </Drawer>
-        </MobileOnly>
-        <DesktopOnly>
-          <ProgressTracker
-            activeStep={activeStep}
-            onStepChange={newStep => setActiveStep(newStep)}
-          >
-            {stepItems}
-          </ProgressTracker>
-        </DesktopOnly>
-      </ProgressTrackerWrapper>
-    </Layout>
-  );
+          </DesktopOnly>
+        </ProgressTrackerWrapper>
+      </Layout>
+    );
+  },
 };
 
 const Fieldset = styled.fieldset`

--- a/packages/components/src/components/ScrollableContainer/ScrollableContainer.mdx
+++ b/packages/components/src/components/ScrollableContainer/ScrollableContainer.mdx
@@ -1,16 +1,9 @@
-import {
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-  Story,
-  Canvas,
-} from '@storybook/blocks';
-import { Scrollbar, ScrollableContainer } from '.';
+import { Meta, ArgTypes, Primary, Canvas, Controls } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
+import { Scrollbar } from '.';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as ScrollableContainerStories from './ScrollableContainer.stories';
 
@@ -26,15 +19,9 @@ import * as ScrollableContainerStories from './ScrollableContainer.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-scrollablecontainer--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-scrollablecontainer--default" />
-</Canvas>
-
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-scrollablecontainer`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/ScrollableContainer" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -96,13 +83,14 @@ const contentRef = useRef();
 </div>
 `} />
 
-## API
+## Props
 
 ## ScrollableContainer
 
 Hovedkomponenten for scrollbar innhold.
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={ScrollableContainerStories.Default} sourceState="shown" />
+<Controls of={ScrollableContainerStories.Default} />
 
 ## Scrollbar
 

--- a/packages/components/src/components/ScrollableContainer/ScrollableContainer.stories.tsx
+++ b/packages/components/src/components/ScrollableContainer/ScrollableContainer.stories.tsx
@@ -1,14 +1,11 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 import { type CSSProperties, useRef } from 'react';
 import styled from 'styled-components';
 
 import { focusVisible } from '../helpers';
 
-import {
-  ScrollableContainer,
-  type ScrollableContainerProps,
-  Scrollbar,
-} from '.';
+import { ScrollableContainer, Scrollbar } from '.';
 
 export default {
   title: 'dds-components/ScrollableContainer',
@@ -16,152 +13,170 @@ export default {
   argTypes: {
     contentHeight: { control: { type: 'text' } },
   },
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Default = (args: ScrollableContainerProps) => {
-  return (
+type Story = StoryObj<typeof ScrollableContainer>;
+
+export const Default: Story = {
+  args: { contentHeight: '300px' },
+  decorators: Story => (
     <StoryTemplate title="ScrollableContainer - default">
-      <ScrollableContainer {...args} contentHeight="300px">
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-        <p>
-          Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-          begrense kostnadene veldig. Under hele meklingsprosessen betaler
-          staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere
-          ikke blir enige gjennom mekling, innkaller retten til et nytt
-          rettsmøte (hovedforhandling).
-        </p>
-      </ScrollableContainer>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <ScrollableContainer {...args}>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+      <p>
+        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
+        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
+        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
+        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
+        (hovedforhandling).
+      </p>
+    </ScrollableContainer>
+  ),
 };
 
-export const JustScrollbar = () => {
-  const contentRef = useRef<HTMLDivElement>(null);
-  const containerStyle: CSSProperties = {
-    display: 'grid',
-    gridTemplate: 'auto / 1fr 20px',
-    overflow: 'hidden',
-    padding: '4px',
-  };
+export const JustScrollbar: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="ScrollableContainer - just scrollbar">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: () => {
+    const contentRef = useRef<HTMLDivElement>(null);
+    const containerStyle: CSSProperties = {
+      display: 'grid',
+      gridTemplate: 'auto / 1fr 20px',
+      overflow: 'hidden',
+      padding: '4px',
+    };
 
-  const ContentContainer = styled.div`
-    height: 500px;
-    overflow: auto;
-    scrollbar-width: none;
-    ::-webkit-scrollbar {
-      display: none;
-    }
-    :focus-visible {
-      ${focusVisible};
-    }
-  `;
+    const ContentContainer = styled.div`
+      height: 500px;
+      overflow: auto;
+      scrollbar-width: none;
+      ::-webkit-scrollbar {
+        display: none;
+      }
+      :focus-visible {
+        ${focusVisible};
+      }
+    `;
 
-  return (
-    <StoryTemplate title="Just Scrollbar">
+    return (
       <div style={containerStyle}>
         <ContentContainer ref={contentRef} tabIndex={0}>
           <p>
@@ -279,6 +294,6 @@ export const JustScrollbar = () => {
         </ContentContainer>
         <Scrollbar contentRef={contentRef} />
       </div>
-    </StoryTemplate>
-  );
+    );
+  },
 };

--- a/packages/components/src/components/Search/Search.mdx
+++ b/packages/components/src/components/Search/Search.mdx
@@ -1,16 +1,9 @@
-import {
-  Story,
-  Canvas,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
+import { Canvas, Controls, Primary, Meta, ArgTypes } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import { Search } from '.';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as SearchStories from './Search.stories';
 
@@ -26,25 +19,13 @@ import * as SearchStories from './Search.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-search--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-search--default" />
-</Canvas>
+<Canvas of={SearchStories.WithButton} />
 
-<Canvas>
-  {/* <Story id="dds-components-search--with-button" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Canvas of={SearchStories.WithSuggestions} height="470px" />
 
-  <Story id="dds-components-search--with-button" />
-</Canvas>
-
-<Canvas>
-  {/* <Story height="470px" id="dds-components-search--with-suggestions" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story height="470px" id="dds-components-search--with-suggestions" />
-</Canvas>
-
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-search`} />
+Se stories med kontrollere i <LinkTo title="dds-components/Search" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -94,13 +75,14 @@ $}
 `}
 />
 
-## API
+## Props
 
 ### Search
 
 Søkefeltet.
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={SearchStories.Default} sourceState="shown" />
+<Controls of={SearchStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLInputElement>`-interface.
 

--- a/packages/components/src/components/Search/Search.stories.tsx
+++ b/packages/components/src/components/Search/Search.stories.tsx
@@ -1,6 +1,9 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { Search, type SearchProps } from '.';
+import { VStack } from '../Stack';
+
+import { Search } from '.';
 
 export default {
   title: 'dds-components/Search',
@@ -10,8 +13,9 @@ export default {
     label: { control: { type: 'text' } },
   },
   parameters: {
-    controls: {
-      exclude: ['style', 'className', 'buttonProps'],
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
     },
   },
 };
@@ -33,9 +37,26 @@ const array = [
   'Øst-Agder',
 ];
 
-export const Overview = (args: SearchProps) => {
-  return (
+type Story = StoryObj<typeof Search>;
+
+export const Default: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="Search - default">
+      <Story />
+    </StoryTemplate>
+  ),
+};
+
+export const Overview: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate title="Search - overview">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <VStack gap="x1">
       <Search {...args} componentSize="medium" />
       <Search {...args} componentSize="medium" tip="Dette er en hjelpetekst" />
       <Search {...args} label={args.label ?? 'Label'} />
@@ -74,17 +95,23 @@ export const Overview = (args: SearchProps) => {
         componentSize="medium"
         buttonProps={{ onClick: () => null, loading: true }}
       />
-    </StoryTemplate>
-  );
+    </VStack>
+  ),
 };
 
-export const OverviewSizes = (args: SearchProps) => {
-  return (
+export const OverviewSizes: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate
       title="Search - overview sizes"
       display="grid"
       $columnsAmount={2}
     >
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <Search {...args} componentSize="small" />
       <Search
         {...args}
@@ -103,13 +130,19 @@ export const OverviewSizes = (args: SearchProps) => {
         componentSize="large"
         buttonProps={{ onClick: () => null, label: 'Søk' }}
       />
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const OverviewWithSuggestions = (args: SearchProps) => {
-  return (
-    <StoryTemplate title="Search - overview with suggestions">
+export const OverviewWithSuggestion: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="Search - overview with suggestion">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <VStack gap="x1">
       <Search.AutocompleteWrapper data={{ array }}>
         <Search {...args} componentSize="large" />
       </Search.AutocompleteWrapper>
@@ -119,32 +152,32 @@ export const OverviewWithSuggestions = (args: SearchProps) => {
       <Search.AutocompleteWrapper data={{ array }}>
         <Search {...args} componentSize="small" />
       </Search.AutocompleteWrapper>
-    </StoryTemplate>
-  );
+    </VStack>
+  ),
 };
 
-export const Default = (args: SearchProps) => {
-  return (
-    <StoryTemplate title="Search - default" display="block">
+export const WithButton: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="Search - with button">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <Search {...args} buttonProps={{ onClick: () => null, label: 'Søk' }} />
+  ),
+};
+
+export const WithSuggestions: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="Search - with suggestions">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <Search.AutocompleteWrapper data={{ array }}>
       <Search {...args} />
-    </StoryTemplate>
-  );
-};
-
-export const WithButton = (args: SearchProps) => {
-  return (
-    <StoryTemplate title="Search - with button" display="block">
-      <Search {...args} buttonProps={{ onClick: () => null, label: 'Søk' }} />
-    </StoryTemplate>
-  );
-};
-
-export const WithSuggestions = (args: SearchProps) => {
-  return (
-    <StoryTemplate title="Search - with suggestions" display="block">
-      <Search.AutocompleteWrapper data={{ array }}>
-        <Search {...args} />
-      </Search.AutocompleteWrapper>
-    </StoryTemplate>
-  );
+    </Search.AutocompleteWrapper>
+  ),
 };

--- a/packages/components/src/components/SelectionControl/Checkbox/Checkbox.mdx
+++ b/packages/components/src/components/SelectionControl/Checkbox/Checkbox.mdx
@@ -1,15 +1,8 @@
-import {
-  Story,
-  Canvas,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
+import { Story, Canvas, Controls, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as CheckboxStories from './Checkbox.stories';
 import * as CheckboxGroupStories from './CheckboxGroup.stories';
@@ -26,39 +19,20 @@ import * as CheckboxGroupStories from './CheckboxGroup.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={CheckboxStories.Default} />
-</Canvas>
+<Canvas of={CheckboxStories.Default} />
 
-<Canvas>
-  <Story of={CheckboxGroupStories.Default} />
-</Canvas>
+<Canvas of={CheckboxGroupStories.Default} />
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-checkbox-checkbox`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/Checkbox/Checkbox" story="Default">Storybook</LinkTo>.
 
-## Bruk i koden
-
-<Source
-  code={`
-  import { Checkbox, CheckboxGroup } from '@norges-domstoler/dds-components';
-
-<Checkbox label="Option" />
-
-<CheckboxGroup label="Label">
-  <Checkbox label="Option" />
-  <Checkbox label="Option" />
-</CheckboxGroup>
-`} />
-
-## API
+## Props
 
 ### Checkbox
 
 En avkrysningboks.
 
-<ArgTypes of={CheckboxStories} />
+<Canvas of={CheckboxStories.Default} sourceState="shown" />
+<Controls of={CheckboxStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLInputElement>`-interface i `htmlProps`.
 `name`, `checked`, `defaultChecked`, `value`, `defaultValue`, `onChange`, `onBlur` er tilgjengelige på rotnivå.
@@ -67,7 +41,8 @@ I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttri
 
 Wrapper for en `<Checkbox />` gruppe. Brukes ved flere barn.
 
-<ArgTypes of={CheckboxGroupStories} />
+<Canvas of={CheckboxGroupStories.Default} sourceState="shown" />
+<Controls of={CheckboxGroupStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
@@ -1,6 +1,7 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { Checkbox, type CheckboxProps } from '.';
+import { Checkbox } from '.';
 
 export default {
   title: 'dds-components/Checkbox/Checkbox',
@@ -13,15 +14,23 @@ export default {
     indeterminate: { control: { type: 'boolean' } },
   },
   parameters: {
-    controls: {
-      exclude: ['style', 'className'],
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
     },
   },
 };
 
-export const Overview = (args: CheckboxProps) => {
-  return (
+type Story = StoryObj<typeof Checkbox>;
+
+export const Overview: Story = {
+  decorators: Story => (
     <StoryTemplate title="Checkbox - overview" display="grid">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <Checkbox {...args} label={args.label ?? 'Default'} />
       <Checkbox {...args} label={args.label ?? 'Checked'} checked />
       <Checkbox {...args} label={args.label ?? 'Indeterminate'} indeterminate />
@@ -41,21 +50,15 @@ export const Overview = (args: CheckboxProps) => {
       <Checkbox {...args} label={args.label ?? 'Error'} error />
       <Checkbox {...args} label={args.label ?? 'Error checked'} error checked />
       <Checkbox {...args} />
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const Default = (args: CheckboxProps) => {
-  return (
+export const Default: Story = {
+  args: { label: 'Label' },
+  decorators: Story => (
     <StoryTemplate title="Checkbox - default" display="block">
-      <Checkbox {...args} />
+      <Story />
     </StoryTemplate>
-  );
-};
-export const WithLabel = (args: CheckboxProps) => {
-  return (
-    <StoryTemplate title="Checkbox - with label" display="block">
-      <Checkbox {...args} label={args.label ?? 'Label'} />
-    </StoryTemplate>
-  );
+  ),
 };

--- a/packages/components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
@@ -1,6 +1,7 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { Checkbox, CheckboxGroup, type CheckboxGroupProps } from '.';
+import { Checkbox, CheckboxGroup } from '.';
 
 export default {
   title: 'dds-components/Checkbox/CheckboxGroup',
@@ -15,115 +16,78 @@ export default {
     indeterminate: { control: { type: 'boolean' } },
   },
   parameters: {
-    controls: {
-      exclude: ['style', 'className'],
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
     },
   },
 };
 
-export const Overview = (args: CheckboxGroupProps) => {
-  return (
+type Story = StoryObj<typeof CheckboxGroup>;
+
+export const Overview: Story = {
+  args: {
+    label: 'Label',
+    children: [
+      <Checkbox key={0} label="Option 1" />,
+      <Checkbox key={1} label="Option 2" />,
+      <Checkbox key={2} label="Option 3" />,
+    ],
+  },
+  decorators: Story => (
     <StoryTemplate
       title="CheckboxGroup - overview"
       display="grid"
       $columnsAmount={2}
     >
-      <CheckboxGroup {...args} label={args.label ?? 'Label'}>
-        <Checkbox label="Option 1" />
-        <Checkbox label="Option 2" />
-        <Checkbox label="Option 3" />
-      </CheckboxGroup>
-      <CheckboxGroup {...args} label={args.label ?? 'Label'} direction="column">
-        <Checkbox label="Option 1" />
-        <Checkbox label="Option 2" />
-        <Checkbox label="Option 3" />
-      </CheckboxGroup>
-      <CheckboxGroup {...args} label={args.label ?? 'Label'} required>
-        <Checkbox label="Option 1" />
-        <Checkbox label="Option 2" />
-        <Checkbox label="Option 3" />
-      </CheckboxGroup>
-      <CheckboxGroup
-        {...args}
-        label={args.label ?? 'Label'}
-        direction="column"
-        required
-      >
-        <Checkbox label="Option 1" />
-        <Checkbox label="Option 2" />
-        <Checkbox label="Option 3" />
-      </CheckboxGroup>
-      <CheckboxGroup
-        {...args}
-        label={args.label ?? 'Label'}
-        tip="Dette er en hjelpetekst"
-      >
-        <Checkbox label="Option 1" />
-        <Checkbox label="Option 2" />
-        <Checkbox label="Option 3" />
-      </CheckboxGroup>
-      <CheckboxGroup
-        {...args}
-        label={args.label ?? 'Label'}
-        direction="column"
-        tip="Dette er en hjelpetekst"
-      >
-        <Checkbox label="Option 1" />
-        <Checkbox label="Option 2" />
-        <Checkbox label="Option 3" />
-      </CheckboxGroup>
-      <CheckboxGroup
-        {...args}
-        label={args.label ?? 'Label'}
-        errorMessage="Dette er en feilmelding"
-      >
-        <Checkbox error label="Option 1" />
-        <Checkbox error label="Option 2" />
-        <Checkbox error label="Option 3" />
-      </CheckboxGroup>
-      <CheckboxGroup
-        {...args}
-        label={args.label ?? 'Label'}
-        direction="column"
-        errorMessage="Dette er en feilmelding"
-      >
-        <Checkbox error label="Option 1" />
-        <Checkbox error label="Option 2" />
-        <Checkbox error label="Option 3" />
-      </CheckboxGroup>
-      <CheckboxGroup
-        {...args}
-        label={args.label ?? 'Label'}
-        tip="Dette er en hjelpetekst"
-        errorMessage="Dette er en feilmelding"
-      >
-        <Checkbox error label="Option 1" />
-        <Checkbox error label="Option 2" />
-        <Checkbox error label="Option 3" />
-      </CheckboxGroup>
-      <CheckboxGroup
-        {...args}
-        label={args.label ?? 'Label'}
-        direction="column"
-        tip="Dette er en hjelpetekst"
-        errorMessage="Dette er en feilmelding"
-      >
-        <Checkbox error label="Option 1" />
-        <Checkbox error label="Option 2" />
-        <Checkbox error label="Option 3" />
-      </CheckboxGroup>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => (
+    <>
+      <CheckboxGroup {...args} />
+      <CheckboxGroup {...args} direction="column" />
+      <CheckboxGroup {...args} required />
+      <CheckboxGroup {...args} direction="column" required />
+      <CheckboxGroup {...args} tip="Dette er en hjelpetekst" />
+      <CheckboxGroup
+        {...args}
+        direction="column"
+        tip="Dette er en hjelpetekst"
+      />
+      <CheckboxGroup {...args} errorMessage="Dette er en feilmelding" />
+      <CheckboxGroup
+        {...args}
+        direction="column"
+        errorMessage="Dette er en feilmelding"
+      />
+      <CheckboxGroup
+        {...args}
+        tip="Dette er en hjelpetekst"
+        errorMessage="Dette er en feilmelding"
+      />
+      <CheckboxGroup
+        {...args}
+        direction="column"
+        tip="Dette er en hjelpetekst"
+        errorMessage="Dette er en feilmelding"
+      />
+    </>
+  ),
 };
 
-export const Default = (args: CheckboxGroupProps) => {
-  return (
+export const Default: Story = {
+  args: {
+    label: 'Label',
+    children: [
+      <Checkbox key={0} label="Option 1" />,
+      <Checkbox key={1} label="Option 2" />,
+      <Checkbox key={2} label="Option 3" />,
+    ],
+  },
+  decorators: Story => (
     <StoryTemplate title="CheckboxGroup - default">
-      <CheckboxGroup {...args} label={args.label ?? 'Label'}>
-        <Checkbox label="Option 1" />
-        <Checkbox label="Option 2" />
-        <Checkbox label="Option 3" />
-      </CheckboxGroup>
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };

--- a/packages/components/src/components/SelectionControl/RadioButton/RadioButton.mdx
+++ b/packages/components/src/components/SelectionControl/RadioButton/RadioButton.mdx
@@ -1,11 +1,9 @@
-import { Canvas, Story, Meta, ArgTypes } from '@storybook/blocks';
-import { RadioButtonGroup } from '.';
+import { Canvas, Controls, Meta, Primary } from '@storybook/blocks';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
+import LinkTo from '@storybook/addon-links/react';
 import * as RadioButtonStories from './RadioButton.stories';
 import * as RadioButtonGroupStories from './RadioButtonGroup.stories';
 
@@ -21,36 +19,20 @@ import * as RadioButtonGroupStories from './RadioButtonGroup.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={RadioButtonStories.Default} />
-</Canvas>
+<Canvas of={RadioButtonStories.Default} />
 
-<Canvas>
-  <Story of={RadioButtonGroupStories.Default} />
-</Canvas>
+<Canvas of={RadioButtonGroupStories.Default} />
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-radiobutton-radiobutton`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/RadioButton" story="Default">Storybook</LinkTo>.
 
-## Bruk i koden
-
-<Source
-  code={`import { RadioButton, RadioButtonGroup } from '@norges-domstoler/dds-components';
-
-<RadioButtonGroup label="Gruppe">
-  <RadioButton label="Alternativ 1" />
-  <RadioButton label="Alternativ 2" />
-</RadioButtonGroup>
-`} />
-
-## API
+## Props
 
 ### RadioButton
 
 En radioknapp.
 
-<ArgTypes of={RadioButtonStories} />
+<Canvas of={RadioButtonStories.Default} sourceState="shown" />
+<Controls of={RadioButtonStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLInputElement>`-interface i `htmlProps`.
 
@@ -58,7 +40,8 @@ I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttri
 
 Wrapper for en `<RadioButton />` gruppe. Brukes ved flere barn.
 
-<ArgTypes of={RadioButtonGroupStories} />
+<Canvas of={RadioButtonGroupStories.Default} sourceState="shown" />
+<Controls of={RadioButtonGroupStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
+++ b/packages/components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
@@ -1,6 +1,7 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { RadioButton, type RadioButtonProps } from '.';
+import { RadioButton } from '.';
 
 export default {
   title: 'dds-components/RadioButton/RadioButton',
@@ -12,15 +13,38 @@ export default {
     readOnly: { control: { type: 'boolean' } },
     className: { control: { type: 'text' } },
   },
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Overview = (args: RadioButtonProps) => {
-  return (
+type Story = StoryObj<typeof RadioButton>;
+
+export const Default: Story = {
+  args: { label: 'Label' },
+  decorators: Story => (
+    <StoryTemplate title="RadioButton - default">
+      <Story />
+    </StoryTemplate>
+  ),
+};
+
+export const Overview: Story = {
+  args: {},
+  decorators: Story => (
     <StoryTemplate
-      title="Radio button - overview"
+      title="RadioButton - overview"
       display="grid"
       $columnsAmount={2}
     >
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <RadioButton {...args} label={args.label ?? 'Default'} />
       <RadioButton {...args} label={args.label ?? 'Checked'} checked />
       <RadioButton {...args} label={args.label ?? 'Disabled'} disabled />
@@ -31,15 +55,6 @@ export const Overview = (args: RadioButtonProps) => {
         checked
       />
       <RadioButton {...args} label={args.label ?? 'Error'} error />
-    </StoryTemplate>
-  );
-};
-
-export const Default = (args: RadioButtonProps) => {
-  return (
-    <StoryTemplate title="Radio button - default">
-      <RadioButton {...args} label={args.label ?? 'Label'} name="test" />
-      <RadioButton {...args} label={args.label ?? 'Label'} name="test" />
-    </StoryTemplate>
-  );
+    </>
+  ),
 };

--- a/packages/components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
+++ b/packages/components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
@@ -1,7 +1,8 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
-import { RadioButton, RadioButtonGroup, type RadioButtonGroupProps } from '.';
+import { RadioButton, RadioButtonGroup } from '.';
 
 export default {
   title: 'dds-components/RadioButton/RadioButtonGroup',
@@ -15,151 +16,184 @@ export default {
     required: { control: { type: 'boolean' } },
   },
   parameters: {
-    controls: {
-      exclude: ['style', 'className', 'onChange', 'name', 'value'],
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
     },
   },
 };
 
-export const Overview = (args: RadioButtonGroupProps<string>) => {
-  const [value, setValue] = useState<number | undefined>();
-  return (
+type Story = StoryObj<typeof RadioButtonGroup>;
+
+export const Default: Story = {
+  args: { label: 'Label' },
+  decorators: Story => (
+    <StoryTemplate title="RadioButtonGroup - default">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => {
+    const [value, setValue] = useState<number | undefined>();
+    return (
+      <RadioButtonGroup
+        {...args}
+        value={value}
+        onChange={(_event, value) => {
+          setValue(value);
+        }}
+      >
+        <RadioButton value={1} label="Option 1" name="test" />
+        <RadioButton value={2} label="Option 2" name="test" />
+        <RadioButton value={3} label="Option 3" name="test" />
+      </RadioButtonGroup>
+    );
+  },
+};
+
+export const Overview: Story = {
+  args: { label: 'Label' },
+  decorators: Story => (
     <StoryTemplate
-      title="Radio button group - overview"
+      title="RadioButtonGroup - overview"
       display="grid"
       $columnsAmount={2}
     >
-      <RadioButtonGroup
-        {...args}
-        direction="row"
-        label="Label"
-        value={value}
-        name="test"
-        onChange={(_event, value) => {
-          setValue(value);
-        }}
-      >
-        <RadioButton label="Option 1" value={1} />
-        <RadioButton label="Option 2" value={2} />
-        <RadioButton label="Option 3" value={3} />
-      </RadioButtonGroup>
-      <RadioButtonGroup
-        {...args}
-        direction="column"
-        label="Label"
-        value={value}
-        name="test1"
-        onChange={(_event, value) => {
-          setValue(value);
-        }}
-      >
-        <RadioButton label="Option 1" value={1} />
-        <RadioButton label="Option 2" value={2} />
-        <RadioButton label="Option 3" value={3} />
-      </RadioButtonGroup>
-      <RadioButtonGroup
-        {...args}
-        tip="Dette er en hjelpetekst"
-        direction="row"
-        label="Label"
-        value={value}
-        name="test2"
-        onChange={(_event, value) => {
-          setValue(value);
-        }}
-      >
-        <RadioButton label="Option 1" value={1} />
-        <RadioButton label="Option 2" value={2} />
-        <RadioButton label="Option 3" value={3} />
-      </RadioButtonGroup>
-      <RadioButtonGroup
-        {...args}
-        tip="Dette er en hjelpetekst"
-        direction="column"
-        label="Label"
-        value={value}
-        name="test3"
-        onChange={(_event, value) => {
-          setValue(value);
-        }}
-      >
-        <RadioButton label="Option 1" value={1} />
-        <RadioButton label="Option 2" value={2} />
-        <RadioButton label="Option 3" value={3} />
-      </RadioButtonGroup>
-      <RadioButtonGroup
-        {...args}
-        errorMessage="Dette er en feilmelding"
-        direction="row"
-        label="Label"
-        value={value}
-        name="test4"
-        onChange={(_event, value) => {
-          setValue(value);
-        }}
-      >
-        <RadioButton label="Option 1" value={1} />
-        <RadioButton label="Option 2" value={2} />
-        <RadioButton label="Option 3" value={3} />
-      </RadioButtonGroup>
-      <RadioButtonGroup
-        {...args}
-        errorMessage="Dette er en feilmelding"
-        direction="column"
-        label="Label"
-        value={value}
-        name="test5"
-        onChange={(_event, value) => {
-          setValue(value);
-        }}
-      >
-        <RadioButton label="Option 1" value={1} />
-        <RadioButton label="Option 2" value={2} />
-        <RadioButton label="Option 3" value={3} />
-      </RadioButtonGroup>
-      <RadioButtonGroup
-        {...args}
-        errorMessage="Dette er en feilmelding"
-        tip="Dette er en hjelpetekst"
-        direction="row"
-        label="Label"
-        value={value}
-        name="test6"
-        onChange={(_event, value) => {
-          setValue(value);
-        }}
-      >
-        <RadioButton label="Option 1" value={1} />
-        <RadioButton label="Option 2" value={2} />
-        <RadioButton label="Option 3" value={3} />
-      </RadioButtonGroup>
-      <RadioButtonGroup
-        {...args}
-        errorMessage="Dette er en feilmelding"
-        tip="Dette er en hjelpetekst"
-        direction="column"
-        label="Label"
-        value={value}
-        name="test7"
-        onChange={(_event, value) => {
-          setValue(value);
-        }}
-      >
-        <RadioButton label="Option 1" value={1} />
-        <RadioButton label="Option 2" value={2} />
-        <RadioButton label="Option 3" value={3} />
-      </RadioButtonGroup>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const [value, setValue] = useState<number | undefined>();
+    return (
+      <>
+        <RadioButtonGroup
+          {...args}
+          direction="row"
+          value={value}
+          name="test"
+          onChange={(_event, value) => {
+            setValue(value);
+          }}
+        >
+          <RadioButton label="Option 1" value={1} />
+          <RadioButton label="Option 2" value={2} />
+          <RadioButton label="Option 3" value={3} />
+        </RadioButtonGroup>
+        <RadioButtonGroup
+          {...args}
+          direction="column"
+          value={value}
+          name="test1"
+          onChange={(_event, value) => {
+            setValue(value);
+          }}
+        >
+          <RadioButton label="Option 1" value={1} />
+          <RadioButton label="Option 2" value={2} />
+          <RadioButton label="Option 3" value={3} />
+        </RadioButtonGroup>
+        <RadioButtonGroup
+          {...args}
+          tip="Dette er en hjelpetekst"
+          direction="row"
+          value={value}
+          name="test2"
+          onChange={(_event, value) => {
+            setValue(value);
+          }}
+        >
+          <RadioButton label="Option 1" value={1} />
+          <RadioButton label="Option 2" value={2} />
+          <RadioButton label="Option 3" value={3} />
+        </RadioButtonGroup>
+        <RadioButtonGroup
+          {...args}
+          tip="Dette er en hjelpetekst"
+          direction="column"
+          value={value}
+          name="test3"
+          onChange={(_event, value) => {
+            setValue(value);
+          }}
+        >
+          <RadioButton label="Option 1" value={1} />
+          <RadioButton label="Option 2" value={2} />
+          <RadioButton label="Option 3" value={3} />
+        </RadioButtonGroup>
+        <RadioButtonGroup
+          {...args}
+          errorMessage="Dette er en feilmelding"
+          direction="row"
+          value={value}
+          name="test4"
+          onChange={(_event, value) => {
+            setValue(value);
+          }}
+        >
+          <RadioButton label="Option 1" value={1} />
+          <RadioButton label="Option 2" value={2} />
+          <RadioButton label="Option 3" value={3} />
+        </RadioButtonGroup>
+        <RadioButtonGroup
+          {...args}
+          errorMessage="Dette er en feilmelding"
+          direction="column"
+          value={value}
+          name="test5"
+          onChange={(_event, value) => {
+            setValue(value);
+          }}
+        >
+          <RadioButton label="Option 1" value={1} />
+          <RadioButton label="Option 2" value={2} />
+          <RadioButton label="Option 3" value={3} />
+        </RadioButtonGroup>
+        <RadioButtonGroup
+          {...args}
+          errorMessage="Dette er en feilmelding"
+          tip="Dette er en hjelpetekst"
+          direction="row"
+          value={value}
+          name="test6"
+          onChange={(_event, value) => {
+            setValue(value);
+          }}
+        >
+          <RadioButton label="Option 1" value={1} />
+          <RadioButton label="Option 2" value={2} />
+          <RadioButton label="Option 3" value={3} />
+        </RadioButtonGroup>
+        <RadioButtonGroup
+          {...args}
+          errorMessage="Dette er en feilmelding"
+          tip="Dette er en hjelpetekst"
+          direction="column"
+          value={value}
+          name="test7"
+          onChange={(_event, value) => {
+            setValue(value);
+          }}
+        >
+          <RadioButton label="Option 1" value={1} />
+          <RadioButton label="Option 2" value={2} />
+          <RadioButton label="Option 3" value={3} />
+        </RadioButtonGroup>
+      </>
+    );
+  },
 };
 
-export const Default = (args: RadioButtonGroupProps<number>) => {
-  const [value, setValue] = useState<number | undefined>();
-  return (
-    <StoryTemplate title="Radio button group - default">
+export const WithDefaultValue: Story = {
+  args: { label: 'Label' },
+  decorators: Story => (
+    <StoryTemplate title="RadioButtonGroup - with default value">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => {
+    const [value, setValue] = useState<number | undefined>(2);
+    return (
       <RadioButtonGroup
         {...args}
-        label={args.label ?? 'Label'}
         value={value}
         onChange={(_event, value) => {
           setValue(value);
@@ -169,26 +203,6 @@ export const Default = (args: RadioButtonGroupProps<number>) => {
         <RadioButton value={2} label="Option 2" name="test" />
         <RadioButton value={3} label="Option 3" name="test" />
       </RadioButtonGroup>
-    </StoryTemplate>
-  );
-};
-
-export const WithDefaultValue = (args: RadioButtonGroupProps<number>) => {
-  const [value, setValue] = useState<number | undefined>(2);
-  return (
-    <StoryTemplate title="Radio button group - default value">
-      <RadioButtonGroup
-        {...args}
-        label="Label"
-        value={value}
-        onChange={(_event, value) => {
-          setValue(value);
-        }}
-      >
-        <RadioButton value={1} label="Option 1" name="test" />
-        <RadioButton value={2} label="Option 2" name="test" />
-        <RadioButton value={3} label="Option 3" name="test" />
-      </RadioButtonGroup>
-    </StoryTemplate>
-  );
+    );
+  },
 };

--- a/packages/components/src/components/SkipToContent/SkipToContent.mdx
+++ b/packages/components/src/components/SkipToContent/SkipToContent.mdx
@@ -1,16 +1,8 @@
-import {
-  Story,
-  Canvas,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { SkipToContent } from '.';
+import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as SkipToContentStories from './SkipToContent.stories';
 
@@ -26,15 +18,9 @@ import * as SkipToContentStories from './SkipToContent.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-skiptocontent--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-skiptocontent--default" />
-</Canvas>
-
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-skiptocontent`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/SkipToContent" story="Default">Storybook</LinkTo>.
 
 ## Bruk i koden
 
@@ -48,9 +34,10 @@ import * as SkipToContentStories from './SkipToContent.stories';
 </body>
 `} />
 
-## API
+## Props
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={SkipToContentStories.Default} sourceState="shown" />
+<Controls of={SkipToContentStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLAnchorElement>`-interface i `htmlProps`.
 

--- a/packages/components/src/components/SkipToContent/SkipToContent.stories.tsx
+++ b/packages/components/src/components/SkipToContent/SkipToContent.stories.tsx
@@ -1,9 +1,10 @@
 import { ddsBaseTokens } from '@norges-domstoler/dds-design-tokens';
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { Typography } from '../Typography';
 
-import { SkipToContent, type SkipToContentProps } from '.';
+import { SkipToContent } from '.';
 
 const { colors: Colors } = ddsBaseTokens;
 
@@ -15,37 +16,58 @@ export default {
     top: { control: { type: 'text' } },
   },
   parameters: {
-    controls: {
-      exclude: ['style', 'className', 'href'],
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
     },
   },
 };
 
-export const Overview = () => (
-  <StoryTemplate title="Skip to content - overview" display="block">
-    <div style={{ position: 'relative' }}>
-      <SkipToContent href="#innhold" />
-      <SkipToContent href="#innhold" top={'30px'} text="Alternativ tekst" />
-      'Tab' når du er i frame for å se varianter av komponenten
-      <Typography id="innhold">Innhold</Typography>
-    </div>
-  </StoryTemplate>
-);
+type Story = StoryObj<typeof SkipToContent>;
 
-export const Default = (args: SkipToContentProps) => (
-  <StoryTemplate title="Skip to content - default" display="block">
+export const Default: Story = {
+  args: { href: '#innhold' },
+  decorators: Story => (
+    <StoryTemplate title="SkipToContent - default" display="block">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
     <div style={{ position: 'relative' }}>
-      <SkipToContent {...args} href="#innhold" />
+      <SkipToContent {...args} />
       'Tab' når du er i frame for å se komponenten
       <Typography id="innhold">Innhold</Typography>
     </div>
-  </StoryTemplate>
-);
+  ),
+};
 
-export const Example = (args: SkipToContentProps) => (
-  <StoryTemplate title="Skip to content - example" display="block">
+export const Overview: Story = {
+  args: { href: '#innhold' },
+  decorators: Story => (
+    <StoryTemplate title="SkipToContent - overview" display="block">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
     <div style={{ position: 'relative' }}>
-      <SkipToContent {...args} href="#innhold" />
+      <SkipToContent {...args} />
+      <SkipToContent {...args} top={'30px'} text="Alternativ tekst" />
+      'Tab' når du er i frame for å se varianter av komponenten
+      <Typography id="innhold">Innhold</Typography>
+    </div>
+  ),
+};
+
+export const Example: Story = {
+  args: { href: '#innhold' },
+  decorators: Story => (
+    <StoryTemplate title="SkipToContent - example" display="block">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <div style={{ position: 'relative' }}>
+      <SkipToContent {...args} />
       'Tab' når du er i frame for å se komponenten; 'Enter' for å åpne i ny side
       og teste
       <Typography typographyType="headingSans08" withMargins>
@@ -63,5 +85,5 @@ export const Example = (args: SkipToContentProps) => (
         Innhold
       </Typography>
     </div>
-  </StoryTemplate>
-);
+  ),
+};

--- a/packages/components/src/components/Spinner/Spinner.mdx
+++ b/packages/components/src/components/Spinner/Spinner.mdx
@@ -1,16 +1,8 @@
-import {
-  Story,
-  Canvas,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { Spinner } from '.';
+import { Story, Canvas, Controls, Primary, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as SpinnerStories from './Spinner.stories';
 
@@ -25,28 +17,17 @@ import * as SpinnerStories from './Spinner.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-spinner--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-spinner--default" />
-</Canvas>
-
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-spinner`} />
+Se stories med kontrollere i <LinkTo title="dds-components/Spinner" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
 `<Spinner />` er et animert `<svg>`-element som bruker nåværende tid til å bestemme hvor den skal starte i animasjonen.
 
-## Bruk i koden
+## Props
 
-<Source
-  code={`import { Spinner } from '@norges-domstoler/dds-components';
-
-<Spinner />
-`} />
-
-## API
-
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={SpinnerStories.Default} sourceState="shown" />
+<Controls of={SpinnerStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLSVGElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/components/src/components/Spinner/Spinner.stories.tsx
@@ -1,7 +1,8 @@
 import { ddsBaseTokens } from '@norges-domstoler/dds-design-tokens';
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
-import { Spinner, type SpinnerProps } from '.';
+import { Spinner } from '.';
 
 export default {
   title: 'dds-components/Spinner',
@@ -11,32 +12,50 @@ export default {
     size: { control: { type: 'text' } },
     tooltip: { control: { type: 'text' }, defaultValue: 'Innlasting pågår' },
   },
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
-export const Overview = (args: SpinnerProps) => (
-  <StoryTemplate
-    title="Spinner - overview"
-    display="grid"
-    $columnsAmount={4}
-    gap="30px"
-  >
-    <Spinner {...args} />
-    <Spinner {...args} size="60px" tooltip="Egendefinert melding" />
-    <Spinner {...args} color="gray4" />
-    <Spinner {...args} color="gray4" size="60px" />
-    <Spinner {...args} color="success" />
-    <Spinner {...args} color="success" size="60px" />
-    <Spinner {...args} color="gray7" />
-    <Spinner {...args} color="gray7" size="60px" />
-  </StoryTemplate>
-);
+type Story = StoryObj<typeof Spinner>;
 
-export const Default = (args: SpinnerProps) => (
-  <StoryTemplate title="Spinner - default">
-    <Spinner
-      {...args}
-      size={args.size ?? ddsBaseTokens.iconSizes.DdsIconsizeMedium}
-      color={args.color ?? 'interactive'}
-    />
-  </StoryTemplate>
-);
+export const Default: Story = {
+  args: {
+    size: ddsBaseTokens.iconSizes.DdsIconsizeMedium,
+    color: 'interactive',
+  },
+  decorators: Story => (
+    <StoryTemplate title="Spinner - default">
+      <Story />
+    </StoryTemplate>
+  ),
+};
+
+export const Overview: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate
+      title="Spinner - overview"
+      display="grid"
+      $columnsAmount={4}
+      gap="30px"
+    >
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
+      <Spinner {...args} />
+      <Spinner {...args} size="60px" tooltip="Egendefinert melding" />
+      <Spinner {...args} color="gray4" />
+      <Spinner {...args} color="gray4" size="60px" />
+      <Spinner {...args} color="success" />
+      <Spinner {...args} color="success" size="60px" />
+      <Spinner {...args} color="gray7" />
+      <Spinner {...args} color="gray7" size="60px" />
+    </>
+  ),
+};

--- a/packages/components/src/components/SplitButton/SplitButton.mdx
+++ b/packages/components/src/components/SplitButton/SplitButton.mdx
@@ -1,16 +1,8 @@
-import {
-  Story,
-  Canvas,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { SplitButton } from '.';
+import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as SplitButtonStories from './SplitButton.stories';
 
@@ -26,15 +18,9 @@ import * as SplitButtonStories from './SplitButton.stories';
 
 ## Demo
 
-<Canvas>
-  {/* <Story id="dds-components-splitbutton--default" height="380px" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
+<Primary />
 
-  <Story id="dds-components-splitbutton--default" height="380px" />
-</Canvas>
-
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-splitbutton`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/SplitButton" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -61,6 +47,7 @@ onClick: () => {},
 
 ## API
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={SplitButtonStories.Default} sourceState="shown" />
+<Controls of={SplitButtonStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/components/src/components/SplitButton/SplitButton.stories.tsx
@@ -1,4 +1,5 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { PlusCircledIcon } from '../Icon/icons';
 
@@ -7,6 +8,12 @@ import { SplitButton, type SplitButtonProps, type SplitButtonPurpose } from '.';
 export default {
   title: 'dds-components/SplitButton',
   component: SplitButton,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
 const items = [
@@ -21,31 +28,46 @@ const items = [
   },
 ];
 
-export const Overview = (args: SplitButtonProps) => (
-  <StoryTemplate title="SplitButton - overview" display="grid">
-    <SplitButtonVariants args={args} purpose="primary" />
-    <SplitButtonVariants args={args} purpose="secondary" />
-  </StoryTemplate>
-);
+type Story = StoryObj<typeof SplitButton>;
 
-export const Default = (args: SplitButtonProps) => (
-  <StoryTemplate title="SplitButton - default" display="block">
-    <SplitButton
-      {...args}
-      primaryAction={{ label: 'Tekst' }}
-      secondaryActions={items}
-    />
-  </StoryTemplate>
-);
+export const Default: Story = {
+  args: {
+    primaryAction: { label: 'Tekst', fullWidth: true },
+    secondaryActions: items,
+  },
+  decorators: Story => (
+    <StoryTemplate title="SplitButton - default">
+      <Story />
+    </StoryTemplate>
+  ),
+};
 
-export const FullWidth = () => (
-  <StoryTemplate title="SplitButton - full width" display="block">
-    <SplitButton
-      primaryAction={{ label: 'Tekst', fullWidth: true }}
-      secondaryActions={items}
-    />
-  </StoryTemplate>
-);
+export const Overview: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate title="SplitButton - overview" display="grid">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
+      <SplitButtonVariants args={args} purpose="primary" />
+      <SplitButtonVariants args={args} purpose="secondary" />
+    </>
+  ),
+};
+
+export const FullWidth: Story = {
+  args: {
+    primaryAction: { label: 'Tekst', fullWidth: true },
+    secondaryActions: items,
+  },
+  decorators: Story => (
+    <StoryTemplate title="SplitButton - full width">
+      <Story />
+    </StoryTemplate>
+  ),
+};
 
 interface SplitButtonVariantsProps {
   args: SplitButtonProps;

--- a/packages/components/src/components/date-inputs/DatePicker/DatePicker.mdx
+++ b/packages/components/src/components/date-inputs/DatePicker/DatePicker.mdx
@@ -1,15 +1,8 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
+import { Canvas, Controls, Meta, Primary } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as DatePickerStories from './DatePicker.stories';
 
@@ -25,13 +18,9 @@ import * as DatePickerStories from './DatePicker.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={DatePickerStories.Default} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-datepicker`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/DatePicker" story="Default">Storybook</LinkTo>.
 
 ## Bruk i koden
 
@@ -75,9 +64,10 @@ const [value, setValue] = useState<Date>(new Date());
 />
 `}/>
 
-## API
+## Props
 
 `DatePicker`-komponenten er implementert vha. [react-aria](https://react-spectrum.adobe.com/react-aria).
 For mer utfyllende dokumentasjon av props referrerer vi deg til [`DatePicker` dokumentasjon til react-aria](https://react-spectrum.adobe.com/react-aria/DatePicker.html#props).
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={DatePickerStories.Default} sourceState="shown" />
+<Controls of={DatePickerStories.Default} />

--- a/packages/components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
@@ -7,7 +7,7 @@ import {
   today,
 } from '@internationalized/date';
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
-import type { Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { useRef, useState } from 'react';
 
 import { Button } from '../../Button';
@@ -20,11 +20,17 @@ import {
   nativeDateToCalendarDate,
 } from '../utils/transform';
 
-import { DatePicker, type DatePickerProps } from '.';
+import { DatePicker } from '.';
 
 const meta: Meta<typeof DatePicker> = {
   title: 'dds-components/DatePicker',
   component: DatePicker,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
   argTypes: {
     label: {
       control: 'text',
@@ -46,168 +52,220 @@ const meta: Meta<typeof DatePicker> = {
 
 export default meta;
 
-export const Default = (args: Partial<DatePickerProps>) => {
-  return (
+type Story = StoryObj<typeof DatePicker>;
+
+export const Default: Story = {
+  args: { label: 'Dato' },
+  decorators: Story => (
     <StoryTemplate title="DatePicker - default">
-      <DatePicker label="Dato" {...args} />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const Required = (args: Partial<DatePickerProps>) => {
-  return (
-    <StoryTemplate title="DatePicker - default">
-      <DatePicker label="Dato" {...args} isRequired />
+export const Required: Story = {
+  args: { label: 'Dato', isRequired: true },
+  decorators: Story => (
+    <StoryTemplate title="DatePicker - required">
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const Controlled = (args: Partial<DatePickerProps>) => {
-  const [value, setValue] = useState<CalendarDate | null>(
-    new CalendarDate(2023, 8, 28),
-  );
-
-  return (
+export const Controlled: Story = {
+  args: { label: 'Dato' },
+  decorators: Story => (
     <StoryTemplate title="DatePicker - controlled">
-      <DatePicker label="Dato" {...args} value={value} onChange={setValue} />
-      <Button onClick={() => setValue(today('Europe/Oslo'))}>Set today</Button>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const [value, setValue] = useState<CalendarDate | null>(
+      new CalendarDate(2023, 8, 28),
+    );
+
+    return (
+      <>
+        <DatePicker label="Dato" {...args} value={value} onChange={setValue} />
+        <Button onClick={() => setValue(today('Europe/Oslo'))}>
+          Set today
+        </Button>
+      </>
+    );
+  },
 };
 
-export const WeekendsUnavailable = (args: Partial<DatePickerProps>) => {
-  return (
+export const WeekendsUnavailable: Story = {
+  args: { label: 'Dato', isDateUnavailable: date => isWeekend(date, 'no-NO') },
+  decorators: Story => (
     <StoryTemplate title="DatePicker - weekends unavailable">
-      <DatePicker
-        label="Dato"
-        {...args}
-        isDateUnavailable={date => isWeekend(date, 'no-NO')}
-      />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const Error = (args: Partial<DatePickerProps>) => {
-  return (
+export const Error: Story = {
+  args: { label: 'Dato', errorMessage: 'Her er noe veldig galt! 😨' },
+  decorators: Story => (
     <StoryTemplate title="DatePicker - error">
-      <DatePicker
-        label="Dato"
-        {...args}
-        errorMessage="Her er noe veldig galt! 😨"
-      />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const OverviewSizes = (args: Partial<DatePickerProps>) => {
-  return (
-    <StoryTemplate title="DatePicker - overview sizes">
+export const OverviewSizes: Story = {
+  decorators: Story => (
+    <StoryTemplate title="DatePicker - weekends unavailable">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <DatePicker {...args} componentSize="medium" label="Medium" />
       <DatePicker {...args} componentSize="small" label="Small" />
       <DatePicker {...args} componentSize="tiny" label="Tiny" />
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const Tip = (args: Partial<DatePickerProps>) => {
-  return (
+export const Tip: Story = {
+  args: {
+    label: 'Dato',
+    tip: 'Visste du at denne komponenten også kan ha en tip?',
+  },
+  decorators: Story => (
     <StoryTemplate title="DatePicker - tip">
-      <DatePicker
-        label="Dato"
-        {...args}
-        tip="Visste du at denne komponenten også kan ha en tip?"
-      />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const ReadOnly = (args: Partial<DatePickerProps>) => {
-  return (
+export const ReadOnly: Story = {
+  args: {
+    label: 'Dato',
+    isReadOnly: true,
+    value: new CalendarDate(2023, 12, 24),
+  },
+  decorators: Story => (
     <StoryTemplate title="DatePicker - read only">
-      <DatePicker
-        label="Dato"
-        {...args}
-        value={new CalendarDate(2023, 12, 24)}
-        isReadOnly
-      />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const Disabled = (args: Partial<DatePickerProps>) => {
-  return (
+export const Disabled: Story = {
+  args: {
+    label: 'Dato',
+    isDisabled: true,
+    value: new CalendarDate(2023, 12, 24),
+  },
+  decorators: Story => (
     <StoryTemplate title="DatePicker - disabled">
-      <DatePicker label="Dato" {...args} isDisabled />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const CustomWidth = (args: Partial<DatePickerProps>) => {
-  return (
+export const CustomWidth: Story = {
+  args: { label: 'Dato', width: '1337px' },
+  decorators: Story => (
     <StoryTemplate title="DatePicker - custom width">
-      <DatePicker label="Dato" {...args} width="1337px" />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const ControlFocus = (args: Partial<DatePickerProps>) => {
-  const ref = useRef<HTMLElement>(null);
-  return (
-    <VStack gap="x1">
-      <DatePicker label="Dato" {...args} ref={ref} />
-      <Button onClick={() => ref.current?.focus()}>Fokuser DatePicker</Button>
-    </VStack>
-  );
-};
-
-export const InsideModal = (args: Partial<DatePickerProps>) => {
-  const [isOpen, setOpen] = useState(true);
-  return (
-    <StoryTemplate title="DatePicker - modal">
-      <Button onClick={() => setOpen(true)}>Åpne modal</Button>
-      <Modal isOpen={isOpen} onClose={() => setOpen(false)}>
-        <DatePicker label="Dato" {...args} />
-      </Modal>
+export const ControlFocus: Story = {
+  args: { label: 'Dato' },
+  decorators: Story => (
+    <StoryTemplate title="DatePicker - control focus">
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const ref = useRef<HTMLElement>(null);
+    return (
+      <VStack gap="x1">
+        <DatePicker label="Dato" {...args} ref={ref} />
+        <Button onClick={() => ref.current?.focus()}>Fokuser DatePicker</Button>
+      </VStack>
+    );
+  },
 };
 
-export const DateAndTime = () => {
-  const norwegianDateFormatter = new DateFormatter('no-NO', {
-    dateStyle: 'full',
-    timeStyle: 'short',
-  });
-  const [date, setDate] = useState<CalendarDate>(today('Europe/Oslo'));
-  const [time, setTime] = useState<Time>(new Time(12, 0, 0));
-  const dateTime = toCalendarDateTime(date, time);
-  return (
+export const InsideModal: Story = {
+  args: { label: 'Dato' },
+  decorators: Story => (
+    <StoryTemplate title="DatePicker - inside modal">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => {
+    const [isOpen, setOpen] = useState(true);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Åpne modal</Button>
+        <Modal isOpen={isOpen} onClose={() => setOpen(false)}>
+          <DatePicker label="Dato" {...args} />
+        </Modal>
+      </>
+    );
+  },
+};
+
+export const DateAndTime: Story = {
+  args: { label: 'Dato' },
+  decorators: Story => (
     <StoryTemplate title="DatePicker - date and time">
-      <HStack gap="x1">
-        <DatePicker
-          label="Dato"
-          value={date}
-          onChange={newValue => setDate(newValue)}
-        />
-        <TimePicker
-          label="Tid"
-          value={time}
-          onChange={newTime => setTime(newTime)}
-        />
-      </HStack>
-      <Paragraph>
-        Valg dato og tid:{' '}
-        {norwegianDateFormatter.format(dateTime.toDate('Europe/Oslo'))}
-      </Paragraph>
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const norwegianDateFormatter = new DateFormatter('no-NO', {
+      dateStyle: 'full',
+      timeStyle: 'short',
+    });
+    const [date, setDate] = useState<CalendarDate>(today('Europe/Oslo'));
+    const [time, setTime] = useState<Time>(new Time(12, 0, 0));
+    const dateTime = toCalendarDateTime(date, time);
+    return (
+      <VStack gap="x1">
+        <HStack gap="x1">
+          <DatePicker
+            {...args}
+            value={date}
+            onChange={newValue => setDate(newValue)}
+          />
+          <TimePicker
+            label="Tid"
+            value={time}
+            onChange={newTime => setTime(newTime)}
+          />
+        </HStack>
+        <Paragraph>
+          Valg dato og tid:{' '}
+          {norwegianDateFormatter.format(dateTime.toDate('Europe/Oslo'))}
+        </Paragraph>
+      </VStack>
+    );
+  },
 };
 
-export const NativeDate = () => {
-  const [date, setDate] = useState<Date>(new Date());
-  return (
-    <DatePicker
-      value={nativeDateToCalendarDate(date)}
-      onChange={d => setDate(calendarDateToNativeDate(d))}
-    />
-  );
+export const NativeDate: Story = {
+  args: { label: 'Dato' },
+  decorators: Story => (
+    <StoryTemplate title="DatePicker - native date">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => {
+    const [date, setDate] = useState<Date>(new Date());
+    return (
+      <DatePicker
+        {...args}
+        value={nativeDateToCalendarDate(date)}
+        onChange={d => setDate(calendarDateToNativeDate(d))}
+      />
+    );
+  },
 };

--- a/packages/components/src/components/date-inputs/TimePicker/TimePicker.mdx
+++ b/packages/components/src/components/date-inputs/TimePicker/TimePicker.mdx
@@ -1,15 +1,8 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
+import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as TimePickerStories from './TimePicker.stories';
 
@@ -25,13 +18,9 @@ import * as TimePickerStories from './TimePicker.stories';
 
 ## Demo
 
-<Canvas>
-  <Story of={TimePickerStories.Default} />
-</Canvas>
+<Primary />
 
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-timepicker`}
-/>
+Se stories med kontrollere i <LinkTo title="dds-components/TimePicker" story="Default">Storybook</LinkTo>.
 
 ## Bruk i koden
 
@@ -48,9 +37,10 @@ new Time(12, 0, 0)
 <TimePicker label="Tidspunkt" value={value} onChange={setValue} />
 `} />
 
-## API
+## Props
 
 `TimePicker`-komponenten er implementert vha. [react-aria](https://react-spectrum.adobe.com/react-aria).
 For mer utfyllende dokumentasjon av props referrerer vi deg til [`useTimeField` dokumentasjon til react-aria](https://react-spectrum.adobe.com/react-aria/useTimeField.html).
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={TimePickerStories.Default} sourceState="shown" />
+<Controls of={TimePickerStories.Default} />

--- a/packages/components/src/components/date-inputs/TimePicker/TimePicker.stories.tsx
+++ b/packages/components/src/components/date-inputs/TimePicker/TimePicker.stories.tsx
@@ -1,147 +1,95 @@
 import { Time } from '@internationalized/date';
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
-import type { Meta } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { Button } from '../../Button';
-import { TimeIcon } from '../../Icon/icons';
-import { HStack, VStack } from '../../Stack';
-import { TextInput } from '../../TextInput';
-import { Label } from '../../Typography';
-import { DatePicker } from '../DatePicker';
 
-import { TimePicker, type TimePickerProps } from '.';
+import { TimePicker } from '.';
 
 const meta: Meta<typeof TimePicker> = {
   title: 'dds-components/TimePicker',
   component: TimePicker,
+  parameters: {
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
+    },
+  },
 };
 
 export default meta;
 
-export const Default = (args: Partial<TimePickerProps>) => {
-  return (
+type Story = StoryObj<typeof TimePicker>;
+
+export const Default: Story = {
+  args: { label: 'Tidspunkt' },
+  decorators: Story => (
     <StoryTemplate title="TimePicker - default">
-      <TimePicker label="Tidspunkt" {...args} />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const Required = (args: Partial<TimePickerProps>) => {
-  return (
+export const Required: Story = {
+  args: { label: 'Tidspunkt', isRequired: true },
+  decorators: Story => (
     <StoryTemplate title="TimePicker - required">
-      <TimePicker label="Tidspunkt" {...args} isRequired />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const Controlled = (args: Partial<TimePickerProps>) => {
-  const [value, setValue] = useState<Time | null>(new Time(12));
-
-  return (
-    <StoryTemplate title="TimePicker - controlled">
-      <TimePicker
-        label="Tidspunkt"
-        {...args}
-        value={value}
-        onChange={setValue}
-      />
-      <Button onClick={() => setValue(new Time(12))}>
-        Sett til klokken 12
-      </Button>
+export const Controlled: Story = {
+  args: { label: 'Tidspunkt' },
+  decorators: Story => (
+    <StoryTemplate title="TimePicker - required">
+      <Story />
     </StoryTemplate>
-  );
+  ),
+  render: args => {
+    const [value, setValue] = useState<Time | null>(new Time(12));
+
+    return (
+      <StoryTemplate title="TimePicker - controlled">
+        <TimePicker {...args} value={value} onChange={setValue} />
+        <Button onClick={() => setValue(new Time(12))}>
+          Sett til klokken 12
+        </Button>
+      </StoryTemplate>
+    );
+  },
 };
 
-export const Error = (args: Partial<TimePickerProps>) => {
-  return (
+export const Error: Story = {
+  args: { label: 'Tidspunkt', errorMessage: 'Her er noe veldig galt! 😨' },
+  decorators: Story => (
     <StoryTemplate title="TimePicker - error">
-      <TimePicker
-        label="Tidspunkt"
-        {...args}
-        errorMessage="Her er noe veldig galt! 😨"
-      />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const OverviewSizes = (args: Partial<TimePickerProps>) => {
-  return (
+export const OverviewSizes: Story = {
+  decorators: Story => (
     <StoryTemplate title="TimePicker - overview sizes">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <TimePicker {...args} componentSize="medium" label="Medium" />
       <TimePicker {...args} componentSize="small" label="Small" />
       <TimePicker {...args} componentSize="tiny" label="Tiny" />
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const OverviewSizesComparedWithTextInputWithIcon = (
-  args: Partial<TimePickerProps>,
-) => {
-  const componentSizes = ['medium', 'small', 'tiny'] as const;
-  return (
-    <StoryTemplate title="TimePicker - overview sizes">
-      {componentSizes.map(componentSize => (
-        <VStack
-          key={componentSize}
-          align="flex-start"
-          justify="flex-start"
-          gap="x0.25"
-        >
-          <Label style={{ textTransform: 'capitalize' }}>{componentSize}</Label>
-          <HStack gap="x0.25">
-            <TimePicker
-              label="Tidspunkt"
-              {...args}
-              componentSize={componentSize}
-            />
-            <TextInput
-              label="Tidspunkt"
-              componentSize={componentSize}
-              icon={TimeIcon}
-            />
-          </HStack>
-          <TextInput
-            label="Tidspunkt"
-            componentSize={componentSize}
-            icon={TimeIcon}
-          />
-        </VStack>
-      ))}
-    </StoryTemplate>
-  );
-};
-
-export const OverviewSizesWithDatePicker = (args: Partial<TimePickerProps>) => {
-  const componentSizes = ['medium', 'small', 'tiny'] as const;
-  return (
-    <StoryTemplate title="TimePicker - overview sizes with datepicker">
-      {componentSizes.map(componentSize => (
-        <VStack
-          key={componentSize}
-          align="flex-start"
-          justify="flex-start"
-          gap="x0.25"
-        >
-          <HStack gap="x0.25">
-            <TimePicker
-              {...args}
-              componentSize={componentSize}
-              label="Tidspunkt"
-            />
-            <DatePicker componentSize={componentSize} label="Tidspunkt" />
-          </HStack>
-          <DatePicker componentSize={componentSize} label="Tidspunkt" />
-        </VStack>
-      ))}
-    </StoryTemplate>
-  );
-};
-
-export const CustomWidth = (args: Partial<TimePickerProps>) => {
-  return (
+export const CustomWidth: Story = {
+  args: { label: 'Tidspunkt', width: '500px' },
+  decorators: Story => (
     <StoryTemplate title="TimePicker - custom width">
-      <TimePicker {...args} width="500px" label="Tidspunkt" />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@storybook/addon-essentials':
         specifier: 7.6.10
         version: 7.6.10(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/addon-links':
+        specifier: ^7.6.10
+        version: 7.6.10(react@18.2.0)
       '@storybook/addon-storysource':
         specifier: 7.6.10
         version: 7.6.10
@@ -3737,6 +3740,20 @@ packages:
     resolution: {integrity: sha512-dIuS5QmoT1R+gFOcf6CoBa6D9UR5/wHCfPqPRH8dNNcCLtIGSHWQ4v964mS5OCq1Huj7CghmR15lOUk7SaYwUA==}
     dependencies:
       '@storybook/global': 5.0.0
+    dev: true
+
+  /@storybook/addon-links@7.6.10(react@18.2.0):
+    resolution: {integrity: sha512-s/WkSYHpr2pb9p57j6u/xDBg3TKJhBq55YMl0GB5gXgkRPIeuGbPhGJhm2yTGVFLvXgr/aHHnOxb/R/W8PiRhA==}
+    peerDependencies:
+      react: 18.2.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+    dependencies:
+      '@storybook/csf': 0.1.2
+      '@storybook/global': 5.0.0
+      react: 18.2.0
+      ts-dedent: 2.2.0
     dev: true
 
   /@storybook/addon-measure@7.6.10:


### PR DESCRIPTION
- Bytter til `StoryObj`-format for stories
- Gjør om "API"-seksjon i docs til å være en interaktiv story med kodevisning
  - Får fortsatt sett alle props til komponenten, men også mulighet til å se hvordan de påvirker komponenten.
- Gjør om prop-filtreringen til react-docgen-typescript til den gamle default filtreringen.
- Endre lenking til stories fra manuelle lenker til å bruke `@storybook/addon-links`
- Oppdatere deprecated funksjonalitet i .mdx-stories

Rekker ikke å endre alle stories nå, men de fleste er endret.