### PR TITLE
ELSA1-306 fjerner fokus på read-only

### DIFF
--- a/.changeset/smooth-wombats-live.md
+++ b/.changeset/smooth-wombats-live.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Fjernet fokusstyling i read-only inputfelt

--- a/packages/components/src/components/helpers/Input/Input.styles.tsx
+++ b/packages/components/src/components/helpers/Input/Input.styles.tsx
@@ -53,7 +53,7 @@ export const Input = styled.input`
   &:hover:enabled:read-write {
     ${hoverInputfield}
   }
-  &:not(.disabled):not(.read-only):focus-within,
+  &:not(.disabled):not(.read-only):not(:read-only):focus-within,
   &.active,
   &:focus:enabled:read-write,
   &:active:enabled:read-write {


### PR DESCRIPTION
Fjerner fokusstyling: 
<img width="371" alt="Navnløs" src="https://github.com/domstolene/designsystem/assets/71430829/4047c71d-7621-4000-8a53-878b932f0baf">
