### PR TITLE
ELSA1-313 marker alle komponenter som client components

### DIFF
--- a/.changeset/wicked-queens-ring.md
+++ b/.changeset/wicked-queens-ring.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Markerer alle komponenter som client components

--- a/packages/components/tsup.config.ts
+++ b/packages/components/tsup.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'tsup';
+
 import baseConfig from '../../tsup.config';
 
 export default defineConfig({
   ...baseConfig,
   publicDir: 'public',
+  banner: {
+    js: '"use client";',
+  },
 });


### PR DESCRIPTION
Gjør det enklere å bruke komponentene i Next.js. Dette gjør at vi kan bruke Elsa-komponenter i server components.