### PR TITLE
ELSA1-362 Fjerner unødvendig `aria-label`

### DIFF
--- a/.changeset/lazy-ties-move.md
+++ b/.changeset/lazy-ties-move.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Fjerner unødvendig `aria-label` fra enkelte komponenter

--- a/packages/components/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/components/src/components/OverflowMenu/OverflowMenu.tsx
@@ -215,7 +215,7 @@ export const OverflowMenu = forwardRef<HTMLDivElement, OverflowMenuProps>(
     };
 
     return (
-      <Container {...containerProps} aria-label="bruk piltaster for å navigere">
+      <Container {...containerProps}>
         {hasStaticUser && (
           <OverflowMenuItem title={username} icon={PersonIcon} />
         )}

--- a/packages/components/src/components/Search/Search.stories.tsx
+++ b/packages/components/src/components/Search/Search.stories.tsx
@@ -140,7 +140,7 @@ export const OverviewWithSuggestion: Story = {
     </StoryTemplate>
   ),
   render: args => (
-    <VStack gap="x1">
+    <VStack gap="x1" align="right">
       <Search.AutocompleteWrapper data={{ array }}>
         <Search {...args} componentSize="large" />
       </Search.AutocompleteWrapper>
@@ -174,8 +174,20 @@ export const WithSuggestions: Story = {
     </StoryTemplate>
   ),
   render: args => (
-    <Search.AutocompleteWrapper data={{ array }}>
-      <Search {...args} />
-    </Search.AutocompleteWrapper>
+    <>
+      <Search.AutocompleteWrapper data={{ array }}>
+        <Search {...args} />
+      </Search.AutocompleteWrapper>
+      <div>
+        Elementer i listen:{' '}
+        {array.map((item, index) => (
+          <span>
+            {item}
+            {index !== array.length - 1 && ', '}
+          </span>
+        ))}
+        .
+      </div>
+    </>
   ),
 };

--- a/packages/components/src/components/Tabs/TabList.tsx
+++ b/packages/components/src/components/Tabs/TabList.tsx
@@ -109,7 +109,6 @@ export const TabList = forwardRef<HTMLDivElement, TabListProps>(
           {...rest}
           ref={combinedRef}
           role="tablist"
-          aria-label="Bruk venste og høyre piltast for å bla"
           id={uniqueId}
           tabIndex={0}
           onFocus={handleOnFocus}


### PR DESCRIPTION
Fjerner unødvendig `aria-label` fra enkelte komponenter: Tabs, OverflowMenu. Den informerte om retning for fokus, noe som er implisitt formidlet via rolle.