### PR TITLE
ELSA1-339 Lenke til hjem i `<InternalHeader />`

### DIFF
--- a/.changeset/fast-bags-boil.md
+++ b/.changeset/fast-bags-boil.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": minor
+---
+
+Støtte for prop `applicationNameHref` som gjør appnavnet til en lenke til hjemmesiden i `<InternalHeader />`.

--- a/packages/components/src/components/InternalHeader/InternalHeader.stories.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.stories.tsx
@@ -233,3 +233,16 @@ export const NonInteractiveUserOnly: Story = {
     </StoryTemplate>
   ),
 };
+
+export const WithHomeLink: Story = {
+  args: {
+    applicationName: 'Lovisa',
+    applicationDesc: 'Produktnavn',
+    applicationHref: '#',
+  },
+  decorators: Story => (
+    <StoryTemplate display="block">
+      <Story />
+    </StoryTemplate>
+  ),
+};

--- a/packages/components/src/components/InternalHeader/InternalHeader.styles.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.styles.tsx
@@ -2,7 +2,12 @@ import styled, { css } from 'styled-components';
 
 import { internalHeaderTokens as tokens } from './InternalHeader.tokens';
 import { type InternalHeaderProps } from './InternalHeader.types';
-import { selection } from '../helpers';
+import {
+  focusVisible,
+  focusVisibleTransitionValue,
+  inheritLinkStyling,
+  selection,
+} from '../helpers';
 import { OverflowMenu } from '../OverflowMenu';
 
 const { bar, separator } = tokens;
@@ -37,6 +42,15 @@ export const Bar = styled.div<{ $hasNavigation: boolean }>`
 export const BarSeparator = styled.div`
   border-left: ${separator.width} solid ${separator.color};
   align-self: stretch;
+`;
+
+export const AppNameLink = styled.a`
+  ${inheritLinkStyling}
+  transition: ${focusVisibleTransitionValue};
+  &:focus-visible,
+  &.focus-visible {
+    ${focusVisible}
+  }
 `;
 
 type NavListProps = Pick<InternalHeaderProps, 'smallScreen'>;

--- a/packages/components/src/components/InternalHeader/InternalHeader.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 
 import {
+  AppNameLink,
   Bar,
   BarSeparator,
   ContextMenuGroup,
@@ -19,6 +20,7 @@ export const InternalHeader = (props: InternalHeaderProps) => {
   const {
     applicationDesc,
     applicationName,
+    applicationHref,
     smallScreen,
     navigationElements,
     contextMenuElements,
@@ -85,7 +87,13 @@ export const InternalHeader = (props: InternalHeaderProps) => {
       $hasNavigation={!!navigation}
     >
       <Typography typographyType="bodySans02" bold as="span">
-        {applicationName}
+        {applicationHref ? (
+          <AppNameLink href={applicationHref} rel="noopener noreferrer">
+            {applicationName}
+          </AppNameLink>
+        ) : (
+          applicationName
+        )}
       </Typography>
       <Typography typographyType="bodySans02" as="span">
         {applicationDesc}

--- a/packages/components/src/components/InternalHeader/InternalHeader.types.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.types.tsx
@@ -30,6 +30,8 @@ export type InternalHeaderProps = BaseComponentProps<
     applicationName?: string;
     /**Beskrivelse på applikasjonen ellen tittel på en underside. Tilgjengelig fram til Lovisa Next kommer. */
     applicationDesc?: string;
+    /**URL til hovedsiden. */
+    applicationHref?: string;
     /**Indikerer om versjonen for små skjermer skal vises. */
     smallScreen?: boolean;
     /**Info om brukeren. Dukker opp som punkt på toppen av kontekstmenyen med tekst oppgitt i name. Blir en lenke hvis href er oppgitt. */

--- a/packages/components/src/components/helpers/styling/index.ts
+++ b/packages/components/src/components/helpers/styling/index.ts
@@ -6,5 +6,6 @@ export * from './hover';
 export * from './normalize';
 export * from './removeButtonStyling';
 export * from './removeListStyling';
+export * from './inheritLinkStyling';
 export * from './selection';
 export * from './visibilityTransition';

--- a/packages/components/src/components/helpers/styling/inheritLinkStyling.tsx
+++ b/packages/components/src/components/helpers/styling/inheritLinkStyling.tsx
@@ -1,0 +1,4 @@
+export const inheritLinkStyling = {
+  color: 'inherit',
+  textDecoration: 'inherit',
+};


### PR DESCRIPTION
Støtte for prop `applicationNameHref` som gjør appnavnet til en lenke til hjemmesiden i `<InternalHeader />`.