### PR TITLE
ELSA1-338 fikse at `accept`-prop i `<FileUploader>` kaster feil ved opplasting

### DIFF
--- a/.changeset/tall-sheep-exercise.md
+++ b/.changeset/tall-sheep-exercise.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Fikser at `<FileUploader>` sin `accept`-prop kastet feil ved bruk av ESM-bygg.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -73,7 +73,6 @@
     "@react-aria/focus": "^3.16.2",
     "@react-stately/calendar": "^3.4.4",
     "@react-stately/datepicker": "^3.9.2",
-    "attr-accept": "^2.2.2",
     "file-selector": "^0.6.0",
     "react-select": "^5.8.0"
   },

--- a/packages/components/src/components/FileUploader/FileUploader.spec.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.spec.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ComponentProps, useState } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { FileUploader } from './FileUploader';
+import type { FileList } from './types';
+
+function FileUploaderTest(
+  props: Omit<ComponentProps<typeof FileUploader>, 'value' | 'onChange'>,
+) {
+  const [files, setFiles] = useState<FileList>([]);
+  return <FileUploader {...props} value={files} onChange={setFiles} />;
+}
+
+const file = new File(['hello'], 'hello.png', { type: 'image/png' });
+
+describe('<FileUploader>', () => {
+  it('accepts uploading files', async () => {
+    render(<FileUploaderTest />);
+    const fileInput = screen.getByTestId('file-uploader-input');
+    await userEvent.upload(fileInput, file);
+    expect(screen.getByText('hello.png', {})).toBeInTheDocument();
+  });
+
+  it('accepts uploading files with accept prop', async () => {
+    render(<FileUploaderTest accept={['image/png']} />);
+    const fileInput = screen.getByTestId('file-uploader-input');
+    await userEvent.upload(fileInput, file);
+    expect(screen.getByText('hello.png', {})).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.tsx
@@ -175,7 +175,10 @@ export const FileUploader = (props: FileUploaderProps) => {
           $isDragActive={isDragActive}
           $hasRootErrors={hasRootErrors}
         >
-          <FileUploaderInput {...getInputProps()} />
+          <FileUploaderInput
+            {...getInputProps()}
+            data-testid="file-uploader-input"
+          />
           Dra og slipp filer her eller{' '}
           <VisuallyHidden as="span">
             velg fil med påfølgende knapp

--- a/packages/components/src/components/FileUploader/attr-accept.ts
+++ b/packages/components/src/components/FileUploader/attr-accept.ts
@@ -1,0 +1,41 @@
+/* Kopiert fra https://github.com/react-dropzone/attr-accept.
+ * attr-accept har problemer med ESM output, så vi tar heller bare inn koden direkte.
+ * Dette er all kode som ligger i pakken, og den har ikke vært endret på fire år, så
+ * det skal nok gå fint å "vedlikeholde" dette selv.
+ */
+
+/**
+ * Check if the provided file type should be accepted by the input with accept attribute.
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input#attr-accept
+ *
+ * Inspired by https://github.com/enyo/dropzone
+ *
+ * @param file {File} https://developer.mozilla.org/en-US/docs/Web/API/File
+ * @param acceptedFiles {string}
+ * @returns {boolean}
+ */
+export function isAccepted(
+  file: File,
+  acceptedFiles: Array<string> | string | undefined,
+) {
+  if (file && acceptedFiles) {
+    const acceptedFilesArray = Array.isArray(acceptedFiles)
+      ? acceptedFiles
+      : acceptedFiles.split(',');
+    const fileName = file.name || '';
+    const mimeType = (file.type || '').toLowerCase();
+    const baseMimeType = mimeType.replace(/\/.*$/, '');
+
+    return acceptedFilesArray.some(type => {
+      const validType = type.trim().toLowerCase();
+      if (validType.charAt(0) === '.') {
+        return fileName.toLowerCase().endsWith(validType);
+      } else if (validType.endsWith('/*')) {
+        // This is something like a image/* mime type
+        return baseMimeType === validType.replace(/\/.*$/, '');
+      }
+      return mimeType === validType;
+    });
+  }
+  return true;
+}

--- a/packages/components/src/components/FileUploader/utils.ts
+++ b/packages/components/src/components/FileUploader/utils.ts
@@ -1,4 +1,4 @@
-import accepted from 'attr-accept';
+import { isAccepted } from './attr-accept';
 
 export const preventDefaults = (event: React.BaseSyntheticEvent) => {
   event.preventDefault();
@@ -30,7 +30,7 @@ export const isFileAccepted = (
   file: File,
   accept: Array<string> | undefined,
 ): boolean => {
-  return accept !== undefined ? accepted(file, accept) : true;
+  return accept !== undefined ? isAccepted(file, accept) : true;
 };
 
 // export const isFileSizeAccepted = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,9 +123,6 @@ importers:
       '@react-stately/datepicker':
         specifier: ^3.9.2
         version: 3.9.2(react@18.2.0)
-      attr-accept:
-        specifier: ^2.2.2
-        version: 2.2.2
       file-selector:
         specifier: ^0.6.0
         version: 0.6.0
@@ -5411,11 +5408,6 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  /attr-accept@2.2.2:
-    resolution: {integrity: sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==}
-    engines: {node: '>=4'}
-    dev: false
 
   /available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}


### PR DESCRIPTION
`attr-accept` har problemer med ESM output. Siden pakken uansett er så liten, og den ikke har blitt oppdatert på 4 år, så er det like greit å bare "inline" implementasjonen.