### PR TITLE
ELSA1-322 Opprydding i Storybook docs

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -74,7 +74,9 @@
     margin-top: 0;
   }
 
-  .sbdocs p:not(.docs-story *) {
+  .sbdocs p:not(.docs-story *),
+  .sbdocs ul:not(.docs-story *),
+  .sbdocs li:not(.docs-story *) {
     font-weight: var(--dds-font-body-sans-02-font-weight);
     font-size: var(--dds-font-body-sans-02-font-size);
     letter-spacing: var(--dds-font-body-sans-02-letter-spacing);

--- a/packages/components/src/components/AppShell/AppShell.mdx
+++ b/packages/components/src/components/AppShell/AppShell.mdx
@@ -1,5 +1,4 @@
-import { Meta, ArgTypes, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Meta, Canvas, Story, Controls } from '@storybook/blocks';
 import {
   Source,
   ComponentLinkRow,
@@ -16,11 +15,17 @@ import * as AppShellStories from './AppShell.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/AppShell/AppShell"
 />
 
-## Demo
+## Oversikt
 
-<Primary />
+Komponenten er en standard wrapper for en Lovisa-applikasjon.
 
-Se stories med kontrollere i <LinkTo title="dds-components/AppShell" story="Default">Storybook</LinkTo>.
+## API
+
+<Canvas>
+  <Story of={AppShellStories.Default} height="700px" />
+</Canvas>
+
+<Controls of={AppShellStories.Default} />
 
 ## Bruk i koden
 
@@ -48,7 +53,3 @@ import { AppShell, FolderIcon, ChecklistIcon } from '@norges-domstoler/dds-compo
   Applikasjonskoden din her...
 </AppShell>
 `} />
-
-## API
-
-<ArgTypes of={AppShellStories.Default} />

--- a/packages/components/src/components/BackLink/BackLink.mdx
+++ b/packages/components/src/components/BackLink/BackLink.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Controls, Meta } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as BackLinkStories from './BackLink.stories';
 
@@ -12,12 +11,6 @@ import * as BackLinkStories from './BackLink.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/DDS-Komponenter?node-id=12825-221439&t=H2ZVa4PDdz4UMfma-0"
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/BackLink"
 />
-
-## Demo
-
-<Canvas of={BackLinkStories.Default} sourceState="hidden" />
-
-Se stories med kontrollere i <LinkTo title="dds-components/BackLink" story="Default">Storybook</LinkTo>.
 
 ## Props
 

--- a/packages/components/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/packages/components/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Controls, Meta, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as BreadcrumbsStories from './Breadcrumbs.stories';
 
@@ -12,12 +11,6 @@ import * as BreadcrumbsStories from './Breadcrumbs.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/?node-id=1676%3A0"
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Breadcrumbs"
 />
-
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Breadcrumbs" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -41,10 +34,11 @@ I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes
 
 ### Breadcrumb
 
-Brødsmule. Returnerer `<a>` hvis `href`-prop er oppgitt eller `<span>` hvis ikke.
-**OBS!** Alle `<Breadcrumb>`-komponenter bør være lenker bortsett fra den siste som tilsvarer siden brukeren er inne på.
+Brødsmule.
+Den støtter alle native HTML-attributter som er en del av `AnchorHTMLAttributes<HTMLAnchorElement>` eller `HTMLAttributes<HTMLSpanElement>` -interface.
+Returnerer `<a>` hvis `href`-prop er oppgitt eller `<span>` hvis ikke.
 
-Det støttes alle native HTML-attributter som er en del av `AnchorHTMLAttributes<HTMLAnchorElement>` eller `HTMLAttributes<HTMLSpanElement>` -interface.
+**OBS!** Alle `<Breadcrumb>`-komponenter bør være lenker bortsett fra den siste som tilsvarer siden brukeren er inne på.
 
 ## Retningslinjer
 

--- a/packages/components/src/components/Button/Button.mdx
+++ b/packages/components/src/components/Button/Button.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Controls, Meta, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as ButtonStories from './Button.stories';
 
@@ -13,18 +12,12 @@ import * as ButtonStories from './Button.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Button"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Button" story="Default">Storybook</LinkTo>.
-
 ## Props
 
 <Canvas of={ButtonStories.Default} sourceState="shown" />
 <Controls of={ButtonStories.Default} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `ButtonHTMLAttributes<HTMLButtonElement>`-interface i `htmlProps`. `type`, `onClick`, `onFocus` og `onBlur` er tilgjengelige på rotnivå.
+Native HTML-attributter `type`, `onClick`, `onFocus` og `onBlur` er tilgjengelige på rotnivå.
 
 ## Retningslinjer
 

--- a/packages/components/src/components/Card/Card.mdx
+++ b/packages/components/src/components/Card/Card.mdx
@@ -1,10 +1,6 @@
-import { ArgTypes, Canvas, Controls, Meta, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
-import { CardAccordion, CardAccordionBody } from '.';
-import {
-  Source,
-  ComponentLinkRow,
-} from '@norges-domstoler/storybook-components';
+import { ArgTypes, Canvas, Controls, Meta } from '@storybook/blocks';
+import { CardAccordion, CardAccordionBody, CardAccordionHeader } from '.';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as CardStories from './Card.stories';
 
 <Meta of={CardStories} />
@@ -16,12 +12,6 @@ import * as CardStories from './Card.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/?node-id=3421%3A94375"
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Card"
 />
-
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Card" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -35,27 +25,6 @@ Det finnes følgene typer `<Card />`:
 - **selectable _(kommer)_**: en `<Card />` som kan bli valgt vha. en radioknapp eller checkbox.
   `<Card />` får typen via cardType-prop (se [Card API](#card)). Ved expandable skal i tillegg brukes `<CardAccordion />`-subkomponenter.
 
-## Bruk i koden
-
-<Source
-  code={`
-  import {
-  Card,
-  CardAccordion,
-  CardAccordionBody,
-  CardAccordionHeader
-  } from '@norges-domstoler/dds-components';
-
-<Card cardType="info">Content</Card>
-
-<Card cardType="expandable">
-  <CardAccordion>
-    <CardAccordionHeader>Title</CardAccordionHeader>
-    <CardAccordionBody>Body</CardAccordionBody>
-  </CardAccordion>
-</Card>
-`} />
-
 ## Props
 
 ### <a id="card" /> Card
@@ -65,13 +34,17 @@ Wrapper for innhold i et kort. Bruk design-tokens for spacing og annet styling d
 <Canvas of={CardStories.Default} sourceState="shown" />
 <Controls of={CardStories.Default} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>` eller `AnchorHTMLAttributes<HTMLAnchorElement>`-interface i `htmlProps`.
-
 ### CardAccordion
 
-En container for CardAccordion-subkomponenter som håndterer utviding, sammentrukking og ARIA-attributter av subkomponentene. Den skal ha `<Card cardType='expandable' />` som forelder og `<CardAccordionHeader />` som første barn og `<CardAccordionBody />` som andre barn.
+En container for CardAccordion-subkomponenter som håndterer oppførsel og universell utforming for subkomponentene. Den skal ha:
 
-En gruppe med expandable `<Card cardType='expandable' />` skal legges i en `<div>` container.
+- `<Card cardType='expandable' />` som forelder,
+- `<CardAccordionHeader />` som første barn,
+- `<CardAccordionBody />` som andre barn.
+
+En gruppe med `<Card cardType='expandable' />` skal legges i en `<div>` container.
+
+<Canvas of={CardStories.Accordion} sourceState="shown" />
 
 <ArgTypes of={CardAccordion} />
 
@@ -79,12 +52,10 @@ En gruppe med expandable `<Card cardType='expandable' />` skal legges i en `<div
 
 Header i `<CardAccordion />`. Skal brukes som første barn og den får automatisk riktig id fra `<CardAccordion />`. Komponenten har default typografi som kan bli overskrevet ved å bruke `<Typography />` som barneelement.
 
-Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
+<ArgTypes of={CardAccordionHeader} />
 
 ### CardAccordionBody
 
 Body i `<CardAccordion />`. Skal brukes som andre barn og den får automatisk riktig `id` fra `<CardAccordion />`. Komponenten har default typografi som kan bli overskrevet ved å bruke `<Typography />` som barneelement(er).
 
 <ArgTypes of={CardAccordionBody} />
-
-Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/Card/Card.stories.tsx
+++ b/packages/components/src/components/Card/Card.stories.tsx
@@ -143,6 +143,23 @@ export const Default: Story = {
 
 export const Accordion: Story = {
   decorators: Story => (
+    <StoryTemplate title="Card - accordion">
+      <Story />
+    </StoryTemplate>
+  ),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  render: (args: any) => (
+    <Card {...args} cardType="expandable">
+      <CardAccordion>
+        <CardAccordionHeader>Header</CardAccordionHeader>
+        <CardAccordionBody>Content</CardAccordionBody>
+      </CardAccordion>
+    </Card>
+  ),
+};
+
+export const Accordions: Story = {
+  decorators: Story => (
     <StoryTemplate title="Card - accordion" gap="0">
       <Story />
     </StoryTemplate>

--- a/packages/components/src/components/Chip/Chip.mdx
+++ b/packages/components/src/components/Chip/Chip.mdx
@@ -1,5 +1,4 @@
 import { Canvas, Controls, Meta } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as ChipStories from './Chip.stories';
 import * as ChipGroupStories from './ChipGroup.stories';
@@ -13,14 +12,6 @@ import * as ChipGroupStories from './ChipGroup.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/?node-id=7788%3A148018"
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Chip"
 />
-
-## Demo
-
-<Canvas of={ChipStories.Default} />
-
-<Canvas of={ChipGroupStories.Default} />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Chip/Chip" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -36,14 +27,11 @@ Komponenten består av to subkomponenter:
 <Canvas of={ChipStories.Default} />
 <Controls of={ChipStories.Default} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
-
 ### ChipGroup
 
 <Canvas of={ChipGroupStories.Default} />
-<Controls of={ChipGroupStories.Default} />
 
-Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLUListElement>`-interface i `htmlProps`.
+Det støttes alle native HTML-attributter for `<ul>`.
 
 ## Retningslinjer
 

--- a/packages/components/src/components/DescriptionList/DescriptionList.mdx
+++ b/packages/components/src/components/DescriptionList/DescriptionList.mdx
@@ -1,5 +1,4 @@
-import { Meta, ArgTypes, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Meta, ArgTypes, Canvas, Controls } from '@storybook/blocks';
 import { DescriptionListDesc, DescriptionListGroup } from '.';
 import {
   Source,
@@ -17,33 +16,14 @@ import * as DescriptionListStories from './DescriptionList.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/DescriptionList"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/DescriptionList" story="Default">Storybook</LinkTo>.
-
 ## Oversikt
 
-Beskrivelseslister bygges med styled versjoner av native HTML elementer og et wrapper-subkomponent ved behov. Disse styled komponentene er `<DescriptionList />` og dens subkomponenter: `<DescriptionListTerm />`, `<DescriptionListDesc />` og `<DescriptionListGroup />`.
+Beskrivelseslister bygges med følgende subkomponenter:
 
-## Bruk i koden
-
-<Source
-  code={`
-  import {
-  DescriptionList,
-  DescriptionListDesc,
-  DescriptionListTerm
-  } from '@norges-domstoler/dds-components';
-
-<DescriptionList>
-  <DescriptionListTerm>Uttrykk</DescriptionListTerm>
-  <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-  <DescriptionListTerm>Uttrykk</DescriptionListTerm>
-  <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-</DescriptionList>
-`} />
+- **`<DescriptionList />`**: tilsvarer `<dl>`, hele listen.
+- **`<DescriptionListTerm />`**: tilsvarer `<dt>`, uttrykk eller ledetekst.
+- **`<DescriptionListDesc />`**: tilsvarer `<dd>`, verdi eller beskrivelse.
+- **`<DescriptionListGroup />`**: wrapper til bruk for gruppering eller spesifikk layout.
 
 ## API
 
@@ -51,23 +31,18 @@ Beskrivelseslister bygges med styled versjoner av native HTML elementer og et wr
 
 Tilsvarer `<dl>`.
 
-<ArgTypes of={DescriptionListStories} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDListElement>`-interface i `htmlProps`.
+<Canvas of={DescriptionListStories.Default} sourceState="shown" />
+<Controls of={DescriptionListStories.Default} />
 
 ### DescriptionListTerm
 
 Tilsvarer `<dt>`.
-
-Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLElement>`-interface i `htmlProps`.
 
 ### DescriptionListDesc
 
 Tilsvarer `<dd>`.
 
 <ArgTypes of={DescriptionListDesc} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLElement>`-interface i `htmlProps`.
 
 ### DescriptionListGroup
 
@@ -77,26 +52,9 @@ til andre formål.
 
 <ArgTypes of={DescriptionListGroup} />
 
-Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
-
 #### Eksempler
 
 Hvis beskrivelseslisten skal legge seg over flere kolonner
 på en spesifikk måte kan man sette `direction="row"` på DescriptionList-elementet.
 
-<Source
-  code={`
-  <DescriptionList direction="row">
-  <DescriptionListGroup>
-   <DescriptionListTerm>Uttrykk</DescriptionListTerm>
-   <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-   <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-  </DescriptionListGroup>
-  <DescriptionListGroup>
-   <DescriptionListTerm>Uttrykk</DescriptionListTerm>
-   <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-  </DescriptionListGroup>
-  {/* ...flere grupper */}
-  </DescriptionList>
-  `}
-/>
+<Canvas of={DescriptionListStories.RowDirectionExample} sourceState="shown" />

--- a/packages/components/src/components/Divider/Divider.mdx
+++ b/packages/components/src/components/Divider/Divider.mdx
@@ -1,9 +1,5 @@
-import { Canvas, Controls, Meta, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
-import {
-  Source,
-  ComponentLinkRow,
-} from '@norges-domstoler/storybook-components';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as DividerStories from './Divider.stories';
 
 <Meta of={DividerStories} />
@@ -16,24 +12,7 @@ import * as DividerStories from './Divider.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Divider"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Divider" story="Default">Storybook</LinkTo>.
-
-## Bruk i koden
-
-<Source
-  code={`
-  import { Divider } from '@norges-domstoler/dds-components';
-
-<Divider />
-`} />
-
-## API
+## Props
 
 <Canvas of={DividerStories.Default} sourceState="shown" />
 <Controls of={DividerStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLHRElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/Drawer/Drawer.mdx
+++ b/packages/components/src/components/Drawer/Drawer.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Controls, Primary, Meta, ArgTypes } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta, ArgTypes } from '@storybook/blocks';
 import { DrawerGroup } from '.';
 import {
   Source,
@@ -17,29 +16,30 @@ import * as DrawerStories from './Drawer.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Drawer"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Drawer" story="Default">Storybook</LinkTo>.
-
 ## Oversikt
 
-`<Drawer />` er en komponent som vises når et trigger-element interageres med, vanligvis når en knapp trykkes. `<Drawer />` kan ha valgfritt innhold.
+Drawer bygges med følgende elementer:
 
-I tillegg kan det brukes `<DrawerGroup />`-subkomponenten som enkelt håndterer lukking og åpning og gir både `<Drawer />` og trigger-elementet ARIA-attributter. Den skal ha trigger-elementet som første barn og `<Drawer />` som andre barn. Subkomponenten er valgfri å bruke. Hvis den ikke brukes må oppførsel, referanser og ARIA-attributter håndteres utenfor komponentene på eget ansvar.
+- **Trigger-element**: styrer en drawer, er typisk en knapp.
+- **`<Drawer />`**: er en komponent som vises når et trigger-element interageres med, vanligvis en knapp. `<Drawer />` kan ha valgfritt innhold.
+- **`<DrawerGroup />`**: håndterer lukking og åpning og gir både `<Drawer />` og trigger-elementet ARIA-attributter. Den skal ha trigger-elementet som første barn og `<Drawer />` som andre barn. Subkomponenten er valgfri å bruke. Hvis den ikke brukes må oppførsel, referanser og ARIA-attributter håndteres utenfor komponentene på eget ansvar.
+
+## API
+
+### Drawer
+
+Hovedkomponenten `<Drawer/>`.
+
+<Canvas of={DrawerStories.LongContent} sourceState="shown" />
+<Controls of={DrawerStories.LongContent} />
+
+### DrawerGroup
+
+En wrapper som håndterer åpning, lukking, ARIA og refs for trigger-elementet og `<Drawer />` ut av boksen. Den skal ha trigger-elementet som første barn og `<Drawer />` som andre barn. Valgfri å bruke.
+
+<ArgTypes of={DrawerGroup} />
 
 ## Bruk i koden
-
-<Source
-  code={`
-  import { Drawer, DrawerGroup, Button } from '@norges-domstoler/dds-components';
-
-<DrawerGroup>
-  <Button>Åpne</Button>
-  <Drawer header="Tittel">Innhold</Drawer>
-</DrawerGroup>
-`} />
 
 ### Uten `<DrawerGroup />`
 
@@ -72,20 +72,3 @@ const id = 'id';
 >
   Innhold
 </Drawer>`} />
-
-## Props
-
-### Drawer
-
-Hovedkomponenten `<Drawer/>`.
-
-<Canvas of={DrawerStories.Default} sourceState="shown" />
-<Controls of={DrawerStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
-
-### DrawerGroup
-
-En wrapper som håndterer åpning, lukking, ARIA og refs for trigger-elementet og `<Drawer />` ut av boksen. Den skal ha trigger-elementet som første barn og `<Drawer />` som andre barn. Valgfri å bruke.
-
-<ArgTypes of={DrawerGroup} />

--- a/packages/components/src/components/FavStar/FavStar.mdx
+++ b/packages/components/src/components/FavStar/FavStar.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
 import {
   Source,
   ComponentLinkRow,
@@ -17,11 +16,14 @@ import * as FavStarStories from './FavStar.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/FavStar"
 />
 
-## Demo
+## Oversikt
 
-<Primary />
+En komponent for å legge noe til i favoritter; bruker `<input type="checkbox">`.
 
-Se stories med kontrollere i <LinkTo title="dds-components/FavStar" story="Default">Storybook</LinkTo>.
+## Props
+
+<Canvas of={FavStarStories.Default} sourceState="shown" />
+<Controls of={FavStarStories.Default} />
 
 ## Bruk i koden
 
@@ -34,8 +36,3 @@ const [checked, setChecked] = useState<boolean>(false);
 
 <FavStar checked={checked} onChange={setChecked} />
 `} />
-
-## Props
-
-<Canvas of={FavStarStories.Default} sourceState="shown" />
-<Controls of={FavStarStories.Default} />

--- a/packages/components/src/components/Feedback/Feedback.mdx
+++ b/packages/components/src/components/Feedback/Feedback.mdx
@@ -1,5 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Meta, Canvas, Controls } from '@storybook/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as FeedbackStories from './Feedback.stories';
 
@@ -13,17 +12,11 @@ import * as FeedbackStories from './Feedback.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Feedback"
 />
 
-## Teknisk implementasjon
-
-Denne feedback-komponenten kan brukes sammen med den [fellese tilbakemeldingsklienten](https://github.com/domstolene/tilbakemelding-loggplattform) som er [dokumentert her](https://domstol.atlassian.net/wiki/spaces/SIVIL1/pages/4267606065/Lagring+av+tilbakemeldinger+fra+brukere+i+loggplattform+Opensearch). Da vil tilbakemeldingene lagres som logger, og det kan lages dashboards for å presentere tilbakemeldingene på metrics.domstol.no (eksempel [her](https://metrics.domstol.no/d/p510Pyqnk/aktorportalen-selvprosederende-metrics?orgId=1&viewPanel=35), og [her](https://metrics.domstol.no/d/p510Pyqnk/aktorportalen-selvprosederende-metrics?orgId=1&viewPanel=34)) Dette har blitt gjort i for eksempel [Aktørportalen for Selvprosederende](https://github.com/domstolene/aktorportalen-selvprosederende).
-
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/" story="Default">Storybook</LinkTo>.
-
 ## Props
 
 <Canvas of={FeedbackStories.Default} sourceState="shown" />
 <Controls of={FeedbackStories.Default} />
+
+## Implementasjon hos domstolene
+
+Se [Lagring av tilbakemeldinger fra brukere i loggplattform](https://domstol.atlassian.net/wiki/spaces/SIVIL1/pages/4267606065/Lagring+av+tilbakemeldinger+fra+brukere+i+loggplattform+Opensearch).

--- a/packages/components/src/components/Feedback/Feedback.stories.tsx
+++ b/packages/components/src/components/Feedback/Feedback.stories.tsx
@@ -22,13 +22,13 @@ export default {
       control: 'text',
     },
     ratingValue: {
+      options: {
+        null: null,
+        positive: 'positive',
+        negative: 'negative',
+      },
       control: {
         type: 'radio',
-        options: {
-          null: null,
-          positive: 'positive',
-          negative: 'negative',
-        },
       },
     },
     positiveFeedbackLabel: {

--- a/packages/components/src/components/FileUploader/FileUploader.mdx
+++ b/packages/components/src/components/FileUploader/FileUploader.mdx
@@ -16,11 +16,10 @@ import * as FileUploaderStories from './FileUploader.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/FileUploader"
 />
 
-## Demo
+## Props
 
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/FileUploader" story="Default">Storybook</LinkTo>.
+<Canvas of={FileUploaderStories.Default} sourceState="shown" />
+<Controls of={FileUploaderStories.Default} />
 
 ## Bruk i koden
 
@@ -31,8 +30,3 @@ import { FileUploader } from '@norges-domstoler/dds-components';
 <FileUploader onChange={(newFiles) => ...} />
 `}
 />
-
-## Props
-
-<Canvas of={FileUploaderStories.Default} sourceState="shown" />
-<Controls of={FileUploaderStories.Default} />

--- a/packages/components/src/components/GlobalMessage/GlobalMessage.mdx
+++ b/packages/components/src/components/GlobalMessage/GlobalMessage.mdx
@@ -1,9 +1,5 @@
-import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
-import {
-  Source,
-  ComponentLinkRow,
-} from '@norges-domstoler/storybook-components';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as GlobalMessageStories from './GlobalMessage.stories';
 
 <Meta of={GlobalMessageStories} />
@@ -16,15 +12,7 @@ import * as GlobalMessageStories from './GlobalMessage.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/GlobalMessage"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/GlobalMessage" story="Default">Storybook</LinkTo>.
-
 ## Props
 
 <Canvas of={GlobalMessageStories.Default} sourceState="shown" />
 <Controls of={GlobalMessageStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/Grid/Grid.mdx
+++ b/packages/components/src/components/Grid/Grid.mdx
@@ -74,9 +74,6 @@ En container-komponent for `<GridChild>` barn. Den håndterer grid layout basert
 
 <ArgTypes of={GridStories} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface eller `HTMLAttributes<HTMLFormElement>`-interface i `htmlProps`.
-`style` støtte både på rotnivå og i `htmlProps`.
-
 ### GridChild
 
 En wrapper-component som håndterer hvor mange kolonner innhold skal ta, i tillegg til eventuelle andre CSS grid spesifikasjoner og styling.
@@ -112,5 +109,3 @@ type ColumnsOccupied = RelativeColumnsOccupied | GridColumnPerScreenSize;
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
 `style` støtte både på rotnivå og i `htmlProps`.
-
-#### Types

--- a/packages/components/src/components/Icon/Icon.mdx
+++ b/packages/components/src/components/Icon/Icon.mdx
@@ -1,4 +1,4 @@
-import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
 import LinkTo from '@storybook/addon-links/react';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import { Link } from '../Typography';
@@ -13,21 +13,11 @@ import * as IconStories from './Icon.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Icon"
 />
 
-## Introduksjon
+## Oversikt
 
-`<Icon />` er en code-only komponent som tar inn ikonnavn og returnerer tilsvarende svg-ikon fra <Link href="https://domstolene.github.io/designsystem/?path=/story/icons-overview--overview">ikonutvalget</Link>. Den brukes for å gi riktig størrelse til ikonet og eventuelt enkelt sette en farge og annen styling. Les mer om hvilke ikoner vi bruker og retningslinjer under <Link href="https://design.domstol.no/987b33f71/p/4046f8-ikoner/b/60d80f">Ikoner</Link>.
-
-## Demo
-
-<Primary />
-
-<Canvas of={IconStories.Overview} />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Icon" story="Default">Storybook</LinkTo>.
+`<Icon />` er en code-only komponent som tar inn et svg-ikon fra <LinkTo title="Icons/Overview" story="Overview">ikonutvalget</LinkTo> og returnerer den med riktig størrelse og annen styling. Les mer om hvilke ikoner vi bruker og retningslinjer under <Link href="https://design.domstol.no/987b33f71/p/4046f8-ikoner/b/60d80f" external>Ikoner</Link>.
 
 ## Props
 
 <Canvas of={IconStories.Default} sourceState="shown" />
 <Controls of={IconStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLSVGElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/InlineEdit/InlineEdit.mdx
+++ b/packages/components/src/components/InlineEdit/InlineEdit.mdx
@@ -1,9 +1,5 @@
-import { Primary, Meta, Canvas, Controls } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
-import {
-  Source,
-  ComponentLinkRow,
-} from '@norges-domstoler/storybook-components';
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as InlineEditStories from './InlineEdit.stories';
 import * as InlineEditInputStories from './InlineEditInput.stories';
 import * as InlineEditTextAreaStories from './InlineEditTextArea.stories';
@@ -18,31 +14,12 @@ import * as InlineEditTextAreaStories from './InlineEditTextArea.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/DDS-Komponenter?node-id=9005%3A150044"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/InlineEdit" story="OverviewInputTypes">Storybook</LinkTo>.
-
 ## Oversikt
 
 `<InlineEdit>`-komponentene håndterer inline redigering, f.eks i tabeller. Vi har følgende komponenter:
 
 - `<InlineEditInput />` - returnerer `<input>`.
 - `<InlineEditTextArea />` - returnerer `<textarea>`.
-
-## Bruk i koden
-
-<Source
-  code={`import { InlineEditInput, InlineEditTextArea } fra '@norges-domstoler/dds-components';
-
-const [value, setValue] = useState('');
-
-<InlineEditInput value={value} onSetValue={setValue} />
-<InlineEditTextArea value={value} onSetValue={setValue} />
-
-`}
-/>
 
 ## Props
 
@@ -53,13 +30,9 @@ Inputfeltet. Returnerer `<textarea>`.
 <Canvas of={InlineEditTextAreaStories.Default} sourceState="shown" />
 <Controls of={InlineEditTextAreaStories.Default} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `TextareaHTMLAttributes<HTMLTextAreaElement>`-interface.
-
 ### InlineEditInput
 
 Inputfeltet. Returnerer `<input>`.
 
 <Canvas of={InlineEditInputStories.Default} sourceState="shown" />
 <Controls of={InlineEditInputStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLInputElement>`-interface.

--- a/packages/components/src/components/InlineEdit/InlineEditInput.stories.tsx
+++ b/packages/components/src/components/InlineEdit/InlineEditInput.stories.tsx
@@ -13,19 +13,11 @@ export default {
     error: { control: { type: 'boolean' } },
     errorMessage: { control: { type: 'text' } },
     width: { control: { type: 'text' } },
+    hideIcon: { control: { type: 'boolean' } },
   },
   parameters: {
     controls: {
-      exclude: [
-        'style',
-        'className',
-        'onFocus',
-        'onBlur',
-        'onChange',
-        'onSetValue',
-        'inputRef',
-        'children',
-      ],
+      exclude: ['inputRef'],
     },
   },
 };

--- a/packages/components/src/components/InlineEdit/InlineEditTextArea.stories.tsx
+++ b/packages/components/src/components/InlineEdit/InlineEditTextArea.stories.tsx
@@ -13,19 +13,11 @@ export default {
     error: { control: { type: 'boolean' } },
     errorMessage: { control: { type: 'text' } },
     width: { control: { type: 'text' } },
+    hideIcon: { control: { type: 'boolean' } },
   },
   parameters: {
     controls: {
-      exclude: [
-        'style',
-        'className',
-        'onFocus',
-        'onBlur',
-        'onChange',
-        'onSetValue',
-        'inputRef',
-        'children',
-      ],
+      exclude: ['inputRef'],
     },
   },
 };

--- a/packages/components/src/components/InputMessage/InputMessage.mdx
+++ b/packages/components/src/components/InputMessage/InputMessage.mdx
@@ -1,9 +1,5 @@
-import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
-import {
-  Source,
-  ComponentLinkRow,
-} from '@norges-domstoler/storybook-components';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as InputMessageStories from './InputMessage.stories';
 
 <Meta of={InputMessageStories} />
@@ -16,12 +12,6 @@ import * as InputMessageStories from './InputMessage.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/?node-id=155%3A38"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/" story="Default">Storybook</LinkTo>.
-
 ## Oversikt
 
 `<InputMessage />` brukes til å vise hjelpetekst eller feilmelding som tilhører et custom inputelement (radio, checkbox, inputfelt...).
@@ -32,5 +22,3 @@ Se stories med kontrollere i <LinkTo title="dds-components/" story="Default">Sto
 
 <Canvas of={InputMessageStories.Default} sourceState="shown" />
 <Controls of={InputMessageStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/InternalHeader/InternalHeader.mdx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Controls, Meta, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta, Primary, Story } from '@storybook/blocks';
 import {
   Source,
   ComponentLinkRow,
@@ -15,19 +14,6 @@ import * as InternalHeaderStories from './InternalHeader.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/?node-id=3431%3A94756"
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/InternalHeader"
 />
-
-## Demo
-
-<Primary />
-
-<Canvas of={InternalHeaderStories.WithNavigationAndContextMenu} />
-
-<Canvas
-  of={InternalHeaderStories.SmallScreenWithNavigationAndContextMenu}
-  height="650px"
-/>
-
-Se stories med kontrollere i <LinkTo title="dds-components/InternalHeader" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -68,8 +54,6 @@ name: 'Name'
 <Canvas of={InternalHeaderStories.Default} sourceState="shown" />
 <Controls of={InternalHeaderStories.Default} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
-
 ### Types
 
 <Source
@@ -105,6 +89,24 @@ I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes
 
 `}
 />
+
+## Varianter
+
+<Primary />
+
+<Canvas>
+  <Story
+    of={InternalHeaderStories.WithNavigationAndContextMenu}
+    height="500px"
+  />
+</Canvas>
+
+<Canvas>
+  <Story
+    of={InternalHeaderStories.SmallScreenWithNavigationAndContextMenu}
+    height="650px"
+  />
+</Canvas>
 
 ## Retningslinjer
 

--- a/packages/components/src/components/List/List.mdx
+++ b/packages/components/src/components/List/List.mdx
@@ -1,9 +1,5 @@
-import { Meta, ArgTypes, Canvas, Controls, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
-import {
-  Source,
-  ComponentLinkRow,
-} from '@norges-domstoler/storybook-components';
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as ListStories from './List.stories';
 
 <Meta of={ListStories} />
@@ -15,12 +11,6 @@ import * as ListStories from './List.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/?node-id=3332%3A94240"
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/List"
 />
-
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/List" story="Default">Storybook</LinkTo>.
 
 ## Oversikt
 
@@ -38,10 +28,6 @@ Tilsvarer `<ul>` eller `<ol>`.
 <Canvas of={ListStories.Default} sourceState="shown" />
 <Controls of={ListStories.Default} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLOListElement>` og `HTMLAttributes<HTMLUListElement>`-interface i `htmlProps`.
-
 ### ListItem
 
 Tilsvarer `<li>`.
-
-Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLLiElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/LocalMessage/LocalMessage.mdx
+++ b/packages/components/src/components/LocalMessage/LocalMessage.mdx
@@ -1,5 +1,4 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Meta, Canvas, Controls } from '@storybook/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as LocalMessageStories from './LocalMessage.stories';
 
@@ -13,15 +12,7 @@ import * as LocalMessageStories from './LocalMessage.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/LocalMessage"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/LocalMessage" story="Default">Storybook</LinkTo>.
-
 ## Props
 
 <Canvas of={LocalMessageStories.Default} sourceState="shown" />
 <Controls of={LocalMessageStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`. `children` kan brukes istedenfor `message`.

--- a/packages/components/src/components/Modal/Modal.mdx
+++ b/packages/components/src/components/Modal/Modal.mdx
@@ -1,11 +1,8 @@
-import { Meta, Canvas, Controls, Primary, ArgTypes } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Meta, Canvas, Controls, ArgTypes } from '@storybook/blocks';
 import { ModalBody } from '.';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as ModalStories from './Modal.stories';
 
@@ -19,12 +16,6 @@ import * as ModalStories from './Modal.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Modal"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Modal" story="Default">Storybook</LinkTo>.
-
 ## Oversikt
 
 En modal kan ha valgfritt innhold, men for å simplifisere implementasjonen av vanlige mønstre har vi predefinert visuell formatering av typiske elementer i en modal:
@@ -37,11 +28,30 @@ Ved bruk av disse elementene vil innholdet i `<Modal />` få spacing utav boksen
 
 Siden modal er en komponent som låser sideinnholdet idet den dukker opp er det viktig å sørge for at det er mulig å lukke modalen, enten ved å gjøre den generelt lukkbar (se API) og/eller ved interaksjon med handlingselementene.
 
+## Props
+
+### Modal
+
+Hovedkomponenten for modal. Kan ha `<ModalBody />`, `<ModalActions />` og ellers fritt valgt innhold som barn. Legger vertikal spacing mellom barn.
+
+<Canvas of={ModalStories.Default} sourceState="shown" />
+<Controls of={ModalStories.Default} />
+
+### ModalBody
+
+Subkomponent for hovedinnhold i modal (tekstlig informasjon o.l.). Brukes som barn i `<Modal />`.
+
+<ArgTypes of={ModalBody} />
+
+### ModalActions
+
+Subkomponent for handlingselementer, typisk knapper. Brukes som barn i `<Modal />`. Legger horisontal spacing mellom barn og legger de over flere rader ved behov.
+
 ## Bruk i koden
 
 <Source
   code={`import { Modal, ModalBody, ModalActions, Button } from '@norges-domstoler/dds-components';
-  import { useState } from 'react';
+import { useState } from 'react';
 
 const [open, setOpen] = useState(false);
 const show = () => setOpen(true);
@@ -103,28 +113,3 @@ const buttonRef = useRef(null);
   <Button onClick={close}>OK</Button>
 </Modal>
 `} />
-
-## Props
-
-### Modal
-
-Hovedkomponenten for modal. Kan ha `<ModalBody />`, `<ModalActions />` og ellers fritt valgt innhold som barn. Legger vertikal spacing mellom barn.
-
-<Canvas of={ModalStories.Default} sourceState="shown" />
-<Controls of={ModalStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
-
-### ModalBody
-
-Subkomponent for hovedinnhold i modal (tekstlig informasjon o.l.). Brukes som barn i `<Modal />`.
-
-<ArgTypes of={ModalBody} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
-
-### ModalActions
-
-Subkomponent for handlingselementer, typisk knapper. Brukes som barn i `<Modal />`. Legger horisontal spacing mellom barn og legger de over flere rader ved behov.
-
-Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/OverflowMenu/OverflowMenu.mdx
+++ b/packages/components/src/components/OverflowMenu/OverflowMenu.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Controls, Primary, Meta, ArgTypes } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta, ArgTypes, Story } from '@storybook/blocks';
 import { OverflowMenuGroup } from '.';
 import {
   Source,
@@ -17,19 +16,13 @@ import * as OverflowMenuStories from './OverflowMenu.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/OverflowMenu"
 />
 
-## Demo
-
-<Primary height="600px" />
-
-<Canvas of={OverflowMenuStories.WithInteractiveUser} height="450px" />
-
-Se stories med kontrollere i <LinkTo title="dds-components/OverflowMenu" story="Default">Storybook</LinkTo>.
-
 ## Oversikt
 
-`<OverflowMenu />` er en komponent som viser og skjuler en liste med handlinger og/eller lenker når brukeren trykker på en knapp. `<OverflowMenu />` plasseres i forhold til knappen, som kalles anchor-element. **OBS!** Anchor-elementet er ikke en del av komponenten, men den knyttes til `<OverflowMenu />` via props (se API).
+OverflowMenu er en komponent som viser og skjuler en meny med handlinger og/eller lenker når brukeren trykker på en knapp - anchor-elementet. Den består av tre elementer:
 
-For at typisk logikk ved åpning, lukking, refs og ARIA-attributter skal håndteres ut av boksen bruk `<OverflowMenuGroup />`-subkomponent. Den er ikke obligatorisk å bruke, men oppførsel og UU må da håndteres på eget ansvar.
+- **`<OverflowMenu />`** - selve menyen.
+- **Anchor-element** - valgfritt element som åpner menyen. `<OverflowMenu />` posisjoneres i forhold til anchor-elementet.
+- **`<OverflowMenuGroup />`** - wrapper som håndterer åpning, lukking, refs og universell utforming. Den skal ha `<OverflowMenu />` og anchor-element som barn. Ikke obligatorisk å bruke, men overnevnt må isåfall håndteres på eget ansvar.
 
 ## Bruk i koden
 
@@ -86,7 +79,9 @@ const items = [
 
 Hovedkomponenten `<OverflowMenu/>`.
 
-<Canvas of={OverflowMenuStories.Default} sourceState="shown" />
+<Canvas>
+  <Story of={OverflowMenuStories.Default} height="300px" />
+</Canvas>
 <Controls of={OverflowMenuStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/Pagination/Pagination.mdx
+++ b/packages/components/src/components/Pagination/Pagination.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
 import {
   Source,
   ComponentLinkRow,
@@ -15,12 +14,6 @@ import * as PaginationStories from './Pagination.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/?node-id=2576%3A78023"
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Pagination"
 />
-
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Pagination" story="Default">Storybook</LinkTo>.
 
 ## Props
 

--- a/packages/components/src/components/Popover/Popover.mdx
+++ b/packages/components/src/components/Popover/Popover.mdx
@@ -1,5 +1,4 @@
-import { Meta, ArgTypes, Canvas, Controls, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Meta, ArgTypes, Canvas, Controls, Story } from '@storybook/blocks';
 import {
   Source,
   ComponentLinkRow,
@@ -17,54 +16,24 @@ import * as PopoverStories from './Popover.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Popover"
 />
 
-## Demo
-
-<Primary height="350px" />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Popover" story="Default">Storybook</LinkTo>.
-
 ## Oversikt
 
 Komponenten består av tre elementer:
 
-- **`<PopoverGroup />`** - wrapper for to barn: et anchor-element som styrer popover og selve popover-elementet: `<Popover />`.
+- **`<Popover />`** - en komponent som dukker opp via museklikk på anchor-elementet.
 - **Anchor-element**, som er også et trigger-element. Et valgfritt interaktivt element, typisk en knapp, som åpner og lukker popover. Elementet får attributtene `onClick`, `ref`, `aria-haspopup` og `aria-controls` fra `<PopoverGroup />`.
-- **`<Popover />`** - en komponent som dukker opp via museklikk på anchor-elementet. Får enkelte props fra `<PopoverGroup />` som ikke kan overskrives.
-
-## Bruk i koden
-
-<Source
-  code={`import { Button, Popover, PopoverGroup } from '@norges-domstoler/dds-components';
-
-<PopoverGroup>
-  <Button>Åpne</Button>
-  <Popover title="Tittel">Dette er en popover</Popover>
-</PopoverGroup>
-`} />
+- **`<PopoverGroup />`** - wrapper for to barn: anchor-element `<Popover />`. Den håndterer oppførsel og universell utforming.
 
 ## Props
-
-### PopoverGroup
-
-Wrapper der anchor-elementet skal være første barnet og `<Popover />` skal være andre barnet. `<PopoverGroup />` har to funksjoner:
-
-- Håndtering av barnas oppførsel: åpning og lukking av popover, eventuelle ekstra callbacks.
-- Automatisk forplanting av enkelte props hos barna: referanse til anchor-elementet for å simplifisere bruken av komponenten, aria-attributter for å oppfylle brukervennlighetskrav osv.
-
-`<PopoverGroup />` returnerer kun barna uten en HTML-tag rundt dem.
-
-**OBS!** all kontroll av `<Popover />` som onClick events implementeres i `<PopoverGroup />`, ikke direkte i `<Popover />`.
-
-<ArgTypes of={PopoverGroup} />
 
 ### Popover
 
 Selve popover-elementet. Den åpnes når anchor-elementet trykkes, og den lukkes ved å trykke på anchor-elementet igjen, Esc-tast, lukkeknapptrykk og onBlur.
 
-<Canvas of={PopoverStories.Default} sourceState="shown" />
+<Canvas>
+  <Story of={PopoverStories.Default} height="350px" />
+</Canvas>
 <Controls of={PopoverStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`. **OBS!** `id` er ekskludert da den blir sendt som prop fra <PopoverGroup /> for å sørge for riktig oppførsel. `id` settes via `<PopoverGroup />` `popoverId`-prop.
 
 #### Types
 
@@ -85,7 +54,9 @@ I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes
 
 Det kan være relevant å begrense størrelsen på Popover slik at ikke hele teksten vises ved overflow. Da bør den synlige teksten avsluttes med en ellipse:
 
-<Canvas height="350px" of={PopoverStories.Overflow} />
+<Canvas>
+  <Story height="350px" of={PopoverStories.Overflow} />
+</Canvas>
 
 For å oppnå det kan du sette sizeProps til ønskede verdier og gi tekstelementet som
 er barnet i `<Popover />` følgende CSS:
@@ -94,10 +65,34 @@ er barnet i `<Popover />` følgende CSS:
   language="css"
   code={`
   text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
+overflow: hidden;
+white-space: nowrap;
   `}
 />
+
+### PopoverGroup
+
+Wrapper der anchor-elementet skal være første barnet og `<Popover />` skal være andre barnet. `<PopoverGroup />` har to funksjoner:
+
+- Håndtering av barnas oppførsel: åpning og lukking av popover, eventuelle ekstra callbacks.
+- Automatisk forplanting av enkelte props hos barna: referanse til anchor-elementet og aria-attributter for universell utofrming.
+
+`<PopoverGroup />` returnerer kun barna uten en HTML-tag rundt dem.
+
+**OBS!** all kontroll av `<Popover />` som onClick events implementeres i `<PopoverGroup />`, ikke direkte i `<Popover />`.
+
+<ArgTypes of={PopoverGroup} />
+
+## Bruk i koden
+
+<Source
+  code={`import { Button, Popover, PopoverGroup } from '@norges-domstoler/dds-components';
+
+<PopoverGroup>
+  <Button>Åpne</Button>
+  <Popover title="Tittel">Dette er en popover</Popover>
+</PopoverGroup>
+`} />
 
 ## Retningslinjer
 

--- a/packages/components/src/components/Popover/PopoverGroup.tsx
+++ b/packages/components/src/components/Popover/PopoverGroup.tsx
@@ -20,7 +20,7 @@ export interface PopoverGroupProps {
   isOpen?: boolean;
   /** `id` til `<Popover />.` */
   popoverId?: string;
-  /** Barna til wrapperen: anchor-element som det første og `<Popover />` so det adnre.  */
+  /** Barna til wrapperen: anchor-element som det første og `<Popover />` som det andre.  */
   children: ReactNode;
 }
 

--- a/packages/components/src/components/ProgressTracker/ProgressTracker.mdx
+++ b/packages/components/src/components/ProgressTracker/ProgressTracker.mdx
@@ -1,7 +1,5 @@
-import { ArgTypes, Meta, Canvas, Controls, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { ArgTypes, Meta, Canvas, Controls } from '@storybook/blocks';
 import * as ProgressTrackerStories from './ProgressTracker.stories';
-
 import { ProgressTracker } from '.';
 import {
   Source,
@@ -18,18 +16,29 @@ import {
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/ProgressTracker"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/ProgressTracker" story="Overview">Storybook</LinkTo>.
-
 ## Oversikt
 
 Komponenten består av:
 
 - `<ProgressTracker />` - ytterste container for andre subkomponenter. Håndterer oppførsel og eventuelt litt styling. Har to eller flere `<ProgressTracker.Item />` som barn.
 - `<ProgressTracker.Item />` - et steg.
+
+## API
+
+### ProgressTracker
+
+Ytterste container som styrer hvilket steg skal vises via indeks. Har to eller flere `<ProgressTracker.Item />` som barn.
+
+<Canvas of={ProgressTrackerStories.Overview} sourceState="shown" />
+<Controls of={ProgressTrackerStories.Overview} />
+
+I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
+
+### ProgressTracker.Item
+
+Et steg.
+
+<ArgTypes of={ProgressTracker.Item} />
 
 ## Bruk i koden
 
@@ -52,22 +61,3 @@ console.log(index)
   </ProgressTracker.Item>
 </ProgressTracker>
 `} />
-
-## API
-
-### ProgressTracker
-
-Ytterste container som styrer hvilket steg skal vises via indeks. Har to eller flere `<ProgressTracker.Item />` som barn.
-
-<Canvas of={ProgressTrackerStories.Overview} sourceState="shown" />
-<Controls of={ProgressTrackerStories.Overview} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
-
-### ProgressTracker.Item
-
-Et steg.
-
-<ArgTypes of={ProgressTracker.Item} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `ButtonHTMLAttributes<HTMLButtonElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/ScrollableContainer/ScrollableContainer.mdx
+++ b/packages/components/src/components/ScrollableContainer/ScrollableContainer.mdx
@@ -1,5 +1,4 @@
-import { Meta, ArgTypes, Primary, Canvas, Controls } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Meta, ArgTypes, Canvas, Controls } from '@storybook/blocks';
 import { Scrollbar } from '.';
 import {
   Source,
@@ -17,18 +16,27 @@ import * as ScrollableContainerStories from './ScrollableContainer.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/ScrollableContainer"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/ScrollableContainer" story="Default">Storybook</LinkTo>.
-
 ## Oversikt
 
 To subkomponenter er tilgjengelige:
 
-- `ScrollableContainer` - hovedkomponenten; en wrapper for innhold som skal scrolles. Håndterer scrolling og fokus ut av boksen.
-- `Scrollbar` - selve scrollbaren som brukes i `ScrollableContainer`. Håndterer scrolling når knyttet til elementet som skal scrolles. Kan brukes alene og håndtere plassering av scrollbaren og styling av innholdselementet selv.
+- **`<ScrollableContainer />`** - hovedkomponenten; en wrapper for innhold som skal scrolles. Håndterer scrolling og fokus ut av boksen.
+- **`<Scrollbar />`** - selve scrollbaren som brukes i `ScrollableContainer`. Håndterer scrolling når knyttet til elementet som skal scrolles. Kan brukes alene og håndtere plassering av scrollbaren og styling av innholdselementet selv.
+
+## Props
+
+### ScrollableContainer
+
+Hovedkomponenten for scrollbar innhold.
+
+<Canvas of={ScrollableContainerStories.Default} sourceState="shown" />
+<Controls of={ScrollableContainerStories.Default} />
+
+### Scrollbar
+
+Alenestående scrollbar til mer custom bruk.
+
+<ArgTypes of={Scrollbar} />
 
 ## Bruk i koden
 
@@ -45,14 +53,14 @@ To subkomponenter er tilgjengelige:
 `}
 />
 
-### Kun med `<Scrollbar>`
+### Kun med `<Scrollbar />`
 
-Ved bruk av kun `<Scrollbar/>` må man håndtere styling av containere, kobling til innholdet, plasseringen av `<Scrollbar/>` og fokus.
+Ved bruk av kun `<Scrollbar />` må man håndtere styling av containere, kobling til innholdet, plasseringen av `<Scrollbar/>` og fokus.
 
 <Source
   code={`import { Scrollbar, focusVisible } from '@norges-domstoler/dds-components';
-  import { useRef } from 'React';
-  import styled fromf 'styled-components';
+import { useRef } from 'React';
+import styled fromf 'styled-components';
 
 const containerStyle = {
 display: 'grid',
@@ -82,18 +90,3 @@ const contentRef = useRef();
   <Scrollbar />
 </div>
 `} />
-
-## Props
-
-## ScrollableContainer
-
-Hovedkomponenten for scrollbar innhold.
-
-<Canvas of={ScrollableContainerStories.Default} sourceState="shown" />
-<Controls of={ScrollableContainerStories.Default} />
-
-## Scrollbar
-
-Alenestående scrollbar til mer custom bruk.
-
-<ArgTypes of={Scrollbar} />

--- a/packages/components/src/components/Search/Search.mdx
+++ b/packages/components/src/components/Search/Search.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Controls, Primary, Meta, ArgTypes } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta, ArgTypes, Story } from '@storybook/blocks';
 import { Search } from '.';
 import {
   Source,
@@ -17,74 +16,23 @@ import * as SearchStories from './Search.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Search"
 />
 
-## Demo
-
-<Primary />
-
-<Canvas of={SearchStories.WithButton} />
-
-<Canvas of={SearchStories.WithSuggestions} height="470px" />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Search" story="Default">Storybook</LinkTo>.
-
 ## Oversikt
 
-`<Search>` er en komponent som tilsvarer `<input type="search">` og kan vise en søkeknapp hvis ønsket.
-I tillegg finnes det følgende subkomponenter:
+Følgende komponenter er tilgjengelige:
 
-- **`<Search.AutocompleteWrapper>`** - wrapper for `<Search>` som håndterer autocomplete-funksjonalitet hvis er ønsket.
+- **`<Search>`** - søkelfelt; tilsvarer `<input type="search">` og kan vise en søkeknapp hvis ønsket.
+- **`<Search.AutocompleteWrapper>`** - wrapper for `<Search>` som håndterer autofullføringsforslag hvis ønsket.
   Den rendrer en liste med forslag under søkefeltet basert på brukerens input.
   Støtter en rekke custom props.
 - **`<Search.Suggestions>`** - selve listen med forslag.
-  Brukes i `<Search.AutocompleteWrapper>`, men kan brukes uten wrapper hvis konsumenten skal håndtere oppførselen selv.
-
-## Bruk i koden
-
-<Source
-  code={`import { Search } from '@norges-domstoler/dds-components';
-
-const handleSearch = () => {
-
-$$
-// code
-}
-
-const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
-$if( e.key == 'Enter' ){
-  $$handleSearch();
-$}
-};
-
-
-
-<Search onKeyPress={handleKeyPress} />
-
-
-
-<Search
-  onKeyPress={handleKeyPress}
-  buttonProps={{ onClick: () => handleSearch() }}
-/>
-
-
-
-<Search.AutocompleteWrapper>
-  <Search onKeyPress={handleKeyPress} />
-</Search.AutocompleteWrapper>
-
-`}
-/>
+  Brukes under panseret i `<Search.AutocompleteWrapper>`, men kan brukes uten wrapper hvis konsumenten skal håndtere oppførselen selv.
 
 ## Props
 
 ### Search
 
-Søkefeltet.
-
 <Canvas of={SearchStories.Default} sourceState="shown" />
 <Controls of={SearchStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLInputElement>`-interface.
 
 #### Types
 
@@ -98,8 +46,11 @@ I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttri
 
 ### Search.AutocompleteWrapper
 
-En wrapper som håndterer autocomplete-funksjonalitet.
+En wrapper som håndterer autofullføring. Skal ha `<Search>` som barn.
 
+<Canvas>
+  <Story of={SearchStories.WithSuggestions} height="470px" />
+</Canvas>
 <ArgTypes of={Search.AutocompleteWrapper} />
 
 #### Types
@@ -111,22 +62,57 @@ En wrapper som håndterer autocomplete-funksjonalitet.
    text: string;
    relevance: number;
   };
-  sortFunction?: (a: WeightedValue, b: WeightedValue) => number;
+    sortFunction?: (a: WeightedValue, b: WeightedValue) => number;
   };
 
 type SearchData = {
-$$array: string[];
-$$sortFunction?: (a: string, b: string) => number;
-};`}
+array: string[];
+sortFunction?: (a: string, b: string) => number;
+};
+`}
 />
 
 ### Search.Suggestions
 
-Liste med forslag. Håndterer tastaturfokus internt.
+Liste med forslag. Brukes ved custom autofullføring uten `<Search.AutocompleteWrapper>`. Håndterer tastaturfokus internt.
 
 <ArgTypes of={Search.Suggestions} />
+
+## Bruk i koden
+
+<Source
+  code={`import { Search } from '@norges-domstoler/dds-components';
+
+const handleSearch = () => {
+// kode
+}
+
+const handleKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+if( e.key == 'Enter' ){
+handleSearch();
+}
+};
+
+// Vanlig
+
+<Search onKeyPress={handleKeyPress} />
+
+// Med knapp
+
+<Search
+  onKeyPress={handleKeyPress}
+  buttonProps={{ onClick: () => handleSearch() }}
+/>
+
+// Med autofullfør
+
+<Search.AutocompleteWrapper>
+  <Search onKeyPress={handleKeyPress} />
+</Search.AutocompleteWrapper>
+
+`}
+/>
 
 ## Retningslinjer
 
 - Mens resultater lastes inn bør det indikeres til brukeren. Hvis det brukes en søkeknapp gjøres det via `loading` i `buttonProps`. Hvis søkeknappen ikke brukes bør det gjøres med `<Spinner />` i resultatlista.
-$$

--- a/packages/components/src/components/Select/Select.mdx
+++ b/packages/components/src/components/Select/Select.mdx
@@ -1,9 +1,8 @@
-import { Story, Canvas, Meta } from '@storybook/blocks';
+import { Story, Canvas, Meta, Controls } from '@storybook/blocks';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
+
 } from '@norges-domstoler/storybook-components';
 import { Link } from '../Typography';
 import { Table } from '../Table';
@@ -21,148 +20,25 @@ import * as MultiSelectStories from './MultiSelect.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Select"
 />
 
-## Demo
+## Oversikt
 
-<Canvas>
-  <Story of={SelectStories.Default} height="450px" />
-</Canvas>
+Komponenten har tre varianter:
 
-<Canvas>
-  <Story of={MultiSelectStories.Default} height="450px" />
-</Canvas>
-
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-select-singlevalue`}
-/>
-
-## Bruk i koden
-
-<Source
-  code={`import { Select } from '@norges-domstoler/dds-components';
-
-const items = [
-{value: 'alternativ 1', label: 'alternativ 1'},
-{value: 'alternativ 2', label: 'alternativ 2'}
-];
-
-//Single value
-
-<Select label="Label" items={items} />
-
-//Multiselect
-
-<Select label="Label" items={items} isMulti />
-`} />
-
-## Filtrering
-
-Brukeren kan filtrere alternativer ved å gi tekstlig input. Det brukes en custom filtreringsfunksjon der søkeordet er enten først i teksten, eller så har det mellomrom, bindestrek eller start-parentes før seg.
+- `<Select />` - nedtrekksliste
+- `<Select isMulti />` - nedtrekksliste med multivalg
+- custom `<Select />` - nedtrekksliste med custom visuelle elementer for både det valgte elemetet og alternativer i lista
 
 ## API
 
 Komponenten bruker <Link href="https://react-select.com/home" external>React-select</Link>. Det støttes props definert i designsystemet (Elsa props) og native React-select props.
 
+<Canvas of={SelectStories.Default} sourceState="shown" />
+
 ### Elsa props
 
-<Table.Wrapper>
-  <Table density="compact" style={{ width: '100%' }}>
-    <Table.Head>
-      <Table.Row type="head">
-        <Table.Cell type="head">Property</Table.Cell>
-        <Table.Cell type="head">Datatype</Table.Cell>
-        <Table.Cell type="head">Påkrevd</Table.Cell>
-        <Table.Cell type="head">Default</Table.Cell>
-        <Table.Cell type="head">Beskrivelse</Table.Cell>
-      </Table.Row>
-    </Table.Head>
+Tabellen inkluderer native props som brukes til styling.
 
-    <Table.Body>
-      <Table.Row>
-        <Table.Cell> `label` </Table.Cell>
-        <Table.Cell> `string` </Table.Cell>
-        <Table.Cell> nei </Table.Cell>
-        <Table.Cell> - </Table.Cell>
-        <Table.Cell> Label for nedtrekkslisten. </Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell> `componentSize` </Table.Cell>
-        <Table.Cell> `'medium'` | `'small'` | `'tiny'` </Table.Cell>
-        <Table.Cell>nei </Table.Cell>
-        <Table.Cell>`'medium'`</Table.Cell>
-        <Table.Cell>Størrelse på komponenten. </Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell> `icon` </Table.Cell>
-        <Table.Cell> `(props: SvgProps) => JSX.Element` </Table.Cell>
-        <Table.Cell>nei </Table.Cell>
-        <Table.Cell>-</Table.Cell>
-        <Table.Cell>Ikonet som vises i komponenten. </Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell> `width` </Table.Cell>
-        <Table.Cell> `string` </Table.Cell>
-        <Table.Cell> nei </Table.Cell>
-        <Table.Cell> `'320px'` </Table.Cell>
-        <Table.Cell> Custom bredde ved behov.</Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell> `tip` </Table.Cell>
-        <Table.Cell> `string` </Table.Cell>
-        <Table.Cell> nei</Table.Cell>
-        <Table.Cell>-</Table.Cell>
-        <Table.Cell>Hjelpetekst.</Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell> `errorMessage` </Table.Cell>
-        <Table.Cell> `string` </Table.Cell>
-        <Table.Cell> nei </Table.Cell>
-        <Table.Cell>-</Table.Cell>
-        <Table.Cell> Meldingen som vises ved valideringsfeil.</Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell> `readOnly` </Table.Cell>
-        <Table.Cell> `boolean` </Table.Cell>
-        <Table.Cell>nei </Table.Cell>
-        <Table.Cell>-</Table.Cell>
-
-        <Table.Cell>
-          Nedtrekkslisten blir disabled og får `readOnly` styling.
-        </Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell> `customSingleValueElement` </Table.Cell>
-        <Table.Cell> `(props: OptionProps<TOption, IsMulti, GroupBase<TOption>>) => JSX.Element` </Table.Cell>
-        <Table.Cell>nei </Table.Cell>
-        <Table.Cell>-</Table.Cell>
-
-        <Table.Cell>
-          Custom element som vises for det valgte elementet.
-        </Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell> `customOptionElement` </Table.Cell>
-        <Table.Cell> `(props: OptionProps<TOption, IsMulti, GroupBase<TOption>>) => JSX.Element` </Table.Cell>
-        <Table.Cell>nei </Table.Cell>
-        <Table.Cell>-</Table.Cell>
-
-        <Table.Cell>
-          Custom element som vises i listen over alternativer.
-        </Table.Cell>
-      </Table.Row>
-    </Table.Body>
-
-  </Table>
-</Table.Wrapper>
-
-<br />
+<Controls of={SelectStories.Default} />
 
 ### Native React-select props
 
@@ -197,13 +73,6 @@ Ofte brukt native props:
         <Table.Cell> onChange funksjon.</Table.Cell>
       </Table.Row>
 
-      <Table.Row>
-        <Table.Cell> `isDisabled` </Table.Cell>
-        <Table.Cell> `boolean` </Table.Cell>
-        <Table.Cell>nei </Table.Cell>
-        <Table.Cell>-</Table.Cell>
-        <Table.Cell>Gjør nedtrekkslisten disabled og gir den relevant styling. </Table.Cell>
-      </Table.Row>
 
       <Table.Row>
         <Table.Cell> `value` </Table.Cell>
@@ -243,29 +112,6 @@ Ofte brukt native props:
         <Table.Cell>Spesifiserer om listen med alternativer skal lukkes når brukeren har valgt en alternativ.</Table.Cell>
       </Table.Row>
 
-      <Table.Row>
-        <Table.Cell> `isClearable` </Table.Cell>
-        <Table.Cell> `boolean` </Table.Cell>
-        <Table.Cell>nei </Table.Cell>
-        <Table.Cell>`true`</Table.Cell>
-        <Table.Cell>Spesifiserer om valgt alternativ kan tømmes. OBS! settes til false i spesialtilfeller, bruker skal ha mulighet til å tømme valget i standard skjema.</Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell> `placeholder` </Table.Cell>
-        <Table.Cell> `string` </Table.Cell>
-        <Table.Cell>nei </Table.Cell>
-        <Table.Cell>`'-- Velg fra listen --'`</Table.Cell>
-        <Table.Cell>Tekst som vises når ingen alternativ er valgt.</Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell> `isLoading` </Table.Cell>
-        <Table.Cell> `boolean` </Table.Cell>
-        <Table.Cell>nei </Table.Cell>
-        <Table.Cell>-</Table.Cell>
-        <Table.Cell>Kan brukes mens komponenten lastes inn, rendrer en innlastningsindikator i inputfeltet.</Table.Cell>
-      </Table.Row>
 
       <Table.Row>
         <Table.Cell> `isSearchable` </Table.Cell>
@@ -273,17 +119,6 @@ Ofte brukt native props:
         <Table.Cell>nei </Table.Cell>
         <Table.Cell>`true`</Table.Cell>
         <Table.Cell>Spesifiserer om brukeren kan søke på alternativene.</Table.Cell>
-      </Table.Row>
-
-      <Table.Row>
-        <Table.Cell> `required` </Table.Cell>
-        <Table.Cell> `boolean` </Table.Cell>
-        <Table.Cell>nei </Table.Cell>
-        <Table.Cell>-</Table.Cell>
-
-        <Table.Cell>
-          Markerer input som påkrevd til skjemavalidering. Gir `required` styling.
-        </Table.Cell>
       </Table.Row>
     </Table.Body>
 
@@ -296,15 +131,20 @@ Full liste over props er tilgjengelig i <Link href="https://react-select.com/pro
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface.
 
-### Bredde ved isMulti
+### Filtrering
+
+Brukeren kan filtrere alternativer ved å gi tekstlig input. Det brukes en custom filtreringsfunksjon der søkeordet er enten først i teksten, eller så har det mellomrom, bindestrek eller start-parentes før seg.
+
+### Multiselect
+
+<Canvas of={MultiSelectStories.Default} sourceState="shown" />
+<Controls of={MultiSelectStories.Default} />
+
+#### Bredde ved `isMulti`
 
 Komponenten har default bredde. Dette gjør at valgte alternativer ved `isMulti` vil prøve å fylle opp bredden og videre legge seg nedover. Hvis det er ønsket at komponenten skal utvide seg i bredden når flere alternativer blir valgt bør det settes f.eks. `width='fit-content'` og `min-width` i styling:
 
-<Canvas>
-  {/* <Story id="dds-components-select-multiselect--with-fit-content" height="500px" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-select-multiselect--with-fit-content" height="500px" />
-</Canvas>
+<Canvas of={MultiSelectStories.WithFitContent} sourceState="shown" />
 
 ## Retningslinjer
 

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -78,9 +78,11 @@ export type SelectProps<Option = unknown, IsMulti extends boolean = false> = {
   className?: string;
   /** Inline styling. */
   style?: React.CSSProperties;
+  /** Custom element som vises for det valgte elementet. */
   customOptionElement?: (
     props: OptionProps<Option, IsMulti, GroupBase<Option>>,
   ) => JSX.Element;
+  /** Custom element som vises i listen over alternativer. */
   customSingleValueElement?: (
     props: SingleValueProps<Option, IsMulti, GroupBase<Option>>,
   ) => JSX.Element;

--- a/packages/components/src/components/SelectionControl/Checkbox/Checkbox.mdx
+++ b/packages/components/src/components/SelectionControl/Checkbox/Checkbox.mdx
@@ -1,9 +1,5 @@
-import { Story, Canvas, Controls, Meta } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
-import {
-  Source,
-  ComponentLinkRow,
-} from '@norges-domstoler/storybook-components';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as CheckboxStories from './Checkbox.stories';
 import * as CheckboxGroupStories from './CheckboxGroup.stories';
 
@@ -16,26 +12,21 @@ import * as CheckboxGroupStories from './CheckboxGroup.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/?node-id=155%3A38"
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Checkbox"
 />
+## Oversikt
 
-## Demo
+Følgende komponenter er tilgjengelige:
 
-<Canvas of={CheckboxStories.Default} />
-
-<Canvas of={CheckboxGroupStories.Default} />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Checkbox/Checkbox" story="Default">Storybook</LinkTo>.
+- **`<Checkbox />`** - en avkrysningsboks.
+- **`<CheckboxGroup />`** - en gruppe-wrapper for flere avkrysningsbokser med felles ledetekst.
 
 ## Props
 
 ### Checkbox
 
-En avkrysningboks.
-
 <Canvas of={CheckboxStories.Default} sourceState="shown" />
 <Controls of={CheckboxStories.Default} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLInputElement>`-interface i `htmlProps`.
-`name`, `checked`, `defaultChecked`, `value`, `defaultValue`, `onChange`, `onBlur` er tilgjengelige på rotnivå.
+Native HTML-attributter `name`, `checked`, `defaultChecked`, `value`, `defaultValue`, `onChange`, `onBlur` er tilgjengelige på rotnivå.
 
 ### CheckboxGroup
 
@@ -43,8 +34,6 @@ Wrapper for en `<Checkbox />` gruppe. Brukes ved flere barn.
 
 <Canvas of={CheckboxGroupStories.Default} sourceState="shown" />
 <Controls of={CheckboxGroupStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
 
 ## Retningslinjer
 

--- a/packages/components/src/components/SelectionControl/RadioButton/RadioButton.mdx
+++ b/packages/components/src/components/SelectionControl/RadioButton/RadioButton.mdx
@@ -1,9 +1,5 @@
-import { Canvas, Controls, Meta, Primary } from '@storybook/blocks';
-import {
-  Source,
-  ComponentLinkRow,
-} from '@norges-domstoler/storybook-components';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as RadioButtonStories from './RadioButton.stories';
 import * as RadioButtonGroupStories from './RadioButtonGroup.stories';
 
@@ -17,33 +13,26 @@ import * as RadioButtonGroupStories from './RadioButtonGroup.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/RadioButton"
 />
 
-## Demo
+## Oversikt
 
-<Canvas of={RadioButtonStories.Default} />
+Følgende komponenter er tilgjengelige:
 
-<Canvas of={RadioButtonGroupStories.Default} />
-
-Se stories med kontrollere i <LinkTo title="dds-components/RadioButton" story="Default">Storybook</LinkTo>.
+- **`<RadioButton />`** - en radioknapp.
+- **`<RadioButtonGroup />`** - en gruppe-wrapper for flere radioknapper.
 
 ## Props
 
 ### RadioButton
 
-En radioknapp.
-
 <Canvas of={RadioButtonStories.Default} sourceState="shown" />
 <Controls of={RadioButtonStories.Default} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLInputElement>`-interface i `htmlProps`.
-
 ### RadioButtonGroup
 
-Wrapper for en `<RadioButton />` gruppe. Brukes ved flere barn.
+Wrapper for en `<RadioButton />` gruppe. Den håndtere universell utforming og oppførsel.
 
 <Canvas of={RadioButtonGroupStories.Default} sourceState="shown" />
 <Controls of={RadioButtonGroupStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
 
 ## Retningslinjer
 

--- a/packages/components/src/components/SkipToContent/SkipToContent.mdx
+++ b/packages/components/src/components/SkipToContent/SkipToContent.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
 import {
   Source,
   ComponentLinkRow,
@@ -16,11 +15,10 @@ import * as SkipToContentStories from './SkipToContent.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/SkipToContent"
 />
 
-## Demo
+## Props
 
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/SkipToContent" story="Default">Storybook</LinkTo>.
+<Canvas of={SkipToContentStories.Default} sourceState="shown" />
+<Controls of={SkipToContentStories.Default} />
 
 ## Bruk i koden
 
@@ -33,13 +31,6 @@ Se stories med kontrollere i <LinkTo title="dds-components/SkipToContent" story=
   <Typography id="innhold">Innhold</Typography>
 </body>
 `} />
-
-## Props
-
-<Canvas of={SkipToContentStories.Default} sourceState="shown" />
-<Controls of={SkipToContentStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLAnchorElement>`-interface i `htmlProps`.
 
 ## Retningslinjer
 

--- a/packages/components/src/components/Spinner/Spinner.mdx
+++ b/packages/components/src/components/Spinner/Spinner.mdx
@@ -1,9 +1,5 @@
-import { Story, Canvas, Controls, Primary, Meta } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
-import {
-  Source,
-  ComponentLinkRow,
-} from '@norges-domstoler/storybook-components';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as SpinnerStories from './Spinner.stories';
 
 <Meta of={SpinnerStories} />
@@ -15,12 +11,6 @@ import * as SpinnerStories from './Spinner.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Spinner"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/Spinner" story="Default">Storybook</LinkTo>.
-
 ## Oversikt
 
 `<Spinner />` er et animert `<svg>`-element som bruker nåværende tid til å bestemme hvor den skal starte i animasjonen.
@@ -29,5 +19,3 @@ Se stories med kontrollere i <LinkTo title="dds-components/Spinner" story="Defau
 
 <Canvas of={SpinnerStories.Default} sourceState="shown" />
 <Controls of={SpinnerStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLSVGElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/SplitButton/SplitButton.mdx
+++ b/packages/components/src/components/SplitButton/SplitButton.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Controls, Primary, Meta } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta } from '@storybook/blocks';
 import {
   Source,
   ComponentLinkRow,
@@ -16,18 +15,17 @@ import * as SplitButtonStories from './SplitButton.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/DDS-Komponenter?node-id=155%3A37"
 />
 
-## Demo
-
-<Primary />
-
-Se stories med kontrollere i <LinkTo title="dds-components/SplitButton" story="Default">Storybook</LinkTo>.
-
 ## Oversikt
 
 `<SplitButton />` er en todelt knapp som skal brukes ved flere relaterte handlinger, der den ene er mest vanlig.
 Komponenten består av to knapper: én for den primære handlingen, og én for å åpne en meny med sekundære handlinger.
 Når menyen åpnes og en handling velges blir den umiddelbart gjennomført.
 `<SplitButton />` er dermed en fusjon med en knapp og meny.
+
+## API
+
+<Canvas of={SplitButtonStories.Default} sourceState="shown" />
+<Controls of={SplitButtonStories.Default} />
 
 ## Bruk i koden
 
@@ -44,10 +42,3 @@ onClick: () => {},
   secondaryActions={items}
 />
 `} />
-
-## API
-
-<Canvas of={SplitButtonStories.Default} sourceState="shown" />
-<Controls of={SplitButtonStories.Default} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/Stack/Stack.mdx
+++ b/packages/components/src/components/Stack/Stack.mdx
@@ -1,11 +1,4 @@
-import {
-  Story,
-  Canvas,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { VStack } from '.';
+import { Story, Canvas, Meta, ArgTypes } from '@storybook/blocks';
 import {
   Source,
   ComponentLinkRow,
@@ -58,6 +51,6 @@ De lar deg respektivt legge elementer i en kolonne eller rad.
 
 ## API
 
-<ArgTypes story={PRIMARY_STORY} />
+<ArgTypes of={StackStories.VStackOverview} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.

--- a/packages/components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
+++ b/packages/components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
@@ -29,6 +29,11 @@ export default {
     stickyHeader: {
       control: { type: 'boolean' },
     },
+    withDividers: {
+      control: {
+        type: 'boolean',
+      },
+    },
   },
   parameters: {
     controls: {

--- a/packages/components/src/components/Table/normal/Table.mdx
+++ b/packages/components/src/components/Table/normal/Table.mdx
@@ -1,10 +1,4 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
+import { Canvas, Story, Meta, ArgTypes, Controls } from '@storybook/blocks';
 import { Table, CollapsibleTable } from '../';
 import { Tag } from '../../Tag';
 import {
@@ -14,6 +8,7 @@ import {
   LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as TableStories from './Table.stories';
+import * as CollapsibleTableStories from '../collapsible/CollapsibleTable.stories';
 
 <Meta of={TableStories} />
 
@@ -129,7 +124,8 @@ Støtter alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivEl
 
 Tilsvarer `<table>`.
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={TableStories.Default} />
+<Controls of={TableStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLTableElement>`-interface.
 
@@ -187,7 +183,8 @@ Kollapset tilstand brukes som mobilversjon.
 
 Rekkefølgen på definerende kolonner følger rekkefølgen i `definingColumnIndex`.
 
-<ArgTypes of={CollapsibleTable} />
+<Canvas of={CollapsibleTableStories.SingleDefiningColumn} />
+<Controls of={CollapsibleTableStories.SingleDefiningColumn} />
 
 ### CollapsibleTable.Row <Tag text="BETA" purpose="warning" />
 

--- a/packages/components/src/components/Tabs/Tab.tsx
+++ b/packages/components/src/components/Tabs/Tab.tsx
@@ -97,10 +97,7 @@ export type TabProps = BaseComponentPropsWithChildren<
     setFocus?: Dispatch<SetStateAction<number>>;
     /** Indeksen til `<Tab />`. **OBS!** settes automatisk av forelder.*/
     index?: number;
-    /**
-     * Bredden til `<Tab />`. Her er det støtte for de samme enhetene som du kan bruke i `grid-template-columns`.
-     * @default '1fr'
-     */
+    /** Bredden til `<Tab />`. Her er det støtte for de samme enhetene som du kan bruke i `grid-template-columns`. */
     width?: CSS.Properties['width'];
   } & Pick<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'onKeyDown'>,
   Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'onKeyDown'>

--- a/packages/components/src/components/Tabs/Tabs.mdx
+++ b/packages/components/src/components/Tabs/Tabs.mdx
@@ -1,16 +1,8 @@
-import {
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-  Canvas,
-  Story,
-} from '@storybook/blocks';
+import { Meta, ArgTypes, Canvas, Story } from '@storybook/blocks';
 import { Tab, TabPanel } from '.';
 import {
   Source,
   ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
 } from '@norges-domstoler/storybook-components';
 import * as TabsStories from './Tabs.stories';
 
@@ -24,14 +16,6 @@ import * as TabsStories from './Tabs.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Tabs"
 />
 
-## Demo
-
-<Canvas>
-  <Story of={TabsStories.Default} />
-</Canvas>
-
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-tabs`} />
-
 ## Oversikt
 
 Komponenten består av flere subkomponenter:
@@ -42,33 +26,15 @@ Komponenten består av flere subkomponenter:
 - `<TabPanel />` - panel med innhold som hører til en spesifikk fane.
 - `<TabPanels />` - liste med paneler. Håndterer ARIA-attributter og `id` for barna.
 
-## Bruk i koden
-
-<Source
-  code={`import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@norges-domstoler/dds-components';
-   <Tabs>
-       <TabList>
-           <Tab> Tab 1 </Tab>
-           <Tab> Tab 2 </Tab>
-       </TabList>
-       <TabPanels>
-           <TabPanel> Innhold 1 </TabPanel>
-           <TabPanel> Innhold 2 </TabPanel>
-       </TabPanels>
-   </Tabs>
-
-`}
-/>
-
 ## API
 
 ### Tabs
 
 Ytterste container som styrer hvilket panel skal vises via indeks. Har `<TabList />` og `<TabPanels />` som barn.
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={TabsStories.Default} sourceState="shown" />
 
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
+<ArgTypes story={TabsStories.Default} />
 
 ### Tab
 
@@ -76,13 +42,7 @@ En fane. Tilhørende `<TabPanel />` vises ved museklikk.
 
 <ArgTypes of={Tab} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `ButtonHTMLAttributes<HTMLButtonElement>`-interface i `htmlProps`.
-
-### TabList
-
-En liste med `<Tab />`. Setter attributter som `aria-controls` og roving focus for barna. `<TabList />` skal ha `<Tab />` som barn i samme rekkefølge som tilhørende paneler i `<TabPanels />`.
-
-Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
+#### `width`
 
 For å endre på bredden til tabs kan du bruke `width`-attributtet. Her støttes alle de samme enhetene som i `grid-template-columns` i CSS.
 
@@ -104,16 +64,20 @@ For å endre på bredden til tabs kan du bruke `width`-attributtet. Her støttes
 `}
 />
 
+### TabList
+
+En liste med `<Tab />`. Setter attributter som `aria-controls` og roving focus for barna. `<TabList />` skal ha `<Tab />` som barn i samme rekkefølge som tilhørende paneler i `<TabPanels />`.
+
+Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface.
+
 ### TabPanel
 
 Panel med innhold. Vises ved museklikk på tilhørende `<Tab />`.
 
 <ArgTypes of={TabPanel} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `ButtonHTMLAttributes<HTMLButtonElement>`-interface i `htmlProps`.
-
 ### TabPanels
 
 En liste med `<TabPanel />`. Setter attributter som `aria-labelledby` for barna. `<TabPanels />` skal ha `<TabPanel />` som barn i samme rekkefølge som tilhørende paneler i `<TabList />`.
 
-Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
+Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface.

--- a/packages/components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/components/Tabs/Tabs.stories.tsx
@@ -16,14 +16,6 @@ export default {
     TabPanel: TabPanel,
     TabPanels: TabPanels,
   },
-  argTypes: {
-    activeTab: {
-      control: 'number',
-    },
-    tabWidth: {
-      control: 'text',
-    },
-  },
 };
 
 export const Overview = () => (

--- a/packages/components/src/components/Tag/Tag.mdx
+++ b/packages/components/src/components/Tag/Tag.mdx
@@ -1,16 +1,5 @@
-import {
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-  Canvas,
-  Story,
-} from '@storybook/blocks';
-import {
-  Source,
-  ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
-} from '@norges-domstoler/storybook-components';
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as TagStories from './Tag.stories';
 
 <Meta of={TagStories} />
@@ -23,25 +12,7 @@ import * as TagStories from './Tag.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Tag"
 />
 
-## Demo
+## Props
 
-<Canvas>
-  <Story of={TagStories.Default} />
-</Canvas>
-
-<LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-tag`} />
-
-## Bruk i koden
-
-<Source
-  code={`
-  import { Tag } from '@norges-domstoler/dds-components';
-
-<Tag>status</Tag>
-`} />
-
-## API
-
-<ArgTypes of={TagStories} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLSpanElement>`-interface i `htmlProps`.
+<Canvas of={TagStories.Default} sourceState="shown" />
+<Controls of={TagStories.Default} />

--- a/packages/components/src/components/TextArea/TextArea.mdx
+++ b/packages/components/src/components/TextArea/TextArea.mdx
@@ -1,17 +1,5 @@
-import {
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-  Story,
-  Canvas,
-} from '@storybook/blocks';
-import { TextArea } from '.';
-import {
-  Source,
-  ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
-} from '@norges-domstoler/storybook-components';
+import { Meta, Controls, Canvas } from '@storybook/blocks';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as TextAreaStories from './TextArea.stories';
 
 <Meta of={TextAreaStories} />
@@ -24,35 +12,10 @@ import * as TextAreaStories from './TextArea.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/TextArea"
 />
 
-## Demo
-
-<Canvas>
-  {/* <Story id="dds-components-textarea--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-textarea--default" />
-</Canvas>
-
-<Canvas>
-  {/* <Story id="dds-components-textarea--with-label" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-textarea--with-label" />
-</Canvas>
-
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-textarea`}
-/>
-
-## Bruk i koden
-
-<Source
-  code={`import { TextArea } from '@norges-domstoler/dds-components';
-
-<TextArea label="Ledetekst" />
-`} />
-
 ## API
 
-<ArgTypes story={PRIMARY_STORY} />
+<Canvas of={TextAreaStories.WithLabel} sourceState="shown" />
+<Controls of={TextAreaStories.WithLabel} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `TextareaHTMLAttributes<HTMLTextAreaElement>`-interface.
 

--- a/packages/components/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/components/src/components/TextArea/TextArea.stories.tsx
@@ -1,4 +1,5 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { TextArea } from './TextArea';
 import { type TextAreaProps } from './TextArea.types';
@@ -16,11 +17,14 @@ export default {
     readOnly: { control: { type: 'boolean' } },
   },
   parameters: {
-    controls: {
-      exclude: ['style', 'className'],
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
     },
   },
 };
+
+type Story = StoryObj<typeof TextArea>;
 
 export const Overview = (args: TextAreaProps) => {
   return (
@@ -71,18 +75,19 @@ export const Overview = (args: TextAreaProps) => {
   );
 };
 
-export const Default = (args: TextAreaProps) => {
-  return (
-    <StoryTemplate title="TextArea - default" display="block">
-      <TextArea {...args} />
+export const Default: Story = {
+  decorators: Story => (
+    <StoryTemplate title="TextArea - default">
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const WithLabel = (args: TextAreaProps) => {
-  return (
+export const WithLabel: Story = {
+  args: { label: 'Label' },
+  decorators: Story => (
     <StoryTemplate title="TextArea - with label">
-      <TextArea {...args} label={args.label ?? 'Label'} />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };

--- a/packages/components/src/components/TextInput/TextInput.mdx
+++ b/packages/components/src/components/TextInput/TextInput.mdx
@@ -1,17 +1,5 @@
-import {
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-  Story,
-  Canvas,
-} from '@storybook/blocks';
-import { TextInput } from '.';
-import {
-  Source,
-  ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
-} from '@norges-domstoler/storybook-components';
+import { Meta, Canvas, Controls } from '@storybook/blocks';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as TextInputStories from './TextInput.stories';
 
 <Meta of={TextInputStories} />
@@ -24,47 +12,16 @@ import * as TextInputStories from './TextInput.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/TextInput"
 />
 
-## Demo
+## Props
 
-<Canvas>
-  {/* <Story id="dds-components-textinput--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-textinput--default" />
-</Canvas>
-
-<Canvas>
-  {/* <Story id="dds-components-textinput--with-label" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-textinput--with-label" />
-</Canvas>
-
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-textinput`}
-/>
-
-## Bruk i koden
-
-<Source
-  code={`import { TextInput } from '@norges-domstoler/dds-components';
-
-<TextInput label="Ledetekst" />
-`} />
-
-## API
-
-<ArgTypes story={PRIMARY_STORY} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLInputElement>`-interface.
+<Canvas of={TextInputStories.WithLabel} sourceState="shown" />
+<Controls of={TextInputStories.WithLabel} />
 
 ### maxLength
 
 Når native attributtet `maxLength` brukes dukker det opp en tegnteller til høyre under inputfeltet:
 
-<Canvas>
-  {/* <Story id="dds-components-textinput--with-character-count" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-textinput--with-character-count" />
-</Canvas>
+<Canvas of={TextInputStories.WithCharacterCount} sourceState="shown" />
 
 For å ikke vise tegntelleren sett `withCharacterCounter=false`.
 

--- a/packages/components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/components/src/components/TextInput/TextInput.stories.tsx
@@ -1,4 +1,5 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
+import { type StoryObj } from '@storybook/react';
 
 import { MailIcon } from '../Icon/icons';
 import { LocalMessage } from '../LocalMessage';
@@ -13,6 +14,8 @@ export default {
     tip: { control: { type: 'text' } },
     errorMessage: { control: { type: 'text' } },
     width: { control: { type: 'text' } },
+    withCharacterCounter: { control: { type: 'boolean' } },
+    maxLength: { control: { type: 'number' } },
     required: { control: { type: 'boolean' } },
     disabled: { control: { type: 'boolean' } },
     readOnly: { control: { type: 'boolean' } },
@@ -20,11 +23,14 @@ export default {
     suffix: { control: { type: 'text' } },
   },
   parameters: {
-    controls: {
-      exclude: ['style', 'className'],
+    docs: {
+      story: { inline: true },
+      canvas: { sourceState: 'hidden' },
     },
   },
 };
+
+type Story = StoryObj<typeof TextInput>;
 
 export const TextInputOverview = (args: TextInputProps) => {
   return (
@@ -122,20 +128,21 @@ export const TextInputOverviewSizes = () => (
   </StoryTemplate>
 );
 
-export const Default = (args: TextInputProps) => {
-  return (
+export const Default: Story = {
+  decorators: Story => (
     <StoryTemplate title="TextInput - default">
-      <TextInput {...args} />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
-export const WithLabel = (args: TextInputProps) => {
-  return (
+export const WithLabel: Story = {
+  args: { label: 'Label' },
+  decorators: Story => (
     <StoryTemplate title="TextInput - with label">
-      <TextInput {...args} label={args.label ?? 'Label'} />
+      <Story />
     </StoryTemplate>
-  );
+  ),
 };
 
 export const WithCharacterCount = (args: TextInputProps) => {

--- a/packages/components/src/components/ToggleBar/ToggleBar.mdx
+++ b/packages/components/src/components/ToggleBar/ToggleBar.mdx
@@ -1,17 +1,6 @@
-import {
-  Canvas,
-  Story,
-  Meta,
-  ArgTypes,
-  PRIMARY_STORY,
-} from '@storybook/blocks';
-import { ToggleBar, ToggleRadio } from '.';
-import {
-  Source,
-  ComponentLinkRow,
-  SB_DESIGNSYSTEM_URL,
-  LinkToInteractiveStory,
-} from '@norges-domstoler/storybook-components';
+import { Canvas, Meta, ArgTypes, Controls } from '@storybook/blocks';
+import { ToggleRadio } from '.';
+import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as ToggleBarStories from './ToggleBar.stories';
 
 <Meta of={ToggleBarStories} />
@@ -24,44 +13,12 @@ import * as ToggleBarStories from './ToggleBar.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/ToggleBar"
 />
 
-## Demo
-
-<Canvas>
-  {/* <Story id="dds-components-togglebar--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-togglebar--default" />
-</Canvas>
-
-<LinkToInteractiveStory
-  href={`${SB_DESIGNSYSTEM_URL}dds-components-togglebar`}
-/>
-
 ## Oversikt
 
 ToggleBar er en rad med semantiske radioknapper. Den består av følgende subkomponenter:
 
-- `<ToggleBar />` - wrapper for barna.
-- `<ToggleRadio />` - elementer å velge mellom.
-
-## Bruk i koden
-
-<Source
-  code={`import { ToggleRadio, ToggleBar } from '@norges-domstoler/dds-components';
-
-const [value, setValue] = useState<string | undefined>();
-
-<ToggleBar
-  label="Gruppe"
-  name="navn"
-  value={value}
-  onChange={(event, value) => {
-    setValue(value);
-  }}
->
-  <ToggleRadio value="alt1" label="Alternativ 1" />
-  <ToggleRadio value="alt2" label="Alternativ 2" />
-</ToggleBar>
-`} />
+- **`<ToggleBar />`** - wrapper for barna.
+- **`<ToggleRadio />`** - elementer å velge mellom.
 
 ## API
 
@@ -69,25 +26,19 @@ const [value, setValue] = useState<string | undefined>();
 
 En rad med `<ToggleRadio />`.
 
-<ArgTypes story={PRIMARY_STORY} />
-
-I tillegg støttes alle native HTML-attributter som er en del av `DivHTMLAttributes<HTMLInputElement>`-interface i `htmlProps`.
+<Canvas of={ToggleBarStories.Default} sourceState="shown" />
+<Controls of={ToggleBarStories.Default} />
 
 #### Bredde
 
 Bredden på alle `<ToggleRadio />` i en `<ToggleBar />` skal være den samme. `<ToggleBar />` tar i utganspunktet hele tigjengelige bredden og fordeler den likt mellom barna. Spesifikk bredde kan settes enten i `<ToggleBar />` eller i selvutviklede wrapperen til `<ToggleBar />`.
 
-<Canvas>
-  {/* <Story id="dds-components-togglebar--with-width" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-togglebar--with-width" />
-</Canvas>
+<Canvas of={ToggleBarStories.WithWidth} sourceState="shown" />
 
 ### ToggleRadio
 
+Radioknapp.
+
 <ArgTypes of={ToggleRadio} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `InputHTMLAttributes<HTMLDivElement>`-interface på følgende måte:
-
-- `'name'`, `'checked'`, `'value'`, `'onChange'`, `'aria-labelledby'`, `'aria-label'` på toppnivå.
-- resterende i `htmlProps`.
+Native HTML-attributter `'name'`, `'checked'`, `'value'`, `'onChange'`, `'aria-labelledby'`, `'aria-label'` støttes på toppnivå.

--- a/packages/components/src/components/ToggleBar/ToggleBar.stories.tsx
+++ b/packages/components/src/components/ToggleBar/ToggleBar.stories.tsx
@@ -11,6 +11,8 @@ export default {
   component: ToggleBar,
   argTypes: {
     label: { control: { type: 'text' } },
+    name: { control: { type: 'text' } },
+    width: { control: { type: 'text' } },
   },
 };
 

--- a/packages/components/src/components/date-inputs/DatePicker/DatePicker.mdx
+++ b/packages/components/src/components/date-inputs/DatePicker/DatePicker.mdx
@@ -1,5 +1,4 @@
-import { Canvas, Controls, Meta, Primary } from '@storybook/blocks';
-import LinkTo from '@storybook/addon-links/react';
+import { Canvas, Controls, Meta, Story } from '@storybook/blocks';
 import {
   Source,
   ComponentLinkRow,
@@ -16,11 +15,15 @@ import * as DatePickerStories from './DatePicker.stories';
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/date-inputs/DatePicker"
 />
 
-## Demo
+## Props
 
-<Primary />
+`DatePicker`-komponenten er implementert vha. [react-aria](https://react-spectrum.adobe.com/react-aria).
+For mer utfyllende dokumentasjon av props referrerer vi deg til [`DatePicker` dokumentasjon til react-aria](https://react-spectrum.adobe.com/react-aria/DatePicker.html#props).
 
-Se stories med kontrollere i <LinkTo title="dds-components/DatePicker" story="Default">Storybook</LinkTo>.
+<Canvas>
+  <Story of={DatePickerStories.Default} height="500px" />
+</Canvas>
+<Controls of={DatePickerStories.Default} />
 
 ## Bruk i koden
 
@@ -63,11 +66,3 @@ const [value, setValue] = useState<Date>(new Date());
   onChange={d => setValue(calendarDateToNativeDate(d))}
 />
 `}/>
-
-## Props
-
-`DatePicker`-komponenten er implementert vha. [react-aria](https://react-spectrum.adobe.com/react-aria).
-For mer utfyllende dokumentasjon av props referrerer vi deg til [`DatePicker` dokumentasjon til react-aria](https://react-spectrum.adobe.com/react-aria/DatePicker.html#props).
-
-<Canvas of={DatePickerStories.Default} sourceState="shown" />
-<Controls of={DatePickerStories.Default} />


### PR DESCRIPTION
Fikser docs:

- fjerner doble demoer
- fjerner bruk i koden der ikke nødvendig
- skrive om dårlige seksjoner
- fikse feil props i argTables
- standarisering
- legge til manglende prop descriptions
- styling på lister
- annet småtteri