### PR TITLE
ELSA1-13 Skalering av overskrifter på mobil

### DIFF
--- a/.changeset/stale-hats-beam.md
+++ b/.changeset/stale-hats-beam.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": minor
+---
+
+Automatisk skalering av stiler `headingSans04`-`headingSans08` i `<Heading />`. På skjerm under 600px skal komponenten automatisk bruke en typografistil ett steg mindre. Eksempel: hvis `headingSans08` er valgt skal det automatisk bli `headingSans07` på mindre skjerm. En mer rutinert system blir implementert når vi har semantiske tokens på plass, f.eks. dedikert stil med skalering for <h4> i alle Lovisa-apper.

--- a/packages/components/src/components/Typography/Heading/Heading.mdx
+++ b/packages/components/src/components/Typography/Heading/Heading.mdx
@@ -21,3 +21,9 @@ import * as HeadingStories from './Heading.stories';
 
 <Canvas of={HeadingStories.Default} />
 <Controls of={HeadingStories.Default} />
+
+## Med spacing
+
+`<Heading />` har en variant med margin og padding som er tilpasset bruk i artikler o.l., der overskriften plasseres over en `<Paragraph />`. Den sørger for at avstanden fra tekst over er større enn fra tekst under.
+
+<Canvas of={HeadingStories.WithMargins} />

--- a/packages/components/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/components/src/components/Typography/Heading/Heading.stories.tsx
@@ -1,7 +1,7 @@
 import { StoryTemplate } from '@norges-domstoler/storybook-components';
 import { type StoryObj } from '@storybook/react';
 
-import { Heading, type HeadingProps } from '.';
+import { Heading } from '.';
 
 export default {
   title: 'dds-components/Typography/Heading',
@@ -19,9 +19,23 @@ export default {
 
 type Story = StoryObj<typeof Heading>;
 
-export const Overview = (args: Partial<HeadingProps>) => {
-  return (
+export const Default: Story = {
+  args: { children: 'Heading', level: 1 },
+  decorators: Story => (
     <StoryTemplate>
+      <Story />
+    </StoryTemplate>
+  ),
+};
+
+export const Overview: Story = {
+  decorators: Story => (
+    <StoryTemplate>
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
       <Heading {...args} level={1}>
         Heading 1
       </Heading>
@@ -40,15 +54,60 @@ export const Overview = (args: Partial<HeadingProps>) => {
       <Heading {...args} level={6}>
         Heading 6
       </Heading>
-    </StoryTemplate>
-  );
+    </>
+  ),
 };
 
-export const Default: Story = {
+export const OverviewStyles: Story = {
+  decorators: Story => (
+    <StoryTemplate>
+      <Story />
+    </StoryTemplate>
+  ),
+  render: args => (
+    <>
+      <Heading {...args} level={1} typographyType="headingSans08">
+        headingSans08
+      </Heading>
+      <Heading {...args} level={1} typographyType="headingSans07">
+        headingSans07
+      </Heading>
+      <Heading {...args} level={1} typographyType="headingSans06">
+        headingSans06
+      </Heading>
+      <Heading {...args} level={1} typographyType="headingSans05">
+        headingSans05
+      </Heading>
+      <Heading {...args} level={1} typographyType="headingSans04">
+        headingSans04
+      </Heading>
+      <Heading {...args} level={1} typographyType="headingSans03">
+        headingSans03
+      </Heading>
+      <Heading {...args} level={1} typographyType="headingSans02">
+        headingSans02
+      </Heading>
+      <Heading {...args} level={1} typographyType="headingSans01">
+        headingSans01
+      </Heading>
+    </>
+  ),
+};
+
+export const WithMargins: Story = {
   args: { children: 'Heading', level: 1 },
   decorators: Story => (
     <StoryTemplate>
       <Story />
     </StoryTemplate>
+  ),
+  render: args => (
+    <div
+      style={{ borderTop: '1px solid black', borderBottom: '1px solid black' }}
+    >
+      <Heading {...args} withMargins>
+        Heading with margins
+      </Heading>
+    </div>
   ),
 };

--- a/packages/components/src/components/Typography/Heading/Heading.tsx
+++ b/packages/components/src/components/Typography/Heading/Heading.tsx
@@ -1,5 +1,6 @@
 import { type ElementType, forwardRef } from 'react';
 
+import { ScreenSize, useScreenSize } from '../../../hooks';
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
@@ -31,6 +32,25 @@ const getDefaultTypographyType = (h: ElementType): TypographyHeadingType => {
   }
 };
 
+const scaledTypographyType = (
+  type: TypographyHeadingType,
+): TypographyHeadingType => {
+  switch (type) {
+    case 'headingSans08':
+      return 'headingSans07';
+    case 'headingSans07':
+      return 'headingSans06';
+    case 'headingSans06':
+      return 'headingSans05';
+    case 'headingSans05':
+      return 'headingSans04';
+    case 'headingSans04':
+      return 'headingSans03';
+    default:
+      return type;
+  }
+};
+
 export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 
 export type HeadingProps = BaseComponentPropsWithChildren<
@@ -57,11 +77,17 @@ export const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(
 
     const headingElement: ElementType = getHeadingElement(level);
 
+    const standardTypographyType =
+      typographyType ?? getDefaultTypographyType(headingElement);
+
+    const screenSize = useScreenSize();
+    const isSmallScreen = screenSize <= ScreenSize.Small;
+
     const headingProps = {
       ...getBaseHTMLProps(id, className, htmlProps, rest),
-      typographyType: typographyType
-        ? typographyType
-        : getDefaultTypographyType(headingElement),
+      typographyType: isSmallScreen
+        ? scaledTypographyType(standardTypographyType)
+        : standardTypographyType,
       as: headingElement,
       ref,
     };


### PR DESCRIPTION
- Automatisk skalering av stiler `headingSans08-04`. På skjerm under 600px skal komponenten automatisk bruke typografistil et steg mindre.
- Eksempel: hvis `headingSans08` er valgt skal den automatisk bli `headingSans07` på mindre skjerm.