### PR TITLE
ELSA1-341 fikse at Calendar brukte språket til nettleser for måned

### DIFF
--- a/.changeset/good-mirrors-reflect.md
+++ b/.changeset/good-mirrors-reflect.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Fikser språkfeil i DatePicker hvor den tekstlige representasjonen for måned i kalenderen fortsatt brukte språket til nettleseren

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -71,6 +71,7 @@
     "@react-aria/calendar": "^3.5.6",
     "@react-aria/datepicker": "^3.9.3",
     "@react-aria/focus": "^3.16.2",
+    "@react-aria/i18n": "^3.10.2",
     "@react-stately/calendar": "^3.4.4",
     "@react-stately/datepicker": "^3.9.2",
     "file-selector": "^0.6.0",

--- a/packages/components/src/components/date-inputs/DatePicker/Calendar/Calendar.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/Calendar/Calendar.tsx
@@ -4,6 +4,7 @@ import {
   type DateValue,
   useCalendar,
 } from '@react-aria/calendar';
+import { useLocale } from '@react-aria/i18n';
 import { useCalendarState } from '@react-stately/calendar';
 import {
   type FC,
@@ -19,7 +20,6 @@ import { Button } from '../../../Button';
 import { ArrowLeftIcon, ArrowRightIcon } from '../../../Icon/icons';
 import { Heading } from '../../../Typography';
 import { CalendarPopoverContext } from '../CalendarPopover';
-import { locale } from '../constants';
 
 const CalendarHeader = styled.div`
   display: flex;
@@ -56,6 +56,7 @@ function createCalendar(identifier: string) {
 export type CalendarProps<T extends DateValue> = AriaCalendarProps<T>;
 
 export function Calendar<T extends DateValue>(props: CalendarProps<T>) {
+  const { locale } = useLocale();
   const state = useCalendarState({
     ...props,
     createCalendar,

--- a/packages/components/src/components/date-inputs/DatePicker/Calendar/CalendarGrid.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/Calendar/CalendarGrid.tsx
@@ -3,6 +3,7 @@ import {
   type AriaCalendarGridProps,
   useCalendarGrid,
 } from '@react-aria/calendar';
+import { useLocale } from '@react-aria/i18n';
 import {
   type CalendarState,
   type RangeCalendarState,
@@ -12,7 +13,6 @@ import styled from 'styled-components';
 import { calendarTokens } from './Calendar.tokens';
 import { CalendarCell } from './CalendarCell';
 import { getWeekNumber } from '../../utils/getWeekNumber';
-import { locale } from '../constants';
 
 const { grid: gridTokens } = calendarTokens;
 
@@ -47,6 +47,7 @@ const WeekNumber = styled.td`
 `;
 
 export function CalendarGrid({ state, ...props }: CalendarGridProps) {
+  const { locale } = useLocale();
   const {
     gridProps: { onKeyDown, ...gridProps },
     headerProps,

--- a/packages/components/src/components/date-inputs/DatePicker/DateField/DateField.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/DateField/DateField.tsx
@@ -8,6 +8,7 @@ import {
   useDateField,
   type useDatePicker,
 } from '@react-aria/datepicker';
+import { useLocale } from '@react-aria/i18n';
 import { useDateFieldState } from '@react-stately/datepicker';
 import type * as CSS from 'csstype';
 import {
@@ -22,7 +23,6 @@ import { CalendarButton } from './CalendarButton';
 import { DateSegment } from './DateSegment';
 import { type InputProps } from '../../../helpers';
 import { DateInput } from '../../common/DateInput';
-import { locale } from '../constants';
 
 export type DateFieldProps<T extends DateValue = CalendarDate> =
   AriaDateFieldOptions<T> & {
@@ -47,6 +47,7 @@ function _DateField(
   }: DateFieldProps,
   forwardedRef: Ref<HTMLDivElement>,
 ) {
+  const { locale } = useLocale();
   const state = useDateFieldState({
     ...props,
     locale,

--- a/packages/components/src/components/date-inputs/DatePicker/DatePicker.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/DatePicker.tsx
@@ -1,5 +1,6 @@
 import { type CalendarDate } from '@internationalized/date';
 import { useDatePicker } from '@react-aria/datepicker';
+import { I18nProvider } from '@react-aria/i18n';
 import { useDatePickerState } from '@react-stately/datepicker';
 import type { AriaDatePickerProps } from '@react-types/datepicker';
 import type * as CSS from 'csstype';
@@ -11,6 +12,7 @@ import {
   CalendarPopoverAnchor,
   CalendarPopoverContent,
 } from './CalendarPopover';
+import { locale } from './constants';
 import { DateField, type DateFieldProps } from './DateField/DateField';
 import { useCombinedRef } from '../../../hooks';
 import {
@@ -56,26 +58,28 @@ export function _DatePicker(
   );
 
   return (
-    <CalendarPopover isOpen={state.isOpen} onClose={state.close}>
-      <CalendarPopoverAnchor>
-        <DateField
-          {...fieldProps}
-          groupProps={groupProps}
-          ref={combinedRef}
-          componentSize={componentSize}
-          tip={tip}
-          label={props.label}
-          errorMessage={errorMessage}
-          buttonProps={buttonProps}
-          isOpen={state.isOpen}
-          style={style}
-          width={width}
-        />
-      </CalendarPopoverAnchor>
-      <CalendarPopoverContent>
-        <Calendar {...calendarProps} />
-      </CalendarPopoverContent>
-    </CalendarPopover>
+    <I18nProvider locale={locale}>
+      <CalendarPopover isOpen={state.isOpen} onClose={state.close}>
+        <CalendarPopoverAnchor>
+          <DateField
+            {...fieldProps}
+            groupProps={groupProps}
+            ref={combinedRef}
+            componentSize={componentSize}
+            tip={tip}
+            label={props.label}
+            errorMessage={errorMessage}
+            buttonProps={buttonProps}
+            isOpen={state.isOpen}
+            style={style}
+            width={width}
+          />
+        </CalendarPopoverAnchor>
+        <CalendarPopoverContent>
+          <Calendar {...calendarProps} />
+        </CalendarPopoverContent>
+      </CalendarPopover>
+    </I18nProvider>
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@react-aria/focus':
         specifier: ^3.16.2
         version: 3.16.2(react@18.2.0)
+      '@react-aria/i18n':
+        specifier: ^3.10.2
+        version: 3.10.2(react@18.2.0)
       '@react-stately/calendar':
         specifier: ^3.4.4
         version: 3.4.4(react@18.2.0)


### PR DESCRIPTION
`useCalendar` tar ikke inn `locale`, så vi må bruke `I18nProvider` for å sette språk istedet.

Det er nok uansett bedre å bruke `I18nProvider` til dette, da det kan bli litt enklere i fremtiden om vi ønsker å la konsumenter overstyre locale.