### PR TITLE
fix: Eksporter styling for Grid

### DIFF
--- a/.changeset/great-humans-approve.md
+++ b/.changeset/great-humans-approve.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Eksporter styling for Grid

--- a/packages/components/src/components/Grid/Grid.tsx
+++ b/packages/components/src/components/Grid/Grid.tsx
@@ -16,7 +16,7 @@ interface StyledGridProps {
   rowGap?: RowGapGrid;
 }
 
-const getHooksGridStyling = (
+export const getHooksGridStyling = (
   screenSize: ScreenSize,
   maxWidth?: MaxWidthGrid,
   rowGap?: RowGapGrid,


### PR DESCRIPTION
Dette gjøres for at PageGenerator kan få samme styling når Fieldset-komponenten er i bruk.