### PR TITLE
Støtte for `headingLevel` i `EmptyContent`.

### DIFF
--- a/.changeset/violet-moons-allow.md
+++ b/.changeset/violet-moons-allow.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": minor
+---
+
+Støtte for `headingLevel` i `EmptyContent`. Grunnet krav for UU skal overskriftsnivået på tittel følge hierarkiet, og konsumenter skal sette det selv når default ikke passer.

--- a/packages/components/src/components/EmptyContent/EmptyContent.mdx
+++ b/packages/components/src/components/EmptyContent/EmptyContent.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as EmptyContentStories from './EmptyContent.stories';
 
@@ -13,15 +12,7 @@ import * as EmptyContentStories from './EmptyContent.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/EmptyContent"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/EmptyContent" story="Default">Storybook</LinkTo>.
-
 ## Props
 
 <Canvas of={EmptyContentStories.Default} sourceState="shown" />
 <Controls of={EmptyContentStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/EmptyContent/EmptyContent.tsx
+++ b/packages/components/src/components/EmptyContent/EmptyContent.tsx
@@ -2,7 +2,7 @@ import { ddsBaseTokens } from '@norges-domstoler/dds-design-tokens';
 import { type HTMLAttributes } from 'react';
 import styled from 'styled-components';
 
-import { Typography } from '../Typography';
+import { Heading, type HeadingLevel, Paragraph } from '../Typography';
 
 const { colors, spacing } = ddsBaseTokens;
 
@@ -26,18 +26,25 @@ const StyledEmptyContentText = styled.div`
 `;
 
 export type EmptyContentProps = {
+  /**Tittel - kort oppsummering. */
   title?: string;
+  /**Nivå på overskriften. Sørg for at den følger hierarkiet på siden. */
+  titleHeadingLevel?: HeadingLevel;
+  /**Melding - beskrivelse og forklaring på hvordan brukeren kan få innhold. */
   message: string;
 } & HTMLAttributes<HTMLDivElement>;
 
-export function EmptyContent({ title, message, ...rest }: EmptyContentProps) {
+export function EmptyContent({
+  title,
+  message,
+  titleHeadingLevel = 5,
+  ...rest
+}: EmptyContentProps) {
   return (
     <StyledEmptyContent {...rest}>
       <StyledEmptyContentText>
-        {title && (
-          <Typography typographyType="headingSans02">{title}</Typography>
-        )}
-        <Typography typographyType="bodySans02">{message}</Typography>
+        {title && <Heading level={titleHeadingLevel}>{title}</Heading>}
+        <Paragraph>{message}</Paragraph>
       </StyledEmptyContentText>
     </StyledEmptyContent>
   );


### PR DESCRIPTION
- `EmptyContent` har alltid tittel i `<h5>`; Det er vanlig at tittel for tom tilstand er en overskrift, men det er viktig at den følger hierarkiet på siden. Konsumenter skal kunne velge nivå selv.
- Opprydding av docs story.
- Beskrivelser av attributter for docs.