### PR TITLE
ELSA1-340 Fikser <Datepicker /> i Safari 

### DIFF
--- a/.changeset/seven-pants-hunt.md
+++ b/.changeset/seven-pants-hunt.md
@@ -1,0 +1,7 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Fikser at museklikk på knapper for å bla i måneder i `<Datepicker />` ikke skal lukke kalender i Safari.
+
+- Fikser også at museklikk inne i kalenderen ikke lukker den (for alle nettlesere).

--- a/packages/components/src/components/date-inputs/DatePicker/Calendar/Calendar.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/Calendar/Calendar.tsx
@@ -5,13 +5,20 @@ import {
   useCalendar,
 } from '@react-aria/calendar';
 import { useCalendarState } from '@react-stately/calendar';
-import { type FC, type PropsWithChildren } from 'react';
+import {
+  type FC,
+  type KeyboardEvent,
+  type KeyboardEventHandler,
+  type PropsWithChildren,
+  useContext,
+} from 'react';
 import styled from 'styled-components';
 
 import { CalendarGrid } from './CalendarGrid';
 import { Button } from '../../../Button';
 import { ArrowLeftIcon, ArrowRightIcon } from '../../../Icon/icons';
 import { Heading } from '../../../Typography';
+import { CalendarPopoverContext } from '../CalendarPopover';
 import { locale } from '../constants';
 
 const CalendarHeader = styled.div`
@@ -61,6 +68,16 @@ export function Calendar<T extends DateValue>(props: CalendarProps<T>) {
     title,
   } = useCalendar(props, state);
 
+  const { onClose } = useContext(CalendarPopoverContext);
+
+  const closeOnKeyboardBlurBack: KeyboardEventHandler<HTMLButtonElement> = (
+    event: KeyboardEvent<HTMLButtonElement>,
+  ) => {
+    if (event.key === 'Tab' && event.shiftKey === true) {
+      onClose();
+    }
+  };
+
   return (
     <CalendarContainer {...calendarProps}>
       <CalendarHeader>
@@ -72,6 +89,7 @@ export function Calendar<T extends DateValue>(props: CalendarProps<T>) {
           purpose="secondary"
           appearance="borderless"
           icon={ArrowLeftIcon}
+          htmlProps={{ onKeyDown: closeOnKeyboardBlurBack }}
         />
         <Month>{title}</Month>
         <StyledButton

--- a/packages/components/src/components/date-inputs/DatePicker/Calendar/CalendarCell.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/Calendar/CalendarCell.tsx
@@ -7,11 +7,12 @@ import {
   type CalendarState,
   type RangeCalendarState,
 } from '@react-stately/calendar';
-import { useRef } from 'react';
+import { type KeyboardEvent, useContext, useRef } from 'react';
 import styled, { css } from 'styled-components';
 
 import { type CellVariant, calendarTokens } from './Calendar.tokens';
 import { focusVisible, normalizeButton } from '../../../helpers';
+import { CalendarPopoverContext } from '../CalendarPopover';
 import { timezone } from '../constants';
 
 interface CalendarCellProps extends AriaCalendarCellProps {
@@ -95,11 +96,19 @@ export function CalendarCell({ date, state }: CalendarCellProps) {
     return <td {...cellProps} />;
   }
 
+  const { onClose } = useContext(CalendarPopoverContext);
+
   const variant: CellVariant = isSelected
     ? 'selected'
     : isUnavailable || isDisabled
       ? 'unavailable'
       : 'default';
+
+  const closeOnKeyboardBlurForward = (event: KeyboardEvent) => {
+    if (event.key === 'Tab' && event.shiftKey === false) {
+      onClose();
+    }
+  };
 
   return (
     <td {...cellProps}>
@@ -110,6 +119,7 @@ export function CalendarCell({ date, state }: CalendarCellProps) {
         $variant={variant}
         ref={ref}
         hidden={isOutsideVisibleRange}
+        onKeyDown={closeOnKeyboardBlurForward}
       >
         {formattedDate}
       </Cell>

--- a/packages/components/src/components/date-inputs/DatePicker/CalendarPopover.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/CalendarPopover.tsx
@@ -29,11 +29,12 @@ interface CalendarPopoverContextValue {
   onClose: () => void;
 }
 
-const CalendarPopoverContext = createContext<CalendarPopoverContextValue>({
-  anchorRef: null,
-  isOpen: false,
-  onClose: () => null,
-});
+export const CalendarPopoverContext =
+  createContext<CalendarPopoverContextValue>({
+    anchorRef: null,
+    isOpen: false,
+    onClose: () => null,
+  });
 
 interface CalendarPopoverProps {
   children: ReactNode;
@@ -107,16 +108,7 @@ export const CalendarPopoverContent = ({
   if (!isOpen) return null;
 
   return (
-    <PopoverContentContainer
-      ref={combinedRef}
-      style={styles.floating}
-      onBlur={e => {
-        const newFocus = e.relatedTarget;
-        if (ref.current && !ref.current.contains(newFocus)) {
-          onClose();
-        }
-      }}
-    >
+    <PopoverContentContainer ref={combinedRef} style={styles.floating}>
       {children}
     </PopoverContentContainer>
   );


### PR DESCRIPTION
Knappene til å bla i måneder kunne ikke brukes, kalender-popover ble lukket istedet.
Gjorde det slik at popover lukkes kun hvis brukeren: velger en dag, klikker utenfor, trykker Esc, klikker Tab fra en dag eller Shift-Tab på første knappen.