### PR TITLE
ELSA1-323 fikse at `useRoveFocus` stjeler keydown mens inaktiv

### DIFF
--- a/.changeset/heavy-experts-agree.md
+++ b/.changeset/heavy-experts-agree.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Fikser feil hvor `<OverflowMenu>`, `<Tabs>` og `<Search.AutocompleteWrapper>` blokkerte andre elementer fra å bruke piltastene.

--- a/packages/components/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/components/src/components/OverflowMenu/OverflowMenu.tsx
@@ -135,7 +135,7 @@ export const OverflowMenu = forwardRef<HTMLDivElement, OverflowMenuProps>(
 
     const hasInteractiveItems = interactiveItems.length > 0;
 
-    const [focus, setFocus] = useRoveFocus(interactiveItems?.length, !isOpen);
+    const [focus] = useRoveFocus(interactiveItems?.length, isOpen);
 
     const interactiveItemsList = hasInteractiveItems
       ? interactiveItems.map((item, index) => (
@@ -143,7 +143,6 @@ export const OverflowMenu = forwardRef<HTMLDivElement, OverflowMenuProps>(
             <OverflowMenuItem
               index={index}
               focus={focus === index && isOpen}
-              setFocus={setFocus}
               icon={hasInteractiveUser && index === 0 ? PersonIcon : undefined}
               {...item}
               onClick={(

--- a/packages/components/src/components/OverflowMenu/OverflowMenuItem.tsx
+++ b/packages/components/src/components/OverflowMenu/OverflowMenuItem.tsx
@@ -1,13 +1,8 @@
 import {
   type AnchorHTMLAttributes,
   type ButtonHTMLAttributes,
-  type Dispatch,
   type ForwardedRef,
-  type KeyboardEvent,
-  type MouseEvent,
-  type SetStateAction,
   forwardRef,
-  useCallback,
   useEffect,
   useRef,
 } from 'react';
@@ -75,7 +70,6 @@ interface BaseOverflowMenuItemProps {
   title: string;
   icon?: SvgIcon;
   focus?: boolean;
-  setFocus?: Dispatch<SetStateAction<number>>;
   index?: number;
   isMenuClosed?: boolean;
 }
@@ -119,19 +113,7 @@ export const OverflowMenuItem = forwardRef<
   HTMLAnchorElement,
   OverflowMenuItemProps
 >((props, ref) => {
-  const {
-    title,
-    icon,
-    focus,
-    setFocus,
-    index,
-    id,
-    className,
-    htmlProps = {},
-    ...rest
-  } = props;
-
-  const { onKeyDown } = htmlProps;
+  const { title, icon, focus, id, className, htmlProps = {}, ...rest } = props;
 
   let href: AnchorOverflowMenuItemProps['href'];
   let onClick: ButtonOverflowMenuItemProps['onClick'];
@@ -150,30 +132,8 @@ export const OverflowMenuItem = forwardRef<
     }
   }, [focus]);
 
-  const handleSelect = useCallback(() => {
-    if (setFocus && index) {
-      setFocus(index);
-    }
-  }, [index, setFocus]);
-
-  const handleOnClick = (
-    e: MouseEvent<HTMLAnchorElement> & MouseEvent<HTMLButtonElement>,
-  ) => {
-    handleSelect();
-    onClick && onClick(e);
-  };
-
-  const handleOnKeyDown = (
-    e: KeyboardEvent<HTMLAnchorElement> & KeyboardEvent<HTMLButtonElement>,
-  ) => {
-    handleSelect();
-    onKeyDown && onKeyDown(e);
-  };
-
   const linkProps = {
     href,
-    onClick: handleOnClick,
-    onKeyDown: handleOnKeyDown,
     role: 'menuitem',
     tabIndex: focus ? 0 : -1,
   };

--- a/packages/components/src/components/Search/SearchSuggestions.tsx
+++ b/packages/components/src/components/Search/SearchSuggestions.tsx
@@ -87,7 +87,7 @@ export const SearchSuggestions = forwardRef<
     'suggestions-header',
   );
 
-  const [focus, setFocus] = useRoveFocus(suggestions?.length, !showSuggestions);
+  const [focus] = useRoveFocus(suggestions?.length, showSuggestions);
 
   const suggestionsToRender = maxSuggestions
     ? suggestions?.slice(maxSuggestions)
@@ -101,7 +101,6 @@ export const SearchSuggestions = forwardRef<
             <MenuItem
               index={index}
               focus={focus === index && showSuggestions}
-              setFocus={setFocus}
               aria-label={`søk på ${suggestion}`}
               onClick={onSuggestionClick}
               title={suggestion}

--- a/packages/components/src/components/Tabs/Tab.tsx
+++ b/packages/components/src/components/Tabs/Tab.tsx
@@ -15,7 +15,7 @@ import styled, { css } from 'styled-components';
 import { useTabsContext } from './Tabs.context';
 import { tabsTokens as tokens } from './Tabs.tokens';
 import { useSetTabWidth } from './TabWidthContext';
-import { useCombinedRef, useOnKeyDown } from '../../hooks';
+import { useCombinedRef } from '../../hooks';
 import {
   type BaseComponentPropsWithChildren,
   type Direction,
@@ -126,20 +126,13 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
 
   const itemRef = useRef<HTMLAnchorElement | HTMLButtonElement>(null);
   const combinedRef = useCombinedRef(ref, itemRef);
-  const { tabPanelsRef, setHasTabFocus, tabContentDirection } =
-    useTabsContext();
+  const { tabContentDirection } = useTabsContext();
 
   useEffect(() => {
     if (focus) {
       itemRef.current?.focus();
-      setHasTabFocus(true);
     }
   }, [focus]);
-
-  useOnKeyDown('Tab', () => {
-    setHasTabFocus(false);
-    tabPanelsRef?.current?.focus();
-  });
 
   const handleSelect = useCallback(() => {
     if (setFocus && index) {

--- a/packages/components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/components/Tabs/Tabs.stories.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { NotificationsIcon } from '../Icon/icons';
 import { VStack } from '../Stack';
+import { TextArea } from '../TextArea';
 import { Paragraph } from '../Typography';
 
 import { Tab, TabList, TabPanel, TabPanels, Tabs, type TabsProps } from '.';
@@ -90,7 +91,10 @@ export const ActiveTab = (args: TabsProps) => {
           <Tab>Tab 3</Tab>
         </TabList>
         <TabPanels>
-          <TabPanel>Innhold 1</TabPanel>
+          <TabPanel>
+            <span>Innhold 1</span>
+            <TextArea label="test" />
+          </TabPanel>
           <TabPanel>Innhold 2</TabPanel>
           <TabPanel>Innhold 3</TabPanel>
         </TabPanels>


### PR DESCRIPTION
Trenger ikke å gjøre noe med keydown events når hooken ikke aktivt styrer fokus.

Syntes det var litt forvirrende med den `reset`-proppen, så endret den samtidig til å heller være en "aktiv toggle". Føler det gir mer mening 😅 

![2024-02-23 14 33 17](https://github.com/domstolene/designsystem/assets/25374940/1af08932-2ff2-4d79-9f04-e29a5114e017)
