### PR TITLE
Fjerner tittel fra stories

### DIFF
--- a/packages/components/src/components/Breadcrumbs/Breadcrumb.stories.tsx
+++ b/packages/components/src/components/Breadcrumbs/Breadcrumb.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Breadcrumb>;
 
 export const BreadcrumbDefault: Story = {
   decorators: Story => (
-    <StoryTemplate title="Breadcrumb - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Button/Button.stories.tsx
+++ b/packages/components/src/components/Button/Button.stories.tsx
@@ -28,7 +28,7 @@ type Story = StoryObj<typeof Button>;
 export const Default: Story = {
   args: { children: 'Tekst' },
   decorators: Story => (
-    <StoryTemplate title="Button - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -36,7 +36,7 @@ export const Default: Story = {
 
 export const OverviewWithText: Story = {
   decorators: Story => (
-    <StoryTemplate title="Button overview - with text" display="grid">
+    <StoryTemplate display="grid">
       <Story />
     </StoryTemplate>
   ),
@@ -193,7 +193,7 @@ export const OverviewWithText: Story = {
 export const OverviewJustIcon: Story = {
   args: { icon: icons.CloseIcon },
   decorators: Story => (
-    <StoryTemplate title="Button overview - just icon" display="grid">
+    <StoryTemplate display="grid">
       <Story />
     </StoryTemplate>
   ),
@@ -217,11 +217,7 @@ export const OverviewJustIcon: Story = {
 
 export const OverviewSizes: Story = {
   decorators: Story => (
-    <StoryTemplate
-      title="Button overview - sizes"
-      display="grid"
-      $columnsAmount={4}
-    >
+    <StoryTemplate display="grid" $columnsAmount={4}>
       <Story />
     </StoryTemplate>
   ),
@@ -313,11 +309,7 @@ export const OverviewSizes: Story = {
 
 export const OverviewLoading: Story = {
   decorators: Story => (
-    <StoryTemplate
-      title="Button overview - loading"
-      display="grid"
-      $columnsAmount={4}
-    >
+    <StoryTemplate display="grid" $columnsAmount={4}>
       <Story />
     </StoryTemplate>
   ),
@@ -498,7 +490,7 @@ export const OverviewLoading: Story = {
 export const OverviewFullWidth: Story = {
   args: { fullWidth: true },
   decorators: Story => (
-    <StoryTemplate title="Button overview - full width">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -554,7 +546,7 @@ export const TextWithIcon: Story = {
     iconPosition: 'left',
   },
   decorators: Story => (
-    <StoryTemplate title="Button - text with icon">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -563,7 +555,7 @@ export const TextWithIcon: Story = {
 export const Icon: Story = {
   args: { icon: icons.CloseIcon },
   decorators: Story => (
-    <StoryTemplate title="Button - just icon">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -572,7 +564,7 @@ export const Icon: Story = {
 export const Ghost: Story = {
   args: { children: 'Tekst' },
   decorators: Story => (
-    <StoryTemplate title="Button - ghost">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -594,7 +586,7 @@ export const Ghost: Story = {
 export const Borderless: Story = {
   args: { children: 'Tekst' },
   decorators: Story => (
-    <StoryTemplate title="Button - borderless">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -610,7 +602,7 @@ export const Borderless: Story = {
 export const Rounded: Story = {
   args: { children: 'Tekst' },
   decorators: Story => (
-    <StoryTemplate title="Button - rounded">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Card/Card.stories.tsx
+++ b/packages/components/src/components/Card/Card.stories.tsx
@@ -45,7 +45,7 @@ const ContentContainer = styled.div`
 
 export const Overview: Story = {
   decorators: Story => (
-    <StoryTemplate title="Card - overview" display="grid" $columnsAmount={4}>
+    <StoryTemplate display="grid" $columnsAmount={4}>
       <Story />
     </StoryTemplate>
   ),
@@ -135,7 +135,7 @@ export const Overview: Story = {
 export const Default: Story = {
   args: { children: 'Content' },
   decorators: Story => (
-    <StoryTemplate title="Card - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -143,7 +143,7 @@ export const Default: Story = {
 
 export const Accordion: Story = {
   decorators: Story => (
-    <StoryTemplate title="Card - accordion">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -160,7 +160,7 @@ export const Accordion: Story = {
 
 export const Accordions: Story = {
   decorators: Story => (
-    <StoryTemplate title="Card - accordion" gap="0">
+    <StoryTemplate gap="0">
       <Story />
     </StoryTemplate>
   ),
@@ -233,7 +233,7 @@ export const Accordions: Story = {
 
 export const AccordionControlled: Story = {
   decorators: Story => (
-    <StoryTemplate title="Card - accordion" gap="0">
+    <StoryTemplate gap="0">
       <Story />
     </StoryTemplate>
   ),
@@ -257,7 +257,7 @@ export const AccordionControlled: Story = {
 
 export const AccordionCustom: Story = {
   decorators: Story => (
-    <StoryTemplate title="Card - accordion" gap="0">
+    <StoryTemplate gap="0">
       <Story />
     </StoryTemplate>
   ),
@@ -298,7 +298,7 @@ export const AccordionCustom: Story = {
 
 export const Examples: Story = {
   decorators: Story => (
-    <StoryTemplate title="Card - examples">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Chip/Chip.stories.tsx
+++ b/packages/components/src/components/Chip/Chip.stories.tsx
@@ -9,7 +9,7 @@ export default {
   parameters: {
     docs: {
       story: { inline: true },
-      canvas: { sourceState: 'hidden' },
+      canvas: { sourceState: 'shown' },
     },
   },
   argTypes: {
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof Chip>;
 export const Default: Story = {
   args: { text: 'Chip' },
   decorators: Story => (
-    <StoryTemplate title="Chip - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Chip/ChipGroup.stories.tsx
+++ b/packages/components/src/components/Chip/ChipGroup.stories.tsx
@@ -9,7 +9,7 @@ export default {
   parameters: {
     docs: {
       story: { inline: true },
-      canvas: { sourceState: 'hidden' },
+      canvas: { sourceState: 'shown' },
     },
   },
 };
@@ -18,7 +18,7 @@ type Story = StoryObj<typeof ChipGroup>;
 
 export const Default: Story = {
   decorators: Story => (
-    <StoryTemplate title="ChipGroup - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/packages/components/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -25,14 +25,24 @@ export default {
 
 type Story = StoryObj<typeof DescriptionList>;
 
+export const Default: Story = {
+  decorators: Story => (
+    <StoryTemplate>
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <DescriptionList {...args}>
+      <DescriptionListTerm>Tittel</DescriptionListTerm>
+      <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+      <DescriptionListTerm>Tittel</DescriptionListTerm>
+      <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+    </DescriptionList>
+  ),
+};
 export const Overview: Story = {
   decorators: Story => (
-    <StoryTemplate
-      display="grid"
-      title="DescriptionList - overview"
-      gap="30px"
-      $columnsAmount={2}
-    >
+    <StoryTemplate display="grid" gap="30px" $columnsAmount={2}>
       <Story />
     </StoryTemplate>
   ),
@@ -80,25 +90,9 @@ export const Overview: Story = {
   ),
 };
 
-export const Default: Story = {
-  decorators: Story => (
-    <StoryTemplate title="DescriptionList - default">
-      <Story />
-    </StoryTemplate>
-  ),
-  render: args => (
-    <DescriptionList {...args}>
-      <DescriptionListTerm>Tittel</DescriptionListTerm>
-      <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-      <DescriptionListTerm>Tittel</DescriptionListTerm>
-      <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-    </DescriptionList>
-  ),
-};
-
 export const Group: Story = {
   decorators: Story => (
-    <StoryTemplate title="DescriptionList - group">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -129,7 +123,7 @@ export const Group: Story = {
 
 export const WithIcon: Story = {
   decorators: Story => (
-    <StoryTemplate title="DescriptionList - with icon">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -146,7 +140,7 @@ export const WithIcon: Story = {
 const margin = tokens.spacing.SizesDdsSpacingX1;
 export const RowDirectionExample: Story = {
   decorators: Story => (
-    <StoryTemplate title="DescriptionList - flere kolonner">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Divider/Divider.stories.tsx
+++ b/packages/components/src/components/Divider/Divider.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof Divider>;
 
 export const Overview: Story = {
   decorators: Story => (
-    <StoryTemplate title="Divider - overview" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -34,7 +34,7 @@ export const Overview: Story = {
 
 export const Default: Story = {
   decorators: Story => (
-    <StoryTemplate title="Divider - default" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -42,7 +42,7 @@ export const Default: Story = {
 
 export const Example: Story = {
   decorators: Story => (
-    <StoryTemplate title="Divider - example">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/components/src/components/Drawer/Drawer.stories.tsx
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof Drawer>;
 export const Default: Story = {
   args: { header: 'Tittel' },
   decorators: Story => (
-    <StoryTemplate title="Drawer - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -46,7 +46,7 @@ export const Default: Story = {
 export const OverviewPlacement: Story = {
   args: { header: 'Tittel' },
   decorators: Story => (
-    <StoryTemplate title="Drawer - placement overview">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -73,7 +73,7 @@ export const OverviewPlacement: Story = {
 export const OverviewSizes: Story = {
   args: { header: 'Rettsmekling' },
   decorators: Story => (
-    <StoryTemplate title="Drawer - size overview">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -158,13 +158,13 @@ export const OverviewSizes: Story = {
 export const LongContent: Story = {
   args: { header: 'Rettsmekling' },
   decorators: Story => (
-    <StoryTemplate title="Drawer - long content">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
   render: args => (
     <DrawerGroup>
-      <Button>Åpne</Button>
+      <Button>Åpne lang</Button>
       <Drawer {...args}>
         <div>
           <Paragraph withMargins>

--- a/packages/components/src/components/EmptyContent/EmptyContent.stories.tsx
+++ b/packages/components/src/components/EmptyContent/EmptyContent.stories.tsx
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof EmptyContent>;
 export const Default: Story = {
   args: { title: 'Tittel', message: 'Dette er en tekst.' },
   decorators: Story => (
-    <StoryTemplate title="EmptyContent - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -34,7 +34,7 @@ export const Default: Story = {
 export const Overview: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="EmptyContent - overview">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/FavStar/FavStar.stories.tsx
+++ b/packages/components/src/components/FavStar/FavStar.stories.tsx
@@ -38,7 +38,7 @@ type Story = StoryObj<typeof FavStar>;
 export const Default: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="FavStar - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -47,7 +47,7 @@ export const Default: Story = {
 export const OverviewSizes: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="FavStar - overview sizes">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -72,7 +72,7 @@ export const OverviewSizes: Story = {
 export const Controlled: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="FavStar - controlled">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -94,7 +94,7 @@ export const Controlled: Story = {
 export const UsingRef: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="FavStar - using ref">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -112,7 +112,7 @@ export const UsingRef: Story = {
 export const RealWorld: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="FavStar - real world">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Feedback/Feedback.stories.tsx
+++ b/packages/components/src/components/Feedback/Feedback.stories.tsx
@@ -69,7 +69,7 @@ type Story = StoryObj<typeof Feedback>;
 export const Default: Story = {
   args: { ratingLabel: 'Hva syns du om tjenesten?' },
   decorators: Story => (
-    <StoryTemplate title="Feedback - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -78,7 +78,7 @@ export const Default: Story = {
 export const HorizontalLayout: Story = {
   args: { ratingLabel: 'Hva syns du om tjenesten?', layout: 'horizontal' },
   decorators: Story => (
-    <StoryTemplate title="Feedback - horizontal layout">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -90,7 +90,7 @@ export const WithoutTextArea: Story = {
     feedbackTextAreaExcluded: true,
   },
   decorators: Story => (
-    <StoryTemplate title="Feedback - without text area">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -103,7 +103,7 @@ export const CustomLabels: Story = {
     negativeFeedbackLabel: 'Min egen negative label',
   },
   decorators: Story => (
-    <StoryTemplate title="Feedback - custom labels">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -125,7 +125,7 @@ export const CustomButtonTooltip: Story = {
     thumbDownTooltip: 'Liker ikke',
   },
   decorators: Story => (
-    <StoryTemplate title="Feedback - custom button tooltip">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -136,7 +136,7 @@ export const LoadingState: Story = {
     ratingLabel: 'Hva synes du om tjenesten?',
   },
   decorators: Story => (
-    <StoryTemplate title="Feedback - loading">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/FileUploader/FileUploader.stories.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.stories.tsx
@@ -31,7 +31,7 @@ type Story = StoryObj<typeof FileUploader>;
 export const Default: Story = {
   args: { label: 'Last opp fil' },
   decorators: Story => (
-    <StoryTemplate title="FileUploader - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -118,7 +118,7 @@ const WithErrorMessage = () => {
 export const Overview: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="FileUploader - overview">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -134,7 +134,7 @@ export const Overview: Story = {
 export const NoZone: Story = {
   args: { label: 'Last opp fil' },
   decorators: Story => (
-    <StoryTemplate title="FileUploader - no drag & drop zone">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -146,7 +146,7 @@ export const NoZone: Story = {
 export const Pdf: Story = {
   args: { label: 'Last opp fil', tip: 'Kun PDF-filer' },
   decorators: Story => (
-    <StoryTemplate title="FileUploader - PDF">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/GlobalMessage/GlobalMessage.stories.tsx
+++ b/packages/components/src/components/GlobalMessage/GlobalMessage.stories.tsx
@@ -27,7 +27,7 @@ export const Default: Story = {
     message: 'En tilfeldig melding',
   },
   decorators: Story => (
-    <StoryTemplate title="GlobalMessage - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -36,12 +36,12 @@ export const Default: Story = {
 export const Overview: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="GlobalMessage - overview">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
   render: args => (
-    <VStack>
+    <VStack gap="x1">
       <GlobalMessage {...args} purpose="info" message="En tilfeldig melding" />
       <GlobalMessage
         {...args}
@@ -82,7 +82,7 @@ export const Closable: Story = {
     closable: true,
   },
   decorators: Story => (
-    <StoryTemplate title="GlobalMessage - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Grid/Grid.stories.tsx
+++ b/packages/components/src/components/Grid/Grid.stories.tsx
@@ -117,7 +117,7 @@ export const PageExample: Story = {
 export const JustRelativeColumns: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Grid - just relative columns" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Icon/Icon.stories.tsx
+++ b/packages/components/src/components/Icon/Icon.stories.tsx
@@ -21,12 +21,14 @@ export default {
 
 type Story = StoryObj<typeof Icon>;
 
+const icon = OpenExternal;
+
 export const Default: Story = {
   args: {
-    icon: OpenExternal,
+    icon,
   },
   decorators: Story => (
-    <StoryTemplate title="Icon - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -34,10 +36,10 @@ export const Default: Story = {
 
 export const Overview: Story = {
   args: {
-    icon: OpenExternal,
+    icon,
   },
   decorators: Story => (
-    <StoryTemplate title="Icon - overview" display="grid" $columnsAmount={4}>
+    <StoryTemplate display="grid" $columnsAmount={4}>
       <Story />
     </StoryTemplate>
   ),
@@ -53,16 +55,23 @@ export const Overview: Story = {
 
 export const Inherit: Story = {
   args: {
-    icon: OpenExternal,
+    icon,
     iconSize: 'inherit',
   },
   decorators: Story => (
-    <StoryTemplate title="Icon - inherit">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
   render: args => (
-    <p style={{ display: 'flex', alignItems: 'center', fontSize: '20px' }}>
+    <p
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '4px',
+        fontSize: '20px',
+      }}
+    >
       <Icon {...args} />
       Tekst
     </p>

--- a/packages/components/src/components/InlineEdit/InlineEdit.stories.tsx
+++ b/packages/components/src/components/InlineEdit/InlineEdit.stories.tsx
@@ -34,7 +34,7 @@ export const OverviewInputTypes = () => {
   const [value2, setValue2] = useState('');
 
   return (
-    <StoryTemplate title="InlineEdit - overview input types">
+    <StoryTemplate>
       <InlineEditInput value={value} onSetValue={setValue} />
       <InlineEditTextArea value={value2} onSetValue={setValue2} />
     </StoryTemplate>

--- a/packages/components/src/components/InlineEdit/InlineEditInput.stories.tsx
+++ b/packages/components/src/components/InlineEdit/InlineEditInput.stories.tsx
@@ -30,7 +30,7 @@ export const Overview = (args: InlineEditInputProps) => {
   const [value5, setValue5] = useState('tømbar');
   const [value6, setValue6] = useState('uten ikon');
   return (
-    <StoryTemplate title="InlineEditInput - overview">
+    <StoryTemplate>
       <InlineEditInput {...args} value={value} onSetValue={setValue} />
       <InlineEditInput {...args} onSetValue={setValue2} value={value2} />
       <InlineEditInput {...args} onSetValue={setValue3} value={value3} error />
@@ -59,7 +59,7 @@ export const Overview = (args: InlineEditInputProps) => {
 export const Default = (args: InlineEditInputProps) => {
   const [value, setValue] = useState('');
   return (
-    <StoryTemplate title="InlineEditInput - default" display="block">
+    <StoryTemplate display="block">
       <InlineEditInput {...args} value={value} onSetValue={setValue} />
     </StoryTemplate>
   );
@@ -69,7 +69,7 @@ export const InTable = () => {
   const [value, setValue] = useState();
   const [value2, setValue2] = useState();
   return (
-    <StoryTemplate title="InlineEditInput - in table" display="block">
+    <StoryTemplate display="block">
       <Table.Wrapper>
         <Table>
           <Table.Head>

--- a/packages/components/src/components/InlineEdit/InlineEditTextArea.stories.tsx
+++ b/packages/components/src/components/InlineEdit/InlineEditTextArea.stories.tsx
@@ -30,7 +30,7 @@ export const Overview = (args: InlineEditTextAreaProps) => {
   const [value5, setValue5] = useState('tømbar');
   const [value6, setValue6] = useState('uten ikon');
   return (
-    <StoryTemplate title="InlineEditTextArea - overview">
+    <StoryTemplate>
       <InlineEditTextArea {...args} value={value} onSetValue={setValue} />
       <InlineEditTextArea {...args} onSetValue={setValue2} value={value2} />
       <InlineEditTextArea
@@ -64,7 +64,7 @@ export const Overview = (args: InlineEditTextAreaProps) => {
 export const Default = (args: InlineEditTextAreaProps) => {
   const [value, setValue] = useState('');
   return (
-    <StoryTemplate title="InlineEditTextArea - default" display="block">
+    <StoryTemplate display="block">
       <InlineEditTextArea {...args} value={value} onSetValue={setValue} />
     </StoryTemplate>
   );
@@ -74,7 +74,7 @@ export const InTable = () => {
   const [value, setValue] = useState();
   const [value2, setValue2] = useState();
   return (
-    <StoryTemplate title="InlineEditTextArea - in table" display="block">
+    <StoryTemplate display="block">
       <Table.Wrapper>
         <Table>
           <Table.Head>

--- a/packages/components/src/components/InputMessage/InputMessage.stories.tsx
+++ b/packages/components/src/components/InputMessage/InputMessage.stories.tsx
@@ -25,7 +25,7 @@ export const Default: Story = {
     message: 'feilmelding',
   },
   decorators: Story => (
-    <StoryTemplate title="InputMessage - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -33,7 +33,7 @@ export const Default: Story = {
 
 export const Overview: Story = {
   decorators: Story => (
-    <StoryTemplate title="InputMessage - overview">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/InternalHeader/InternalHeader.mdx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.mdx
@@ -73,7 +73,7 @@ applikasjoner vil være tilgjengelige ved å trykke på det som i dag er navn p�
 
 ## Varianter
 
-<Primary />
+### Navigasjon og kontekstmeny
 
 <Canvas>
   <Story
@@ -81,6 +81,8 @@ applikasjoner vil være tilgjengelige ved å trykke på det som i dag er navn p�
     height="400px"
   />
 </Canvas>
+
+### Navigasjon og kontekstmeny - liten skjerm
 
 <Canvas>
   <Story

--- a/packages/components/src/components/InternalHeader/InternalHeader.stories.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.stories.tsx
@@ -69,7 +69,7 @@ export const Default: Story = {
     applicationDesc: 'Produktnavn',
   },
   decorators: Story => (
-    <StoryTemplate title="InternalHeader - default" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -81,11 +81,7 @@ export const Overview: Story = {
     applicationDesc: 'Produktnavn',
   },
   decorators: Story => (
-    <StoryTemplate
-      title="InternalHeader - overview"
-      gap="40px"
-      containerStyle={{ alignItems: 'stretch' }}
-    >
+    <StoryTemplate gap="40px" containerStyle={{ alignItems: 'stretch' }}>
       <Story />
     </StoryTemplate>
   ),
@@ -147,10 +143,7 @@ export const WithNavigationAndContextMenu: Story = {
     userProps: user,
   },
   decorators: Story => (
-    <StoryTemplate
-      title="InternalHeader - with nav and context menu"
-      display="block"
-    >
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -166,7 +159,7 @@ export const WithCurrentPage: Story = {
     currentPageHref: '#',
   },
   decorators: Story => (
-    <StoryTemplate title="InternalHeader - with current page" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -180,10 +173,7 @@ export const SmallScreenWithNavigation: Story = {
     smallScreen: true,
   },
   decorators: Story => (
-    <StoryTemplate
-      title="InternalHeader - small screen with navigation"
-      display="block"
-    >
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -197,10 +187,7 @@ export const SmallScreenWithContextMenu: Story = {
     smallScreen: true,
   },
   decorators: Story => (
-    <StoryTemplate
-      title="InternalHeader - small screen with context menu"
-      display="block"
-    >
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -216,10 +203,7 @@ export const SmallScreenWithNavigationAndContextMenu: Story = {
     smallScreen: true,
   },
   decorators: Story => (
-    <StoryTemplate
-      title="InternalHeader - small screen with navigation and context menu"
-      display="block"
-    >
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -231,7 +215,7 @@ export const WithNavigationLongLink: Story = {
     navigationElements: navigationLinksWithLong,
   },
   decorators: Story => (
-    <StoryTemplate title="InternalHeader - with long link" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -244,10 +228,7 @@ export const NonInteractiveUserOnly: Story = {
     userProps: user,
   },
   decorators: Story => (
-    <StoryTemplate
-      title="InternalHeader - non-interactive user only"
-      display="block"
-    >
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/List/List.stories.tsx
+++ b/packages/components/src/components/List/List.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof List>;
 
 export const Default: Story = {
   decorators: Story => (
-    <StoryTemplate title="List - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -35,7 +35,7 @@ export const Default: Story = {
 
 export const Overview: Story = {
   decorators: Story => (
-    <StoryTemplate title="List - overview" display="grid" $columnsAmount={4}>
+    <StoryTemplate display="grid" $columnsAmount={4}>
       <Story />
     </StoryTemplate>
   ),
@@ -190,7 +190,7 @@ export const Overview: Story = {
 
 export const Nested: Story = {
   decorators: Story => (
-    <StoryTemplate title="List - nested">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -217,7 +217,7 @@ export const Nested: Story = {
 
 export const Example: Story = {
   decorators: Story => (
-    <StoryTemplate title="List - example">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/LocalMessage/LocalMessage.stories.tsx
+++ b/packages/components/src/components/LocalMessage/LocalMessage.stories.tsx
@@ -3,6 +3,7 @@ import { type StoryObj } from '@storybook/react';
 
 import { LocalMessage } from './LocalMessage';
 import { List, ListItem } from '../List';
+import { HStack, VStack } from '../Stack';
 import { Typography } from '../Typography';
 
 export default {
@@ -31,7 +32,7 @@ export const Default: Story = {
     children: 'Dette er en lokal melding',
   },
   decorators: Story => (
-    <StoryTemplate title="LocalMessage - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -42,26 +43,32 @@ export const Overview: Story = {
     children: 'Dette er en lokal melding',
   },
   decorators: Story => (
-    <StoryTemplate title="LocalMessage - overview">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
   render: args => (
     <>
-      <LocalMessage {...args} purpose="info" />
-      <LocalMessage {...args} purpose="warning" />
-      <LocalMessage {...args} purpose="danger" />
-      <LocalMessage {...args} purpose="confidential" />
-      <LocalMessage {...args} purpose="success" />
-      <LocalMessage {...args} purpose="tips" />
-      <LocalMessage {...args} layout="vertical" />
-      <LocalMessage {...args} purpose="info" closable />
-      <LocalMessage {...args} purpose="warning" closable />
-      <LocalMessage {...args} purpose="danger" closable />
-      <LocalMessage {...args} purpose="confidential" closable />
-      <LocalMessage {...args} purpose="success" closable />
-      <LocalMessage {...args} purpose="tips" closable />
-      <LocalMessage {...args} layout="vertical" closable />
+      <HStack gap="x1">
+        <VStack gap="x0.75" align="start">
+          <LocalMessage {...args} purpose="info" />
+          <LocalMessage {...args} purpose="success" />
+          <LocalMessage {...args} purpose="warning" />
+          <LocalMessage {...args} purpose="danger" />
+          <LocalMessage {...args} purpose="confidential" />
+          <LocalMessage {...args} purpose="tips" />
+          <LocalMessage {...args} layout="vertical" />
+        </VStack>
+        <VStack gap="x0.75" align="start">
+          <LocalMessage {...args} purpose="info" closable />
+          <LocalMessage {...args} purpose="success" closable />
+          <LocalMessage {...args} purpose="warning" closable />
+          <LocalMessage {...args} purpose="danger" closable />
+          <LocalMessage {...args} purpose="confidential" closable />
+          <LocalMessage {...args} purpose="tips" closable />
+          <LocalMessage {...args} layout="vertical" closable />
+        </VStack>
+      </HStack>
     </>
   ),
 };
@@ -72,7 +79,7 @@ export const Closable: Story = {
     closable: true,
   },
   decorators: Story => (
-    <StoryTemplate title="LocalMessage - closable">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -81,7 +88,7 @@ export const Closable: Story = {
 export const ComplexContent: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="LocalMessage - complex content">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Modal/Modal.stories.tsx
+++ b/packages/components/src/components/Modal/Modal.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof Modal>;
 export const Default: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Modal - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -64,7 +64,7 @@ export const Default: Story = {
 export const Overview: Story = {
   args: { header: 'Tittel', onClose: undefined },
   decorators: Story => (
-    <StoryTemplate title="Modal - overview">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -120,7 +120,7 @@ export const Overview: Story = {
 export const NoActionButtons: Story = {
   args: { header: 'Info' },
   decorators: Story => (
-    <StoryTemplate title="Modal - no action buttons">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -152,7 +152,7 @@ export const NoActionButtons: Story = {
 export const Scrollable: Story = {
   args: { header: 'Fritt valg av forsvarer' },
   decorators: Story => (
-    <StoryTemplate title="Modal - scrollable">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -198,7 +198,7 @@ export const Scrollable: Story = {
 export const WithInitialFocus: Story = {
   args: { header: 'Søk etter sak' },
   decorators: Story => (
-    <StoryTemplate title="Modal - with initial focus">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/OverflowMenu/OverflowMenu.mdx
+++ b/packages/components/src/components/OverflowMenu/OverflowMenu.mdx
@@ -80,7 +80,7 @@ const items = [
 Hovedkomponenten `<OverflowMenu/>`.
 
 <Canvas>
-  <Story of={OverflowMenuStories.Default} height="300px" />
+  <Story of={OverflowMenuStories.Default} height="210px" />
 </Canvas>
 <Controls of={OverflowMenuStories.Default} />
 
@@ -129,3 +129,26 @@ I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes
 En wrapper som håndterer åpning, lukking, ARIA og refs for trigger-elementet og `<OverflowMenu />` ut av boksen. Den skal ha anchor-elementet som første barn og `<OverflowMenu />` som andre barn. Ikke obligatorisk, men da må oppførsel osv. håndteres utenfor komponenten.
 
 <ArgTypes of={OverflowMenuGroup} />
+
+## Eksempler
+
+### Med interaktiv bruker
+
+<Canvas>
+  <Story of={OverflowMenuStories.WithInteractiveUser} height="240px" />
+</Canvas>
+### Med navigasjon
+<Canvas>
+  <Story of={OverflowMenuStories.WithNavigation} height="320px" />
+</Canvas>
+### Med statisk bruker
+<Canvas>
+  <Story of={OverflowMenuStories.WithStaticUser} height="250px" />
+</Canvas>
+### Med navigasjon og interaktiv bruker
+<Canvas>
+  <Story
+    of={OverflowMenuStories.WithNavigationAndInteractiveUser}
+    height="360px"
+  />
+</Canvas>

--- a/packages/components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -56,7 +56,7 @@ export const Default: Story = {
     items,
   },
   decorators: Story => (
-    <StoryTemplate title="OverflowMenu - default" display="flex-centered">
+    <StoryTemplate display="flex-centered">
       <Story />
     </StoryTemplate>
   ),
@@ -74,10 +74,7 @@ export const WithStaticUser: Story = {
     userProps: { name: 'Brukernavn' },
   },
   decorators: Story => (
-    <StoryTemplate
-      title="OverflowMenu - with static user"
-      display="flex-centered"
-    >
+    <StoryTemplate display="flex-centered">
       <Story />
     </StoryTemplate>
   ),
@@ -95,10 +92,7 @@ export const WithInteractiveUser: Story = {
     userProps: { name: 'Brukernavn', onClick: () => null },
   },
   decorators: Story => (
-    <StoryTemplate
-      title="OverflowMenu - with interactive user"
-      display="flex-centered"
-    >
+    <StoryTemplate display="flex-centered">
       <Story />
     </StoryTemplate>
   ),
@@ -116,10 +110,7 @@ export const WithNavigation: Story = {
     navItems,
   },
   decorators: Story => (
-    <StoryTemplate
-      title="OverflowMenu - with navigation"
-      display="flex-centered"
-    >
+    <StoryTemplate display="flex-centered">
       <Story />
     </StoryTemplate>
   ),
@@ -138,10 +129,7 @@ export const WithNavigationAndInteractiveUser: Story = {
     userProps: { name: 'Brukernavn', onClick: () => null },
   },
   decorators: Story => (
-    <StoryTemplate
-      title="OverflowMenu - with navigation and interactive user"
-      display="flex-centered"
-    >
+    <StoryTemplate display="flex-centered">
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Pagination/Pagination.mdx
+++ b/packages/components/src/components/Pagination/Pagination.mdx
@@ -36,3 +36,17 @@ I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes
 ### Indeksering
 
 Det brukes 1-indeksering slik at sidenummeret blir brukt som label i knappene.
+
+## Eksempler
+
+### Custom options
+
+<Canvas of={PaginationStories.CustomOptions} />
+
+### Default aktiv side
+
+<Canvas of={PaginationStories.DefaultActivePage} />
+
+### Default antall elementer per side
+
+<Canvas of={PaginationStories.DefaultItemsPerPage} />

--- a/packages/components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/components/src/components/Pagination/Pagination.stories.tsx
@@ -35,7 +35,7 @@ type Story = StoryObj<typeof Pagination>;
 export const Default: Story = {
   args: { itemsAmount: 100 },
   decorators: Story => (
-    <StoryTemplate title="Pagination - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -44,28 +44,15 @@ export const Default: Story = {
 export const Overview: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Pagination - overview">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
   render: args => (
-    <VStack gap="x2">
-      <Pagination {...args} itemsAmount={70} />
+    <VStack gap="x3" align="start">
       <Pagination {...args} itemsAmount={100} />
-      <Pagination {...args} defaultActivePage={6} itemsAmount={100} />
+
       <Pagination {...args} withCounter itemsAmount={100} />
-      <Pagination
-        {...args}
-        withCounter
-        defaultItemsPerPage={20}
-        itemsAmount={100}
-      />
-      <Pagination
-        {...args}
-        withPagination={false}
-        withCounter
-        itemsAmount={100}
-      />
       <Pagination {...args} withSelect itemsAmount={100} />
       <Pagination {...args} withCounter withSelect itemsAmount={100} />
       <Pagination
@@ -77,11 +64,9 @@ export const Overview: Story = {
       />
       <Pagination
         {...args}
+        withPagination={false}
         withCounter
-        withSelect
-        defaultItemsPerPage={customOptions[0].value}
-        selectOptions={customOptions}
-        itemsAmount={customOptionsItemsAmount}
+        itemsAmount={100}
       />
     </VStack>
   ),
@@ -90,12 +75,12 @@ export const Overview: Story = {
 export const OverviewMobile: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Pagination - overview mobile">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
   render: args => (
-    <VStack gap="x2">
+    <VStack gap="x3">
       <Pagination {...args} smallScreen itemsAmount={100} />
       <Pagination {...args} smallScreen withCounter itemsAmount={100} />
       <Pagination
@@ -113,4 +98,43 @@ export const OverviewMobile: Story = {
       />
     </VStack>
   ),
+};
+
+export const CustomOptions: Story = {
+  args: { itemsAmount: 100 },
+  decorators: Story => (
+    <StoryTemplate>
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <Pagination
+      {...args}
+      withCounter
+      withSelect
+      defaultItemsPerPage={customOptions[0].value}
+      selectOptions={customOptions}
+      itemsAmount={customOptionsItemsAmount}
+    />
+  ),
+};
+
+export const DefaultActivePage: Story = {
+  args: { itemsAmount: 100 },
+  decorators: Story => (
+    <StoryTemplate>
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => <Pagination {...args} defaultActivePage={6} />,
+};
+
+export const DefaultItemsPerPage: Story = {
+  args: { itemsAmount: 100 },
+  decorators: Story => (
+    <StoryTemplate>
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => <Pagination {...args} withCounter defaultItemsPerPage={48} />,
 };

--- a/packages/components/src/components/Popover/Popover.mdx
+++ b/packages/components/src/components/Popover/Popover.mdx
@@ -31,7 +31,7 @@ Komponenten består av tre elementer:
 Selve popover-elementet. Den åpnes når anchor-elementet trykkes, og den lukkes ved å trykke på anchor-elementet igjen, Esc-tast, lukkeknapptrykk og onBlur.
 
 <Canvas>
-  <Story of={PopoverStories.Default} height="350px" />
+  <Story of={PopoverStories.Default} height="280px" />
 </Canvas>
 <Controls of={PopoverStories.Default} />
 
@@ -55,7 +55,7 @@ Selve popover-elementet. Den åpnes når anchor-elementet trykkes, og den lukkes
 Det kan være relevant å begrense størrelsen på Popover slik at ikke hele teksten vises ved overflow. Da bør den synlige teksten avsluttes med en ellipse:
 
 <Canvas>
-  <Story height="350px" of={PopoverStories.Overflow} />
+  <Story height="300px" of={PopoverStories.Overflow} />
 </Canvas>
 
 For å oppnå det kan du sette sizeProps til ønskede verdier og gi tekstelementet som

--- a/packages/components/src/components/Popover/Popover.stories.tsx
+++ b/packages/components/src/components/Popover/Popover.stories.tsx
@@ -36,7 +36,7 @@ type Story = StoryObj<typeof Popover>;
 export const Default: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Popover - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -58,7 +58,7 @@ export const Default: Story = {
 export const ContentOverview: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Popover - content overview" display="grid">
+    <StoryTemplate display="grid">
       <Story />
     </StoryTemplate>
   ),
@@ -117,7 +117,6 @@ export const PlacementOverview: Story = {
   args: {},
   decorators: Story => (
     <StoryTemplate
-      title="Popover - placement overview"
       display="grid"
       $columnsAmount={4}
       containerStyle={{
@@ -162,7 +161,7 @@ export const PlacementOverview: Story = {
 export const Overflow: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Popover - overflow" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -191,7 +190,7 @@ export const Overflow: Story = {
 export const InlineExample: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Popover - inline example" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/ProgressTracker/ProgressTracker.stories.tsx
+++ b/packages/components/src/components/ProgressTracker/ProgressTracker.stories.tsx
@@ -36,7 +36,7 @@ type Story = StoryObj<typeof ProgressTracker>;
 export const Overview: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="ProgressTracker - overview">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -93,7 +93,7 @@ export const Overview: Story = {
 export const WithIcons: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="ProgressTracker - with icons">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -163,7 +163,7 @@ export const WithIcons: Story = {
 export const FutureStepsDisabled: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="ProgressTracker - future steps disabled">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -225,10 +225,10 @@ export const FutureStepsDisabled: Story = {
   },
 };
 
-export const Mobile: Story = {
+export const SmallScreen: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="ProgressTracker - mobile">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -325,7 +325,7 @@ const DesktopOnly = styled.div`
 export const RealWorldExample: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="ProgressTracker - real world example">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/ScrollableContainer/ScrollableContainer.mdx
+++ b/packages/components/src/components/ScrollableContainer/ScrollableContainer.mdx
@@ -55,38 +55,6 @@ Alenestående scrollbar til mer custom bruk.
 
 ### Kun med `<Scrollbar />`
 
-Ved bruk av kun `<Scrollbar />` må man håndtere styling av containere, kobling til innholdet, plasseringen av `<Scrollbar/>` og fokus.
+Ved bruk av kun `<Scrollbar />` må man håndtere styling av containere, kobling til innholdet, plasseringen av `<Scrollbar/>` og fokus. Se koden i eksempelet.
 
-<Source
-  code={`import { Scrollbar, focusVisible } from '@norges-domstoler/dds-components';
-import { useRef } from 'React';
-import styled fromf 'styled-components';
-
-const containerStyle = {
-display: 'grid',
-gridTemplate: 'auto / 1fr 20px',
-overflow: 'hidden'
-};
-
-const Content = styled.div\`
-height: 500px;
-overflow: auto;
-scrollbar-width: none;
-::-webkit-scrollbar {
-display: none;
-}
-:focus-visible {
-\${focusVisible}
-}
-\`;
-
-const contentRef = useRef();
-
-<div style={containerStyle}>
-  <Content tabIndex={0}>
-    <p>lang tekst</p>
-    <p>lang tekst</p>
-  </Content>
-  <Scrollbar />
-</div>
-`} />
+<Canvas of={ScrollableContainerStories.JustScrollbar} sourceState="shown" />

--- a/packages/components/src/components/ScrollableContainer/ScrollableContainer.stories.tsx
+++ b/packages/components/src/components/ScrollableContainer/ScrollableContainer.stories.tsx
@@ -1,7 +1,7 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
 import { type StoryObj } from '@storybook/react';
+import { type Property } from 'csstype';
 import { type CSSProperties, useRef } from 'react';
-import styled from 'styled-components';
 
 import { focusVisible } from '../helpers';
 
@@ -26,40 +26,12 @@ type Story = StoryObj<typeof ScrollableContainer>;
 export const Default: Story = {
   args: { contentHeight: '300px' },
   decorators: Story => (
-    <StoryTemplate title="ScrollableContainer - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
   render: args => (
     <ScrollableContainer {...args}>
-      <p>
-        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
-        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
-        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
-        (hovedforhandling).
-      </p>
-      <p>
-        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
-        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
-        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
-        (hovedforhandling).
-      </p>
-      <p>
-        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
-        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
-        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
-        (hovedforhandling).
-      </p>
-      <p>
-        Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
-        begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
-        for eventuell hjelp fra sakkyndig psykolog underveis. Hvis dere ikke
-        blir enige gjennom mekling, innkaller retten til et nytt rettsmøte
-        (hovedforhandling).
-      </p>
       <p>
         Hvis både du og den andre forelderen ønsker å forsøke mekling, kan det
         begrense kostnadene veldig. Under hele meklingsprosessen betaler staten
@@ -151,11 +123,12 @@ export const Default: Story = {
 export const JustScrollbar: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="ScrollableContainer - just scrollbar">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
-  render: () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  render: args => {
     const contentRef = useRef<HTMLDivElement>(null);
     const containerStyle: CSSProperties = {
       display: 'grid',
@@ -164,21 +137,21 @@ export const JustScrollbar: Story = {
       padding: '4px',
     };
 
-    const ContentContainer = styled.div`
-      height: 500px;
-      overflow: auto;
-      scrollbar-width: none;
-      ::-webkit-scrollbar {
-        display: none;
-      }
-      :focus-visible {
-        ${focusVisible};
-      }
-    `;
+    const contentContainerStyle = {
+      height: '300px',
+      overflow: 'auto',
+      scrollbarWidth: 'none' as Property.ScrollbarWidth,
+      '&::WebkitScrollbar': {
+        display: 'none',
+      },
+      ':focus-visible': {
+        ...focusVisible,
+      },
+    };
 
     return (
       <div style={containerStyle}>
-        <ContentContainer ref={contentRef} tabIndex={0}>
+        <div style={contentContainerStyle} ref={contentRef} tabIndex={0}>
           <p>
             Hvis både du og den andre forelderen ønsker å forsøke mekling, kan
             det begrense kostnadene veldig. Under hele meklingsprosessen betaler
@@ -228,70 +201,7 @@ export const JustScrollbar: Story = {
             dere ikke blir enige gjennom mekling, innkaller retten til et nytt
             rettsmøte (hovedforhandling).
           </p>
-          <p>
-            Hvis både du og den andre forelderen ønsker å forsøke mekling, kan
-            det begrense kostnadene veldig. Under hele meklingsprosessen betaler
-            staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis
-            dere ikke blir enige gjennom mekling, innkaller retten til et nytt
-            rettsmøte (hovedforhandling).
-          </p>
-          <p>
-            Hvis både du og den andre forelderen ønsker å forsøke mekling, kan
-            det begrense kostnadene veldig. Under hele meklingsprosessen betaler
-            staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis
-            dere ikke blir enige gjennom mekling, innkaller retten til et nytt
-            rettsmøte (hovedforhandling).
-          </p>
-          <p>
-            Hvis både du og den andre forelderen ønsker å forsøke mekling, kan
-            det begrense kostnadene veldig. Under hele meklingsprosessen betaler
-            staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis
-            dere ikke blir enige gjennom mekling, innkaller retten til et nytt
-            rettsmøte (hovedforhandling).
-          </p>
-          <p>
-            Hvis både du og den andre forelderen ønsker å forsøke mekling, kan
-            det begrense kostnadene veldig. Under hele meklingsprosessen betaler
-            staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis
-            dere ikke blir enige gjennom mekling, innkaller retten til et nytt
-            rettsmøte (hovedforhandling).
-          </p>
-          <p>
-            Hvis både du og den andre forelderen ønsker å forsøke mekling, kan
-            det begrense kostnadene veldig. Under hele meklingsprosessen betaler
-            staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis
-            dere ikke blir enige gjennom mekling, innkaller retten til et nytt
-            rettsmøte (hovedforhandling).
-          </p>
-          <p>
-            Hvis både du og den andre forelderen ønsker å forsøke mekling, kan
-            det begrense kostnadene veldig. Under hele meklingsprosessen betaler
-            staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis
-            dere ikke blir enige gjennom mekling, innkaller retten til et nytt
-            rettsmøte (hovedforhandling).
-          </p>
-          <p>
-            Hvis både du og den andre forelderen ønsker å forsøke mekling, kan
-            det begrense kostnadene veldig. Under hele meklingsprosessen betaler
-            staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis
-            dere ikke blir enige gjennom mekling, innkaller retten til et nytt
-            rettsmøte (hovedforhandling).
-          </p>
-          <p>
-            Hvis både du og den andre forelderen ønsker å forsøke mekling, kan
-            det begrense kostnadene veldig. Under hele meklingsprosessen betaler
-            staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis
-            dere ikke blir enige gjennom mekling, innkaller retten til et nytt
-            rettsmøte (hovedforhandling).
-          </p>
-          <p>
-            Hvis både du og den andre forelderen ønsker å forsøke mekling, kan
-            det begrense kostnadene veldig. Under hele meklingsprosessen betaler
-            staten for eventuell hjelp fra sakkyndig psykolog underveis. Hvis
-            dere ikke blir enige gjennom mekling, innkaller retten til et nytt
-            rettsmøte (hovedforhandling).
-          </p>
-        </ContentContainer>
+        </div>
         <Scrollbar contentRef={contentRef} />
       </div>
     );

--- a/packages/components/src/components/Search/Search.mdx
+++ b/packages/components/src/components/Search/Search.mdx
@@ -49,7 +49,7 @@ Følgende komponenter er tilgjengelige:
 En wrapper som håndterer autofullføring. Skal ha `<Search>` som barn.
 
 <Canvas>
-  <Story of={SearchStories.WithSuggestions} height="470px" />
+  <Story of={SearchStories.WithSuggestions} height="440px" />
 </Canvas>
 <ArgTypes of={Search.AutocompleteWrapper} />
 

--- a/packages/components/src/components/Search/Search.stories.tsx
+++ b/packages/components/src/components/Search/Search.stories.tsx
@@ -42,7 +42,7 @@ type Story = StoryObj<typeof Search>;
 export const Default: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Search - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -51,7 +51,7 @@ export const Default: Story = {
 export const Overview: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Search - overview">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -102,11 +102,7 @@ export const Overview: Story = {
 export const OverviewSizes: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate
-      title="Search - overview sizes"
-      display="grid"
-      $columnsAmount={2}
-    >
+    <StoryTemplate display="grid" $columnsAmount={2}>
       <Story />
     </StoryTemplate>
   ),
@@ -137,7 +133,7 @@ export const OverviewSizes: Story = {
 export const OverviewWithSuggestion: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Search - overview with suggestion">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -159,7 +155,7 @@ export const OverviewWithSuggestion: Story = {
 export const WithButton: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Search - with button">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -171,7 +167,7 @@ export const WithButton: Story = {
 export const WithSuggestions: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="Search - with suggestions">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Select/MultiSelect.stories.tsx
+++ b/packages/components/src/components/Select/MultiSelect.stories.tsx
@@ -42,12 +42,7 @@ type MultiSelectProps = SelectProps<Option, true>;
 
 export const Overview = (args: MultiSelectProps) => {
   return (
-    <StoryTemplate
-      title="Multiselect - overview"
-      gap="25px"
-      display="grid"
-      $columnsAmount={2}
-    >
+    <StoryTemplate gap="25px" display="grid" $columnsAmount={2}>
       <DDSSelect
         {...args}
         label={args.label ?? 'Label'}
@@ -112,20 +107,6 @@ export const Overview = (args: MultiSelectProps) => {
         options={options}
         isMulti
       />
-      <DDSSelect
-        {...args}
-        label={args.label ?? 'Label'}
-        defaultValue={options[0]}
-        options={options}
-        isMulti
-      />
-      <DDSSelect
-        {...args}
-        label={args.label ?? 'Label'}
-        value={options[3]}
-        options={options}
-        isMulti
-      />
       <DDSSelect {...args} options={options} isMulti />
     </StoryTemplate>
   );
@@ -133,11 +114,7 @@ export const Overview = (args: MultiSelectProps) => {
 
 export const OverviewSizes = (args: MultiSelectProps) => {
   return (
-    <StoryTemplate
-      title="MultiSelect - overview sizes"
-      display="grid"
-      $columnsAmount={2}
-    >
+    <StoryTemplate display="grid" $columnsAmount={2}>
       <DDSSelect {...args} options={options} isMulti />
       <DDSSelect {...args} options={options} isMulti icon={CourtIcon} />
       <DDSSelect {...args} options={options} isMulti componentSize="small" />
@@ -154,15 +131,7 @@ export const OverviewSizes = (args: MultiSelectProps) => {
 
 export const Default = (args: MultiSelectProps) => {
   return (
-    <StoryTemplate title="MultiSelect - default" display="block">
-      <DDSSelect {...args} options={options} isMulti />
-    </StoryTemplate>
-  );
-};
-
-export const WithLabel = (args: MultiSelectProps) => {
-  return (
-    <StoryTemplate title="MultiSelect - with label">
+    <StoryTemplate>
       <DDSSelect
         {...args}
         label={args.label ?? 'Label'}
@@ -175,7 +144,7 @@ export const WithLabel = (args: MultiSelectProps) => {
 
 export const WithDefaultValue = (args: MultiSelectProps) => {
   return (
-    <StoryTemplate title="Select - multiselect with value">
+    <StoryTemplate>
       <DDSSelect
         {...args}
         label={args.label ?? 'Label'}
@@ -187,9 +156,23 @@ export const WithDefaultValue = (args: MultiSelectProps) => {
   );
 };
 
+export const WithValue = (args: MultiSelectProps) => {
+  return (
+    <StoryTemplate>
+      <DDSSelect
+        {...args}
+        label={args.label ?? 'Label'}
+        options={options}
+        isMulti
+        value={options[0]}
+      />
+    </StoryTemplate>
+  );
+};
+
 export const WithFitContent = (args: MultiSelectProps) => {
   return (
-    <StoryTemplate title="Select - multiselect with fit content">
+    <StoryTemplate>
       <DDSSelect
         {...args}
         label={args.label ?? 'Label'}

--- a/packages/components/src/components/Select/Select.mdx
+++ b/packages/components/src/components/Select/Select.mdx
@@ -24,9 +24,9 @@ import * as MultiSelectStories from './MultiSelect.stories';
 
 Komponenten har tre varianter:
 
-- `<Select />` - nedtrekksliste
-- `<Select isMulti />` - nedtrekksliste med multivalg
-- custom `<Select />` - nedtrekksliste med custom visuelle elementer for både det valgte elemetet og alternativer i lista
+- **`<Select />`** - nedtrekksliste
+- **`<Select isMulti />`** - nedtrekksliste med multivalg
+- **Custom `<Select />`** - nedtrekksliste med custom visuelle elementer for både det valgte elemetet og alternativer i lista
 
 ## API
 
@@ -145,6 +145,14 @@ Brukeren kan filtrere alternativer ved å gi tekstlig input. Det brukes en custo
 Komponenten har default bredde. Dette gjør at valgte alternativer ved `isMulti` vil prøve å fylle opp bredden og videre legge seg nedover. Hvis det er ønsket at komponenten skal utvide seg i bredden når flere alternativer blir valgt bør det settes f.eks. `width='fit-content'` og `min-width` i styling:
 
 <Canvas of={MultiSelectStories.WithFitContent} sourceState="shown" />
+
+#### Med verdi
+
+<Canvas of={MultiSelectStories.WithValue} sourceState="shown" />
+
+#### Med default verdi
+
+<Canvas of={MultiSelectStories.WithDefaultValue} sourceState="shown" />
 
 ## Retningslinjer
 

--- a/packages/components/src/components/Select/Select.stories.tsx
+++ b/packages/components/src/components/Select/Select.stories.tsx
@@ -47,12 +47,7 @@ const optionsLong = createSelectOptions(
 
 export const Overview = (args: SelectProps) => {
   return (
-    <StoryTemplate
-      title="Select - overview"
-      gap="25px"
-      display="grid"
-      $columnsAmount={2}
-    >
+    <StoryTemplate gap="25px" display="grid" $columnsAmount={2}>
       <Select {...args} label={args.label ?? 'Label'} options={options} />
       <Select
         {...args}
@@ -117,11 +112,7 @@ export const Overview = (args: SelectProps) => {
 
 export const OverviewSizes = (args: SelectProps) => {
   return (
-    <StoryTemplate
-      title="Select - overview sizes"
-      display="grid"
-      $columnsAmount={2}
-    >
+    <StoryTemplate display="grid" $columnsAmount={2}>
       <Select {...args} componentSize="medium" options={options} />
       <Select
         {...args}
@@ -149,8 +140,8 @@ export const OverviewSizes = (args: SelectProps) => {
 
 export const Default = (args: SelectProps) => {
   return (
-    <StoryTemplate title="Select - default">
-      <Select {...args} options={options} />
+    <StoryTemplate>
+      <Select {...args} options={options} label={args.label ?? 'Label'} />
     </StoryTemplate>
   );
 };
@@ -173,23 +164,15 @@ export const WithGroups = (args: SelectProps) => {
     },
   ];
   return (
-    <StoryTemplate title="Select - with groups">
+    <StoryTemplate>
       <Select {...args} options={groupedOptions} />
-    </StoryTemplate>
-  );
-};
-
-export const WithLabel = (args: SelectProps) => {
-  return (
-    <StoryTemplate title="Select - with label">
-      <Select {...args} label={args.label ?? 'Label'} options={options} />
     </StoryTemplate>
   );
 };
 
 export const ManyItems = (args: SelectProps) => {
   return (
-    <StoryTemplate title="Select - many options">
+    <StoryTemplate>
       <Select {...args} label={args.label ?? 'Label'} options={optionsLong} />
     </StoryTemplate>
   );
@@ -204,7 +187,7 @@ export const CustomData = (
     { name: 'Endre', employeeId: 789 },
   ];
   return (
-    <StoryTemplate title="Select - custom data">
+    <StoryTemplate>
       <Select
         {...args}
         label={args.label ?? 'Saksbehandler'}

--- a/packages/components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof Checkbox>;
 
 export const Overview: Story = {
   decorators: Story => (
-    <StoryTemplate title="Checkbox - overview" display="grid">
+    <StoryTemplate display="grid">
       <Story />
     </StoryTemplate>
   ),
@@ -57,7 +57,7 @@ export const Overview: Story = {
 export const Default: Story = {
   args: { label: 'Label' },
   decorators: Story => (
-    <StoryTemplate title="Checkbox - default" display="block">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
@@ -35,43 +35,23 @@ export const Overview: Story = {
     ],
   },
   decorators: Story => (
-    <StoryTemplate
-      title="CheckboxGroup - overview"
-      display="grid"
-      $columnsAmount={2}
-    >
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
   render: args => (
     <>
       <CheckboxGroup {...args} />
-      <CheckboxGroup {...args} direction="column" />
       <CheckboxGroup {...args} required />
-      <CheckboxGroup {...args} direction="column" required />
       <CheckboxGroup {...args} tip="Dette er en hjelpetekst" />
-      <CheckboxGroup
-        {...args}
-        direction="column"
-        tip="Dette er en hjelpetekst"
-      />
       <CheckboxGroup {...args} errorMessage="Dette er en feilmelding" />
-      <CheckboxGroup
-        {...args}
-        direction="column"
-        errorMessage="Dette er en feilmelding"
-      />
+
       <CheckboxGroup
         {...args}
         tip="Dette er en hjelpetekst"
         errorMessage="Dette er en feilmelding"
       />
-      <CheckboxGroup
-        {...args}
-        direction="column"
-        tip="Dette er en hjelpetekst"
-        errorMessage="Dette er en feilmelding"
-      />
+      <CheckboxGroup {...args} direction="column" />
     </>
   ),
 };
@@ -86,7 +66,7 @@ export const Default: Story = {
     ],
   },
   decorators: Story => (
-    <StoryTemplate title="CheckboxGroup - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
+++ b/packages/components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof RadioButton>;
 export const Default: Story = {
   args: { label: 'Label' },
   decorators: Story => (
-    <StoryTemplate title="RadioButton - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -35,11 +35,7 @@ export const Default: Story = {
 export const Overview: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate
-      title="RadioButton - overview"
-      display="grid"
-      $columnsAmount={2}
-    >
+    <StoryTemplate display="grid" $columnsAmount={2}>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
+++ b/packages/components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
@@ -28,7 +28,7 @@ type Story = StoryObj<typeof RadioButtonGroup>;
 export const Default: Story = {
   args: { label: 'Label' },
   decorators: Story => (
-    <StoryTemplate title="RadioButtonGroup - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -53,11 +53,7 @@ export const Default: Story = {
 export const Overview: Story = {
   args: { label: 'Label' },
   decorators: Story => (
-    <StoryTemplate
-      title="RadioButtonGroup - overview"
-      display="grid"
-      $columnsAmount={2}
-    >
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -80,37 +76,10 @@ export const Overview: Story = {
         </RadioButtonGroup>
         <RadioButtonGroup
           {...args}
-          direction="column"
-          value={value}
-          name="test1"
-          onChange={(_event, value) => {
-            setValue(value);
-          }}
-        >
-          <RadioButton label="Option 1" value={1} />
-          <RadioButton label="Option 2" value={2} />
-          <RadioButton label="Option 3" value={3} />
-        </RadioButtonGroup>
-        <RadioButtonGroup
-          {...args}
           tip="Dette er en hjelpetekst"
           direction="row"
           value={value}
           name="test2"
-          onChange={(_event, value) => {
-            setValue(value);
-          }}
-        >
-          <RadioButton label="Option 1" value={1} />
-          <RadioButton label="Option 2" value={2} />
-          <RadioButton label="Option 3" value={3} />
-        </RadioButtonGroup>
-        <RadioButtonGroup
-          {...args}
-          tip="Dette er en hjelpetekst"
-          direction="column"
-          value={value}
-          name="test3"
           onChange={(_event, value) => {
             setValue(value);
           }}
@@ -136,20 +105,6 @@ export const Overview: Story = {
         <RadioButtonGroup
           {...args}
           errorMessage="Dette er en feilmelding"
-          direction="column"
-          value={value}
-          name="test5"
-          onChange={(_event, value) => {
-            setValue(value);
-          }}
-        >
-          <RadioButton label="Option 1" value={1} />
-          <RadioButton label="Option 2" value={2} />
-          <RadioButton label="Option 3" value={3} />
-        </RadioButtonGroup>
-        <RadioButtonGroup
-          {...args}
-          errorMessage="Dette er en feilmelding"
           tip="Dette er en hjelpetekst"
           direction="row"
           value={value}
@@ -164,11 +119,9 @@ export const Overview: Story = {
         </RadioButtonGroup>
         <RadioButtonGroup
           {...args}
-          errorMessage="Dette er en feilmelding"
-          tip="Dette er en hjelpetekst"
           direction="column"
           value={value}
-          name="test7"
+          name="test1"
           onChange={(_event, value) => {
             setValue(value);
           }}

--- a/packages/components/src/components/SkipToContent/SkipToContent.stories.tsx
+++ b/packages/components/src/components/SkipToContent/SkipToContent.stories.tsx
@@ -28,7 +28,7 @@ type Story = StoryObj<typeof SkipToContent>;
 export const Default: Story = {
   args: { href: '#innhold' },
   decorators: Story => (
-    <StoryTemplate title="SkipToContent - default" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -44,7 +44,7 @@ export const Default: Story = {
 export const Overview: Story = {
   args: { href: '#innhold' },
   decorators: Story => (
-    <StoryTemplate title="SkipToContent - overview" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -61,7 +61,7 @@ export const Overview: Story = {
 export const Example: Story = {
   args: { href: '#innhold' },
   decorators: Story => (
-    <StoryTemplate title="SkipToContent - example" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -75,7 +75,7 @@ export const Example: Story = {
       </Typography>
       <div
         style={{
-          height: '800px',
+          height: '1000px',
           backgroundColor: Colors.DdsColorPrimaryLightest,
         }}
       >

--- a/packages/components/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/components/src/components/Spinner/Spinner.stories.tsx
@@ -28,7 +28,7 @@ export const Default: Story = {
     color: 'interactive',
   },
   decorators: Story => (
-    <StoryTemplate title="Spinner - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -37,25 +37,30 @@ export const Default: Story = {
 export const Overview: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate
-      title="Spinner - overview"
-      display="grid"
-      $columnsAmount={4}
-      gap="30px"
-    >
+    <StoryTemplate display="grid" $columnsAmount={4} gap="30px">
       <Story />
     </StoryTemplate>
   ),
   render: args => (
     <>
       <Spinner {...args} />
-      <Spinner {...args} size="60px" tooltip="Egendefinert melding" />
       <Spinner {...args} color="gray4" />
-      <Spinner {...args} color="gray4" size="60px" />
       <Spinner {...args} color="success" />
-      <Spinner {...args} color="success" size="60px" />
-      <Spinner {...args} color="gray7" />
-      <Spinner {...args} color="gray7" size="60px" />
+      <Spinner {...args} size="60px" />
+    </>
+  ),
+};
+
+export const CustomTooltip: Story = {
+  args: {},
+  decorators: Story => (
+    <StoryTemplate display="grid" $columnsAmount={4} gap="30px">
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
+      <Spinner {...args} size="60px" tooltip="Egendefinert melding" />
     </>
   ),
 };

--- a/packages/components/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/components/src/components/SplitButton/SplitButton.stories.tsx
@@ -36,7 +36,7 @@ export const Default: Story = {
     secondaryActions: items,
   },
   decorators: Story => (
-    <StoryTemplate title="SplitButton - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -45,7 +45,7 @@ export const Default: Story = {
 export const Overview: Story = {
   args: {},
   decorators: Story => (
-    <StoryTemplate title="SplitButton - overview" display="grid">
+    <StoryTemplate display="grid">
       <Story />
     </StoryTemplate>
   ),
@@ -63,7 +63,7 @@ export const FullWidth: Story = {
     secondaryActions: items,
   },
   decorators: Story => (
-    <StoryTemplate title="SplitButton - full width">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Stack/Stack.stories.tsx
+++ b/packages/components/src/components/Stack/Stack.stories.tsx
@@ -18,7 +18,7 @@ const ExampleElement = () => (
 );
 
 export const VStackOverview = (args: StackProps) => (
-  <StoryTemplate title="VStack - overview">
+  <StoryTemplate>
     <VStack {...args}>
       <ExampleElement />
       <ExampleElement />
@@ -29,7 +29,7 @@ export const VStackOverview = (args: StackProps) => (
 );
 
 export const HStackOverview = (args: StackProps) => (
-  <StoryTemplate title="HStack - overview">
+  <StoryTemplate>
     <HStack {...args}>
       <ExampleElement />
       <ExampleElement />

--- a/packages/components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
+++ b/packages/components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
@@ -59,10 +59,7 @@ const headerValues = headerCells.map(cell => {
 
 export const SingleDefiningColumn = (args: CollapsibleTableProps) => {
   return (
-    <StoryTemplate
-      title="CollapsibleTable - single defining column"
-      display="block"
-    >
+    <StoryTemplate display="block">
       <CollapsibleTable
         {...args}
         headerValues={headerValues}
@@ -89,10 +86,7 @@ export const SingleDefiningColumn = (args: CollapsibleTableProps) => {
 
 export const MultipleDefiningColumns = (args: CollapsibleTableProps) => {
   return (
-    <StoryTemplate
-      title="CollapsibleTable - multiple defining columns"
-      display="block"
-    >
+    <StoryTemplate display="block">
       <Table.Wrapper style={{ width: '100%' }}>
         <CollapsibleTable
           {...args}
@@ -123,10 +117,7 @@ export const MultipleDefiningColumns = (args: CollapsibleTableProps) => {
 
 export const PrioritizedDefiningColumns = (args: CollapsibleTableProps) => {
   return (
-    <StoryTemplate
-      title="CollapsibleTable - prioritized defining columns"
-      display="block"
-    >
+    <StoryTemplate display="block">
       <Table.Wrapper style={{ width: '100%' }}>
         <CollapsibleTable
           {...args}
@@ -157,7 +148,7 @@ export const PrioritizedDefiningColumns = (args: CollapsibleTableProps) => {
 
 export const WithDividers = (args: CollapsibleTableProps) => {
   return (
-    <StoryTemplate title="CollapsibleTable - with dividers" display="block">
+    <StoryTemplate display="block">
       <CollapsibleTable
         {...args}
         withDividers
@@ -185,7 +176,7 @@ export const WithDividers = (args: CollapsibleTableProps) => {
 
 export const Compact = (args: CollapsibleTableProps) => {
   return (
-    <StoryTemplate title="CollapsibleTable - compact" display="block">
+    <StoryTemplate display="block">
       <CollapsibleTable
         {...args}
         density="compact"
@@ -213,7 +204,7 @@ export const Compact = (args: CollapsibleTableProps) => {
 
 export const StickyHeader = (args: CollapsibleTableProps) => {
   return (
-    <StoryTemplate title="CollapsibleTable - sticky header" display="block">
+    <StoryTemplate display="block">
       <CollapsibleTable
         {...args}
         stickyHeader
@@ -264,7 +255,7 @@ export const WithButtonAndIcons = (args: CollapsibleTableProps) => {
     </Button>
   );
   return (
-    <StoryTemplate title="Table - with buttons and icons" display="block">
+    <StoryTemplate display="block">
       <CollapsibleTable {...args} headerValues={headerValues} isCollapsed>
         <Table.Head>
           <CollapsibleTable.Row>
@@ -299,7 +290,7 @@ export const WithButtonAndIcons = (args: CollapsibleTableProps) => {
 export const Responsive = (args: CollapsibleTableProps) => {
   const screenSize = useScreenSize();
   return (
-    <StoryTemplate title="CollapsibleTable - responsive" display="block">
+    <StoryTemplate display="block">
       <Table.Wrapper style={{ width: '100%' }}>
         <CollapsibleTable
           {...args}
@@ -329,10 +320,7 @@ export const Responsive = (args: CollapsibleTableProps) => {
 export const ResposiveMultipleBreakpoints = (args: CollapsibleTableProps) => {
   const screenSize = useScreenSize();
   return (
-    <StoryTemplate
-      title="CollapsibleTable - responsive multiple breakpoints"
-      display="block"
-    >
+    <StoryTemplate display="block">
       <Table.Wrapper style={{ width: '100%' }}>
         <CollapsibleTable
           {...args}
@@ -387,7 +375,7 @@ export const Example = () => {
   const isXSmall = screenSize <= ScreenSize.XSmall;
   const iconSize = isXSmall ? 'small' : 'medium';
   return (
-    <StoryTemplate title="CollapsibleTable - Example" display="block">
+    <StoryTemplate display="block">
       <CollapsibleTable
         isCollapsed={isSmall}
         headerValues={headers}

--- a/packages/components/src/components/Table/normal/Table.mdx
+++ b/packages/components/src/components/Table/normal/Table.mdx
@@ -20,7 +20,20 @@ import * as CollapsibleTableStories from '../collapsible/CollapsibleTable.storie
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Table"
 />
 
-## Demo
+## Oversikt
+
+Tabeller bygges ved å bruke styled versjoner av native HTML elementer. Disse komponentene er:
+
+- **`<Table.Wrapper />`** - wrapper for tabell.
+- **`<Table />`** - selve tabellen.
+- **Subkomponenter:** `<Table.Head />`, `<Table.Body />`, `<Table.Foot />`, `<Table.Row />`, `<Table.Cell />`, `<Table.SortCell />`.
+- **`<CollapsibleTable />`** - variant av tabell som kan kollapses, med tilhørende rad-komponent: `<CollapsibleTable.Row>`.
+
+Enkelte subkomponenter har props for å sørge for riktig styling og oppførsel, mens andre har kun native props, som forklart i API.
+
+## Varianter
+
+### Tabell
 
 <Canvas>
   {/* <Story id="dds-components-table-table--default" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
@@ -28,30 +41,15 @@ import * as CollapsibleTableStories from '../collapsible/CollapsibleTable.storie
   <Story id="dds-components-table-table--default" />
 </Canvas>
 
+### Kollapsibel tabell
+
 <Canvas>
   {/* <Story id="dds-components-table-collapsibletable-beta--single-defining-column" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
 
   <Story id="dds-components-table-collapsibletable-beta--single-defining-column" />
 </Canvas>
 
-<Canvas>
-  {/* <Story id="dds-components-table-collapsibletable-beta--multiple-defining-columns" /> is deprecated, please migrate it to <Story of={referenceToStory} /> see: https://storybook.js.org/migration-guides/7.0 */}
-
-  <Story id="dds-components-table-collapsibletable-beta--multiple-defining-columns" />
-</Canvas>
-
 <LinkToInteractiveStory href={`${SB_DESIGNSYSTEM_URL}dds-components-table`} />
-
-## Oversikt
-
-Tabeller bygges ved å bruke styled versjoner av native HTML elementer. Disse komponentene er:
-
-- `<Table.Wrapper />` - wrapper for tabell.
-- `<Table />` - selve tabellen.
-- Subkomponenter: `<Table.Head />`, `<Table.Body />`, `<Table.Foot />`, `<Table.Row />`, `<Table.Cell />`, `<Table.SortCell />`.
-- BETA - variant av tabell som kan kollapses, med tilhørende rad-komponent: `<CollapsibleTable />` og `<CollapsibleTable.Row>`.
-
-Enkelte subkomponenter har props for å sørge for riktig styling og oppførsel, mens andre har kun native props, som forklart i API.
 
 ## Bruk i koden
 
@@ -171,7 +169,7 @@ Et styled `<Cell type='head'>`-element som brukes som `<th>` i sorteringskolonne
 
 I tillegg støttes `<Cell>`-props, bortsett fra `type` da den er satt til `'head'`.
 
-### CollapsibleTable <Tag text="BETA" purpose="warning" />
+### CollapsibleTable
 
 En variant av `<Table>` som kan kollapse deler av hver rad.
 Konsumenten må bestemme en eller flere såkalte definerende kolonner - kolonner som vises til enhver tid som i vanlig tabell, mens reseterende kolonner kan kollapse.
@@ -186,7 +184,7 @@ Rekkefølgen på definerende kolonner følger rekkefølgen i `definingColumnInde
 <Canvas of={CollapsibleTableStories.SingleDefiningColumn} />
 <Controls of={CollapsibleTableStories.SingleDefiningColumn} />
 
-### CollapsibleTable.Row <Tag text="BETA" purpose="warning" />
+### CollapsibleTable.Row
 
 En variant av `<Table.Row>` som brukes med `<CollapsibleTable>`. Den håndterer kollapsing.
 

--- a/packages/components/src/components/Table/normal/Table.stories.tsx
+++ b/packages/components/src/components/Table/normal/Table.stories.tsx
@@ -44,7 +44,7 @@ const mappedHeaderCells = headerCells.map(headerCell => {
 
 export const Default = (args: TableProps) => {
   return (
-    <StoryTemplate title="Table - default">
+    <StoryTemplate>
       <Table.Wrapper>
         <Table {...args}>
           <Table.Head>

--- a/packages/components/src/components/Tabs/Tabs.mdx
+++ b/packages/components/src/components/Tabs/Tabs.mdx
@@ -81,3 +81,13 @@ Panel med innhold. Vises ved museklikk på tilhørende `<Tab />`.
 En liste med `<TabPanel />`. Setter attributter som `aria-labelledby` for barna. `<TabPanels />` skal ha `<TabPanel />` som barn i samme rekkefølge som tilhørende paneler i `<TabList />`.
 
 Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface.
+
+## Eksempler
+
+### Aktiv fane
+
+<Canvas of={TabsStories.ActiveTab} />
+
+### Mange faner
+
+<Canvas of={TabsStories.ManyTabs} />

--- a/packages/components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/components/src/components/Tabs/Tabs.stories.tsx
@@ -20,7 +20,7 @@ export default {
 };
 
 export const Overview = () => (
-  <StoryTemplate title="Tabs - overview">
+  <StoryTemplate>
     <Tabs>
       <TabList>
         <Tab>Restriksjoner</Tab>
@@ -46,7 +46,7 @@ export const Overview = () => (
 );
 
 export const Default = (args: TabsProps) => (
-  <StoryTemplate title="Tabs - default" display="block">
+  <StoryTemplate display="block">
     <Tabs {...args}>
       <TabList>
         <Tab>Tab 1</Tab>
@@ -63,7 +63,7 @@ export const Default = (args: TabsProps) => (
 );
 
 export const WithIcon = (args: TabsProps) => (
-  <StoryTemplate title="Tabs - with icon">
+  <StoryTemplate>
     <Tabs {...args}>
       <TabList>
         <Tab icon={NotificationsIcon}>Tab 1</Tab>
@@ -83,7 +83,7 @@ export const ActiveTab = (args: TabsProps) => {
   const [activeTab, setActiveTab] = useState(1);
 
   return (
-    <StoryTemplate title="Tabs - active tab" display="block">
+    <StoryTemplate display="block">
       <Tabs {...args} activeTab={activeTab} onChange={tab => setActiveTab(tab)}>
         <TabList>
           <Tab>Tab 1</Tab>
@@ -104,7 +104,7 @@ export const ActiveTab = (args: TabsProps) => {
 };
 
 export const WithWidth = (args: TabsProps) => (
-  <StoryTemplate title="Tabs - tab width" display="block">
+  <StoryTemplate display="block">
     <Tabs {...args} width="500px">
       <TabList>
         <Tab>Tab 1</Tab>
@@ -121,7 +121,7 @@ export const WithWidth = (args: TabsProps) => (
 );
 
 export const TabLongNames = (args: TabsProps) => (
-  <StoryTemplate title="Tabs - tab width" display="block">
+  <StoryTemplate display="block">
     <Tabs {...args}>
       <TabList>
         <Tab>Partsopplysninger</Tab>
@@ -138,7 +138,7 @@ export const TabLongNames = (args: TabsProps) => (
 );
 
 export const ManyTabs = (args: TabsProps) => (
-  <StoryTemplate title="Tabs - many tabs" display="block">
+  <StoryTemplate display="block">
     <Tabs {...args} htmlProps={{ style: { width: '400px' } }}>
       <TabList>
         <Tab>Tab1</Tab>
@@ -169,7 +169,7 @@ export const ManyTabs = (args: TabsProps) => (
 );
 
 export const MaxContentWidth = (args: TabsProps) => (
-  <StoryTemplate title="Tabs - fixed width" display="block">
+  <StoryTemplate display="block">
     <VStack align="flex-start" gap="x1">
       <Paragraph>
         Dette er et eksempel på hvordan du kan sette egne bredder på hver tab.

--- a/packages/components/src/components/Tag/Tag.stories.tsx
+++ b/packages/components/src/components/Tag/Tag.stories.tsx
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Tag>;
 export const Default: Story = {
   args: { children: 'default' },
   decorators: Story => (
-    <StoryTemplate title="Tag - default" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -28,7 +28,7 @@ export const Default: Story = {
 export const Overview: Story = {
   args: { children: 'default' },
   decorators: Story => (
-    <StoryTemplate title="Tag - overview" display="grid" $columnsAmount={4}>
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/TextArea/TextArea.mdx
+++ b/packages/components/src/components/TextArea/TextArea.mdx
@@ -14,8 +14,8 @@ import * as TextAreaStories from './TextArea.stories';
 
 ## API
 
-<Canvas of={TextAreaStories.WithLabel} sourceState="shown" />
-<Controls of={TextAreaStories.WithLabel} />
+<Canvas of={TextAreaStories.Default} sourceState="shown" />
+<Controls of={TextAreaStories.Default} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `TextareaHTMLAttributes<HTMLTextAreaElement>`-interface.
 

--- a/packages/components/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/components/src/components/TextArea/TextArea.stories.tsx
@@ -28,39 +28,29 @@ type Story = StoryObj<typeof TextArea>;
 
 export const Overview = (args: TextAreaProps) => {
   return (
-    <StoryTemplate title="Textrea - overview" display="grid" $columnsAmount={2}>
+    <StoryTemplate display="grid" $columnsAmount={2}>
       <TextArea {...args} label={args.label ?? 'Label'} />
-      <TextArea {...args} />
       <TextArea
         {...args}
         label={args.label ?? 'Label'}
         required
         value="Påkrevd"
       />
-      <TextArea {...args} required value="Påkrevd" />
       <TextArea
         {...args}
         label={args.label ?? 'Label'}
         disabled
         value="Disabled"
       />
-      <TextArea {...args} disabled value="Disabled" />
       <TextArea
         {...args}
         label={args.label ?? 'Label'}
         readOnly
         value="Readonly"
       />
-      <TextArea {...args} readOnly value="Readonly" />
       <TextArea
         {...args}
         label={args.label ?? 'Label'}
-        errorMessage={
-          args.errorMessage ?? 'Dette er en feilmelding ved valideringsfeil'
-        }
-      />
-      <TextArea
-        {...args}
         errorMessage={
           args.errorMessage ?? 'Dette er en feilmelding ved valideringsfeil'
         }
@@ -70,23 +60,15 @@ export const Overview = (args: TextAreaProps) => {
         label={args.label ?? 'Label'}
         tip={args.tip ?? 'Dette er en hjelpetekst'}
       />
-      <TextArea {...args} tip={args.tip ?? 'Dette er en hjelpetekst'} />
+      <TextArea {...args} />
     </StoryTemplate>
   );
 };
 
 export const Default: Story = {
-  decorators: Story => (
-    <StoryTemplate title="TextArea - default">
-      <Story />
-    </StoryTemplate>
-  ),
-};
-
-export const WithLabel: Story = {
   args: { label: 'Label' },
   decorators: Story => (
-    <StoryTemplate title="TextArea - with label">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/TextInput/TextInput.mdx
+++ b/packages/components/src/components/TextInput/TextInput.mdx
@@ -14,8 +14,8 @@ import * as TextInputStories from './TextInput.stories';
 
 ## Props
 
-<Canvas of={TextInputStories.WithLabel} sourceState="shown" />
-<Controls of={TextInputStories.WithLabel} />
+<Canvas of={TextInputStories.Default} sourceState="shown" />
+<Controls of={TextInputStories.Default} />
 
 ### maxLength
 

--- a/packages/components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/components/src/components/TextInput/TextInput.stories.tsx
@@ -35,29 +35,21 @@ type Story = StoryObj<typeof TextInput>;
 export const TextInputOverview = (args: TextInputProps) => {
   return (
     <StoryTemplate
-      title="TextInput - overview"
       display="grid"
       $columnsAmount={2}
       style={{ alignItems: 'end' }}
     >
       <TextInput {...args} label={args.label ?? 'Label'} />
-      <TextInput {...args} />
       <TextInput
         {...args}
         label={args.label ?? 'Label'}
         required
         value="Påkrevd inputfelt"
       />
-      <TextInput {...args} required value="Påkrevd inputfelt" />
       <TextInput
         {...args}
         aria-required
         label={args.label ?? 'Label'}
-        value="Påkrevd inputfelt med aria-required"
-      />
-      <TextInput
-        {...args}
-        aria-required
         value="Påkrevd inputfelt med aria-required"
       />
       <TextInput
@@ -66,23 +58,15 @@ export const TextInputOverview = (args: TextInputProps) => {
         disabled
         value="Disabled inputfelt"
       />
-      <TextInput {...args} disabled value="Disabled inputfelt" />
       <TextInput
         {...args}
         label={args.label ?? 'Label'}
         readOnly
         value="Readonly inputfelt"
       />
-      <TextInput {...args} readOnly value="Readonly inputfelt" />
       <TextInput
         {...args}
         label={args.label ?? 'Label'}
-        errorMessage={
-          args.errorMessage ?? 'Dette er en feilmelding ved valideringsfeil'
-        }
-      />
-      <TextInput
-        {...args}
         errorMessage={
           args.errorMessage ?? 'Dette er en feilmelding ved valideringsfeil'
         }
@@ -92,7 +76,6 @@ export const TextInputOverview = (args: TextInputProps) => {
         label={args.label ?? 'Label'}
         tip={args.tip ?? 'Dette er en hjelpetekst'}
       />
-      <TextInput {...args} tip={args.tip ?? 'Dette er en hjelpetekst'} />
       <TextInput
         {...args}
         label={args.label ?? 'Label'}
@@ -100,25 +83,16 @@ export const TextInputOverview = (args: TextInputProps) => {
         tip={args.tip ?? 'Dette er en hjelpetekst med en tegnteller'}
         maxLength={20}
       />
-      <TextInput
-        {...args}
-        tip={args.tip ?? 'Dette er en hjelpetekst med en tegnteller'}
-        maxLength={20}
-      />
       <TextInput {...args} icon={MailIcon} label={args.label ?? 'Label'} />
-      <TextInput {...args} icon={MailIcon} />
-      <TextInput {...args} prefix="Prefix" />
-      <TextInput {...args} suffix="Suffix" />
+      <TextInput {...args} label={args.label ?? 'Label'} prefix="Prefix" />
+      <TextInput {...args} label={args.label ?? 'Label'} suffix="Suffix" />
+      <TextInput {...args} />
     </StoryTemplate>
   );
 };
 
 export const TextInputOverviewSizes = () => (
-  <StoryTemplate
-    title="TextInput - overview sizes"
-    display="grid"
-    $columnsAmount={2}
-  >
+  <StoryTemplate display="grid" $columnsAmount={2}>
     <TextInput label="Label" />
     <TextInput label="Label" icon={MailIcon} />
     <TextInput label="Label" componentSize="small" />
@@ -129,17 +103,9 @@ export const TextInputOverviewSizes = () => (
 );
 
 export const Default: Story = {
-  decorators: Story => (
-    <StoryTemplate title="TextInput - default">
-      <Story />
-    </StoryTemplate>
-  ),
-};
-
-export const WithLabel: Story = {
   args: { label: 'Label' },
   decorators: Story => (
-    <StoryTemplate title="TextInput - with label">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -147,18 +113,14 @@ export const WithLabel: Story = {
 
 export const WithCharacterCount = (args: TextInputProps) => {
   return (
-    <StoryTemplate title="TextInput - with character count">
+    <StoryTemplate>
       <TextInput {...args} maxLength={25} label={args.label ?? 'Label'} />
     </StoryTemplate>
   );
 };
 
 export const TextInputAffixes = (args: TextInputProps) => (
-  <StoryTemplate
-    title="TextInput - With affixes"
-    display="grid"
-    $columnsAmount={1}
-  >
+  <StoryTemplate display="grid" $columnsAmount={1}>
     <LocalMessage purpose="tips">
       <strong>OBS!</strong> Skjermleser leser ikke opp affixes. Husk derfor å
       inkludere en tilstrekkelig beskrivende label i tillegg.

--- a/packages/components/src/components/ToggleBar/ToggleBar.stories.tsx
+++ b/packages/components/src/components/ToggleBar/ToggleBar.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof ToggleBar>;
 
 export const Default: Story = {
   decorators: Story => (
-    <StoryTemplate title="ToggleBar - default" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -53,11 +53,7 @@ export const Default: Story = {
 
 export const Overview: Story = {
   decorators: Story => (
-    <StoryTemplate
-      title="ToggleBar - overview"
-      display="grid"
-      $columnsAmount={3}
-    >
+    <StoryTemplate display="grid" $columnsAmount={3}>
       <Story />
     </StoryTemplate>
   ),
@@ -204,7 +200,7 @@ export const Overview: Story = {
 
 export const WithDefaultValue: Story = {
   decorators: Story => (
-    <StoryTemplate title="ToggleBar - with default value" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -231,7 +227,7 @@ export const WithDefaultValue: Story = {
 
 export const WithLongWords: Story = {
   decorators: Story => (
-    <StoryTemplate title="ToggleBar - with long words" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),
@@ -258,7 +254,7 @@ export const WithLongWords: Story = {
 
 export const WithWidth: Story = {
   decorators: Story => (
-    <StoryTemplate title="ToggleBar - with width" display="block">
+    <StoryTemplate display="block">
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/packages/components/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof ToggleButton>;
 export const Default: Story = {
   args: { label: 'Tekst' },
   decorators: Story => (
-    <StoryTemplate title="ToggleButton - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -33,7 +33,7 @@ export const Default: Story = {
 export const WithIcon: Story = {
   args: { label: 'Tekst', icon: NotificationsIcon },
   decorators: Story => (
-    <StoryTemplate title="ToggleButton - with icon">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/ToggleButton/ToggleButtonGroup.stories.tsx
+++ b/packages/components/src/components/ToggleButton/ToggleButtonGroup.stories.tsx
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof ToggleButtonGroup>;
 export const Default: Story = {
   args: { label: 'Label' },
   decorators: Story => (
-    <StoryTemplate title="ToggleButtonGroup - default" display="block">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.stories.tsx
@@ -26,7 +26,6 @@ type Story = StoryObj<typeof Tooltip>;
 export const Overview: Story = {
   decorators: Story => (
     <StoryTemplate
-      title="Tooltip - default"
       display="grid"
       containerStyle={{
         alignContent: 'center',
@@ -143,7 +142,6 @@ export const Default: Story = {
   args: { text: 'Dette er en tooltip' },
   decorators: Story => (
     <StoryTemplate
-      title="Tooltip - default"
       display="block"
       containerStyle={{
         alignContent: 'center',

--- a/packages/components/src/components/Typography/Caption/Caption.stories.tsx
+++ b/packages/components/src/components/Typography/Caption/Caption.stories.tsx
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof Caption>;
 export const Default: Story = {
   args: { children: 'Caption' },
   decorators: Story => (
-    <StoryTemplate title="Caption - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/components/src/components/Typography/Heading/Heading.stories.tsx
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof Heading>;
 
 export const Overview = (args: Partial<HeadingProps>) => {
   return (
-    <StoryTemplate title="Heading - overview">
+    <StoryTemplate>
       <Heading {...args} level={1}>
         Heading 1
       </Heading>
@@ -47,7 +47,7 @@ export const Overview = (args: Partial<HeadingProps>) => {
 export const Default: Story = {
   args: { children: 'Heading', level: 1 },
   decorators: Story => (
-    <StoryTemplate title="Heading - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Typography/Label/Label.stories.tsx
+++ b/packages/components/src/components/Typography/Label/Label.stories.tsx
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof Label>;
 export const Default: Story = {
   args: { children: 'Label' },
   decorators: Story => (
-    <StoryTemplate title="Label - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Typography/Legend/Legend.stories.tsx
+++ b/packages/components/src/components/Typography/Legend/Legend.stories.tsx
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof Legend>;
 export const Default: Story = {
   args: { children: 'Legend' },
   decorators: Story => (
-    <StoryTemplate title="Legend - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Typography/Link/Link.stories.tsx
+++ b/packages/components/src/components/Typography/Link/Link.stories.tsx
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof Link>;
 export const Default: Story = {
   args: { children: 'Link', href: 'https://www.domstol.no' },
   decorators: Story => (
-    <StoryTemplate title="Link - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -34,7 +34,7 @@ export const Default: Story = {
 export const Overview: Story = {
   args: { children: 'Link', href: 'https://www.domstol.no' },
   decorators: Story => (
-    <StoryTemplate title="Link - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Typography/Paragraph/Paragraph.stories.tsx
+++ b/packages/components/src/components/Typography/Paragraph/Paragraph.stories.tsx
@@ -22,7 +22,7 @@ type Story = StoryObj<typeof Paragraph>;
 
 export const Overview: Story = {
   decorators: Story => (
-    <StoryTemplate title="Paragraph - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -62,7 +62,7 @@ export const Overview: Story = {
 export const Default: Story = {
   args: { children: 'Paragraph' },
   decorators: Story => (
-    <StoryTemplate title="Paragraph - overview">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Typography/Typography/Typography.stories.tsx
+++ b/packages/components/src/components/Typography/Typography/Typography.stories.tsx
@@ -29,7 +29,7 @@ type Story = StoryObj<typeof Typography>;
 export const Default: Story = {
   args: { children: 'Typography' },
   decorators: Story => (
-    <StoryTemplate title="Typography - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/Typography/stories/Examples.stories.tsx
+++ b/packages/components/src/components/Typography/stories/Examples.stories.tsx
@@ -9,11 +9,12 @@ export default {
 
 const ArticleContainer = styled.div`
   max-width: 700px;
+  margin-top: -1rem;
 `;
 
 export const Article = () => {
   return (
-    <StoryTemplate title="Article - example">
+    <StoryTemplate>
       <ArticleContainer>
         <Heading level={1} typographyType="headingSans06" withMargins>
           Vitne

--- a/packages/components/src/components/Typography/stories/TypographyComponents.stories.tsx
+++ b/packages/components/src/components/Typography/stories/TypographyComponents.stories.tsx
@@ -25,7 +25,7 @@ export default {
 
 export const ComponentsOverview = () => {
   return (
-    <StoryTemplate title="Typography components - overview">
+    <StoryTemplate>
       <Heading level={1}>Heading</Heading>
       <Paragraph>Paragraph</Paragraph>
       <Label>Label</Label>

--- a/packages/components/src/components/Typography/stories/TypographyTypes.stories.tsx
+++ b/packages/components/src/components/Typography/stories/TypographyTypes.stories.tsx
@@ -9,7 +9,7 @@ export default {
 
 export const Body = () => {
   return (
-    <StoryTemplate title="Typography - body styles overview">
+    <StoryTemplate>
       <Typography typographyType="bodySans01">
         bodySans01 - Når du kommer inn i rettssalen, blir du bedt om å stå ved
         vitneboksen. Så blir du spurt om hva du heter, hvor du bor og så videre.
@@ -40,7 +40,7 @@ export const Body = () => {
 
 export const Headings = () => {
   return (
-    <StoryTemplate title="Typography - heading styles overview" gap="30px">
+    <StoryTemplate gap="30px">
       <Typography typographyType="headingSans01">Heading-sans-01</Typography>
       <Typography typographyType="headingSans02">Heading-sans-02</Typography>
       <Typography typographyType="headingSans03">Heading-sans-03</Typography>
@@ -55,7 +55,7 @@ export const Headings = () => {
 
 export const Leads = () => {
   return (
-    <StoryTemplate title=" Typography - lead styles overview" gap="30px">
+    <StoryTemplate gap="30px">
       <Typography typographyType="leadSans01">lead-sans-01</Typography>
       <Typography typographyType="leadSans02">lead-sans-02</Typography>
       <Typography typographyType="leadSans03">lead-sans-03</Typography>
@@ -67,7 +67,7 @@ export const Leads = () => {
 
 export const Supporting = () => {
   return (
-    <StoryTemplate title="Typography - supporting styles overview" gap="30px">
+    <StoryTemplate gap="30px">
       <Typography typographyType="supportingStyleLabel01">
         supportingStyleLabel01
       </Typography>
@@ -95,7 +95,7 @@ export const Supporting = () => {
 
 export const Link = () => {
   return (
-    <StoryTemplate title="Typography - link styles overview">
+    <StoryTemplate>
       <Typography typographyType="a" href="https://www.domstol.no">
         Link
       </Typography>

--- a/packages/components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/packages/components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof VisuallyHidden>;
 
 export const Default: Story = {
   decorators: Story => (
-    <StoryTemplate title="VisuallyHidden - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -39,7 +39,7 @@ export const Default: Story = {
 
 export const WithLink: Story = {
   decorators: Story => (
-    <StoryTemplate title="VisuallyHidden - link example">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -67,7 +67,7 @@ export const WithLink: Story = {
 
 export const TableButtons: Story = {
   decorators: Story => (
-    <StoryTemplate title="VisuallyHidden - table example">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
@@ -57,7 +57,7 @@ type Story = StoryObj<typeof DatePicker>;
 export const Default: Story = {
   args: { label: 'Dato' },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -66,7 +66,7 @@ export const Default: Story = {
 export const Required: Story = {
   args: { label: 'Dato', isRequired: true },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - required">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -75,7 +75,7 @@ export const Required: Story = {
 export const Controlled: Story = {
   args: { label: 'Dato' },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - controlled">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -98,7 +98,7 @@ export const Controlled: Story = {
 export const WeekendsUnavailable: Story = {
   args: { label: 'Dato', isDateUnavailable: date => isWeekend(date, 'no-NO') },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - weekends unavailable">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -107,7 +107,7 @@ export const WeekendsUnavailable: Story = {
 export const Error: Story = {
   args: { label: 'Dato', errorMessage: 'Her er noe veldig galt! 😨' },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - error">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -115,7 +115,7 @@ export const Error: Story = {
 
 export const OverviewSizes: Story = {
   decorators: Story => (
-    <StoryTemplate title="DatePicker - weekends unavailable">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -134,7 +134,7 @@ export const Tip: Story = {
     tip: 'Visste du at denne komponenten også kan ha en tip?',
   },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - tip">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -147,7 +147,7 @@ export const ReadOnly: Story = {
     value: new CalendarDate(2023, 12, 24),
   },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - read only">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -160,7 +160,7 @@ export const Disabled: Story = {
     value: new CalendarDate(2023, 12, 24),
   },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - disabled">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -169,7 +169,7 @@ export const Disabled: Story = {
 export const CustomWidth: Story = {
   args: { label: 'Dato', width: '1337px' },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - custom width">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -178,7 +178,7 @@ export const CustomWidth: Story = {
 export const ControlFocus: Story = {
   args: { label: 'Dato' },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - control focus">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -196,7 +196,7 @@ export const ControlFocus: Story = {
 export const InsideModal: Story = {
   args: { label: 'Dato' },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - inside modal">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -216,7 +216,7 @@ export const InsideModal: Story = {
 export const DateAndTime: Story = {
   args: { label: 'Dato' },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - date and time">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -254,7 +254,7 @@ export const DateAndTime: Story = {
 export const NativeDate: Story = {
   args: { label: 'Dato' },
   decorators: Story => (
-    <StoryTemplate title="DatePicker - native date">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/components/src/components/date-inputs/TimePicker/TimePicker.stories.tsx
+++ b/packages/components/src/components/date-inputs/TimePicker/TimePicker.stories.tsx
@@ -25,7 +25,7 @@ type Story = StoryObj<typeof TimePicker>;
 export const Default: Story = {
   args: { label: 'Tidspunkt' },
   decorators: Story => (
-    <StoryTemplate title="TimePicker - default">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -34,7 +34,7 @@ export const Default: Story = {
 export const Required: Story = {
   args: { label: 'Tidspunkt', isRequired: true },
   decorators: Story => (
-    <StoryTemplate title="TimePicker - required">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -43,7 +43,7 @@ export const Required: Story = {
 export const Controlled: Story = {
   args: { label: 'Tidspunkt' },
   decorators: Story => (
-    <StoryTemplate title="TimePicker - required">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -51,7 +51,7 @@ export const Controlled: Story = {
     const [value, setValue] = useState<Time | null>(new Time(12));
 
     return (
-      <StoryTemplate title="TimePicker - controlled">
+      <StoryTemplate>
         <TimePicker {...args} value={value} onChange={setValue} />
         <Button onClick={() => setValue(new Time(12))}>
           Sett til klokken 12
@@ -64,7 +64,7 @@ export const Controlled: Story = {
 export const Error: Story = {
   args: { label: 'Tidspunkt', errorMessage: 'Her er noe veldig galt! 😨' },
   decorators: Story => (
-    <StoryTemplate title="TimePicker - error">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -73,7 +73,7 @@ export const Error: Story = {
 export const ReadOnly: Story = {
   args: { label: 'Tidspunkt', isReadOnly: true },
   decorators: Story => (
-    <StoryTemplate title="TimePicker - read only">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -81,7 +81,7 @@ export const ReadOnly: Story = {
 
 export const OverviewSizes: Story = {
   decorators: Story => (
-    <StoryTemplate title="TimePicker - overview sizes">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),
@@ -97,7 +97,7 @@ export const OverviewSizes: Story = {
 export const CustomWidth: Story = {
   args: { label: 'Tidspunkt', width: '500px' },
   decorators: Story => (
-    <StoryTemplate title="TimePicker - custom width">
+    <StoryTemplate>
       <Story />
     </StoryTemplate>
   ),

--- a/packages/storybook-components/src/StoryTemplate.tsx
+++ b/packages/storybook-components/src/StoryTemplate.tsx
@@ -9,9 +9,7 @@ import 'focus-visible';
 const { fontPackages } = ddsBaseTokens;
 const { textDefault } = ddsReferenceTokens;
 
-const StoryContainer = styled.div`
-  padding: 1.5rem;
-`;
+const StoryContainer = styled.div``;
 
 const H1 = styled.h1`
   color: ${textDefault.textColor};
@@ -22,11 +20,16 @@ interface ContainerProps {
   $gap?: string;
   $display?: StoryDisplay;
   $columnsAmount?: number;
+  $hasTitle?: boolean;
 }
 
 const Container = styled.div<ContainerProps>`
-  padding-top: ${ddsBaseTokens.spacing.SizesDdsSpacingX1};
-  ${({ $display: display, $gap: gap, $columnsAmount }) =>
+  ${({ $hasTitle: hasTitle }) =>
+    hasTitle &&
+    css`
+      padding-top: ${ddsBaseTokens.spacing.SizesDdsSpacingX1};
+    `}
+  ${({ $display: display, $gap: gap, $columnsAmount, $hasTitle: hasTitle }) =>
     gap &&
     display &&
     $columnsAmount &&
@@ -52,7 +55,7 @@ const Container = styled.div<ContainerProps>`
               justify-content: center;
               gap: ${gap};
             `
-          : display === 'block'
+          : display === 'block' && hasTitle
             ? css`
                 margin-top: ${gap};
               `
@@ -62,7 +65,7 @@ const Container = styled.div<ContainerProps>`
 export type StoryDisplay = 'block' | 'flex-column' | 'grid' | 'flex-centered';
 
 type StoryTemplateProps = {
-  title: string;
+  title?: string;
   gap?: string;
   $columnsAmount?: number;
   display?: StoryDisplay;
@@ -80,9 +83,14 @@ export const StoryTemplate = ({
 }: StoryTemplateProps) => {
   return (
     <StoryContainer {...rest} className="component-container">
-      <H1>{title}</H1>
-      <hr />
+      {title && (
+        <>
+          <H1>{title}</H1>
+          <hr />
+        </>
+      )}
       <Container
+        $hasTitle={!!title}
         $gap={gap}
         $display={display}
         style={containerStyle}


### PR DESCRIPTION
Tittel er unødvendig, i dokumentasjonen bør den komme fra oversktifter.

Rydder også mindre ting oppi stories, legger til eksempler i docs-filer på tenknisk relevante ting (activ tab, default value i en komponent osv).