### PR TITLE
ELSA1-325 Fikser støtte for ARIA i `<ToggleRadio />`

### DIFF
--- a/.changeset/mighty-panthers-talk.md
+++ b/.changeset/mighty-panthers-talk.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Fikser støtte for `aria-label` og `aria-labelledby` i `<ToggleRadio />`

--- a/packages/components/src/components/ToggleBar/ToggleRadio.tsx
+++ b/packages/components/src/components/ToggleBar/ToggleRadio.tsx
@@ -64,6 +64,8 @@ export const ToggleRadio = forwardRef<HTMLInputElement, ToggleRadioProps>(
       name,
       onChange,
       checked,
+      'aria-label': ariaLabel,
+      'aria-labelledby': ariaLabelledBy,
       icon,
       label,
       htmlProps,
@@ -91,6 +93,8 @@ export const ToggleRadio = forwardRef<HTMLInputElement, ToggleRadioProps>(
           onChange={handleChange}
           value={value}
           checked={calculateChecked(value, group, checked)}
+          aria-label={ariaLabel}
+          aria-labelledby={ariaLabelledBy}
         />
         <Content $size={group.size} $justIcon={!!icon && !label}>
           {icon && <Icon icon={icon} iconSize="inherit" />}


### PR DESCRIPTION
Fikser manglende støtte for `aria-label` og `aria-labelledby`.