### PR TITLE
ELSA1-230 fjerner `defaultWidth` på `LocalMessage`

### DIFF
--- a/.changeset/shaggy-peas-lie.md
+++ b/.changeset/shaggy-peas-lie.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Fjerner `defaultWidth` fra `LocalMessage` da den ikke skal ha hardkodet bredde. Legger på litt padding i innhold for bedre avstand.

--- a/packages/components/src/components/LocalMessage/LocalMessage.tokens.tsx
+++ b/packages/components/src/components/LocalMessage/LocalMessage.tokens.tsx
@@ -52,6 +52,12 @@ const container = {
   },
 };
 
+const content = {
+  base: {
+    paddingRight: spacing.SizesDdsSpacingX075,
+  },
+};
+
 const purposeVariants: {
   [k in LocalMessagePurpose]: {
     icon: SvgIcon;
@@ -108,6 +114,7 @@ const icon = {
 
 export const localMessageTokens = {
   container,
+  content,
   purposeVariants,
   icon,
 };

--- a/packages/components/src/components/LocalMessage/LocalMessage.tsx
+++ b/packages/components/src/components/LocalMessage/LocalMessage.tsx
@@ -17,8 +17,7 @@ import {
   getFontStyling,
 } from '../Typography';
 
-const defaultWidth: Property.Width<string> = '400px';
-const { container, icon, purposeVariants } = tokens;
+const { container, content, icon, purposeVariants } = tokens;
 
 type ContainerProps = Pick<
   LocalMessageProps,
@@ -98,6 +97,7 @@ const MessageIconWrapper = styled(Icon)`
 
 const TextContainer = styled.div`
   grid-area: text;
+  padding-right: ${content.base.paddingRight};
 `;
 
 const CloseButton = styled(Button)<Pick<LocalMessageProps, 'layout'>>`
@@ -140,7 +140,7 @@ export const LocalMessage = forwardRef<HTMLDivElement, LocalMessageProps>(
       purpose = 'info',
       closable,
       onClose,
-      width = defaultWidth,
+      width,
       layout = 'horisontal',
       children,
       id,


### PR DESCRIPTION
Fjerner `defaultWidth` da komponenten ikke skal ha hardkodet bredde, og legger på padding for bedre avstand.