### PR TITLE
ELSA1-332 Eksporterer types fra `<FileUploader />`

### DIFF
--- a/.changeset/fluffy-chefs-invent.md
+++ b/.changeset/fluffy-chefs-invent.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": minor
+---
+
+Eksporterer følgene types fra `<FileUploader />`: `FileUploaderAccept`, `FileList` og `FileUploaderProps` slik at konsumenter kan importere de i sine løsninger.

--- a/packages/components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.tsx
@@ -64,7 +64,7 @@ const FileListElement = styled.ul`
   list-style-type: none;
 `;
 
-type FileUploaderProps = {
+export type FileUploaderProps = {
   /**Id til filopplasteren. */
   id?: string;
   /**Ledetekst for filopplaster. */

--- a/packages/components/src/components/FileUploader/index.ts
+++ b/packages/components/src/components/FileUploader/index.ts
@@ -1,1 +1,2 @@
 export * from './FileUploader';
+export * from './types';

--- a/packages/components/src/components/FileUploader/types.ts
+++ b/packages/components/src/components/FileUploader/types.ts
@@ -62,6 +62,6 @@ type MimeType =
   | `audio/${AudioMimeType | AnyMimeType}`
   | `application/${ApplicationMimeType}`;
 
-export type Accept = MimeType | FileExtensionAccept;
+export type FileUploaderAccept = MimeType | FileExtensionAccept;
 
 export type FileList = Array<File>;

--- a/packages/components/src/components/FileUploader/useFileUploader.ts
+++ b/packages/components/src/components/FileUploader/useFileUploader.ts
@@ -16,7 +16,7 @@ import {
   type RootErrorList,
   fileUploaderReducer,
 } from './fileUploaderReducer';
-import { type Accept, type FileList } from './types';
+import { type FileList, type FileUploaderAccept } from './types';
 import {
   getInvalidFileTypeErrorMessage,
   getTooManyFilesErrorMessage,
@@ -34,7 +34,7 @@ export interface FileUploaderHookProps {
   /**Callback for når fil-listen endres. */
   onChange: (newFiles: FileList) => void;
   /**Hvilke filendelser eller mime-typer som filopplasteren skal akseptere. */
-  accept: Array<Accept> | undefined;
+  accept: Array<FileUploaderAccept> | undefined;
   /**Om filopplasteren er avslått eller ikke */
   disabled: boolean | undefined;
   /**Maks antall filer som tillates. */


### PR DESCRIPTION
Eksporterer følgene types fra `<FileUploader />`: `FileUploaderAccept`, `FileList` og `FileUploaderProps` slik at konsumenter kan importere de i sine løsninger.