### PR TITLE
ELSA1-296 Fjerner `<div>` fra `<Table.Cell />`

### DIFF
--- a/.changeset/lazy-spiders-lie.md
+++ b/.changeset/lazy-spiders-lie.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+`layout`-prop pleide å legge til en flex `<div>` i en celle for å styre layout; det er som regel unødvendig.Fjerner div-en for alle varianter av layout unntatt tekst og ikon. Bruker `text-align` direkte på cellen i de andre variantene.

--- a/packages/components/src/components/Table/normal/Cell.tsx
+++ b/packages/components/src/components/Table/normal/Cell.tsx
@@ -16,11 +16,11 @@ const getLayoutStyle = (layout: TableCellLayout) => {
   switch (layout) {
     case 'center':
       return css`
-        justify-content: center;
+        text-align: center;
       `;
     case 'right':
       return css`
-        justify-content: flex-end;
+        text-align: right;
       `;
     case 'text and icon':
       return css`
@@ -34,12 +34,14 @@ const getLayoutStyle = (layout: TableCellLayout) => {
 
 const StyledCell = styled.td<{
   $type: TableCellType;
+  $layout?: TableCellLayout;
 }>`
   ${({ $type: type }) =>
     type === 'head' &&
     css`
       background-color: ${cell.head.backgroundColor};
     `}
+  ${({ $layout: layout }) => layout && getLayoutStyle(layout)}
 `;
 
 const InnerCell = styled.div<{ $layout: TableCellLayout }>`
@@ -60,7 +62,7 @@ export type TableCellProps = {
    * @default 'data' hvis den er brukt i `<Table.Body>` eller `<Table.Foot>`, 'head' hvis den er i `<Table.Head>`.
    */
   type?: TableCellType;
-  /**Layout av innholdet i cellen. 'tekst and icon' legger `gap` mellom barna og andre barnet i cellen.  */
+  /**Layout av innholdet i cellen; legger en flex `<div>` i cellen, unntatt 'none' som ikke legger inn noe. 'tekst and icon' legger `gap` mellom barna og andre barnet i cellen.  */
   layout?: TableCellLayout;
   /** Props ved bruk av `<CollapsibleRow>`. **OBS!** settes automatisk av forelder. */
   collapsibleProps?: CollapsibleProps;
@@ -89,12 +91,23 @@ export const Cell = forwardRef<HTMLTableCellElement, TableCellProps>(
     const as: ElementType = getTableCellType(type);
 
     const { isCollapsibleChild } = collapsibleProps ?? {};
+    const isComplexLayout = layout === 'text and icon';
 
     return isCollapsibleChild ? (
       <DescriptionListDesc>{children}</DescriptionListDesc>
     ) : (
-      <StyledCell as={as} ref={ref} $type={type} {...rest}>
-        <InnerCell $layout={layout}>{children}</InnerCell>
+      <StyledCell
+        as={as}
+        ref={ref}
+        $layout={isComplexLayout ? undefined : layout}
+        $type={type}
+        {...rest}
+      >
+        {isComplexLayout ? (
+          <InnerCell $layout={layout}>{children}</InnerCell>
+        ) : (
+          children
+        )}
       </StyledCell>
     );
   },


### PR DESCRIPTION
`layout`-prop legger til en flex `<div>` i en celle for  å styre layout; det er som regel unødvendig.

Fjerner div-en for alle varianter av layout unntatt tekst og ikon. Bruker `text-align` direkte på cellen i de andre variantene.