### PR TITLE
ELSA1-364 Fokusmarkering i selection cotrols

### DIFF
--- a/.changeset/olive-bugs-beg.md
+++ b/.changeset/olive-bugs-beg.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": patch
+---
+
+Endrer fokusmarkering i `<Checkbox />` og `<RadioButton />` til å markere kun inputelementet, ikke ledetekst. Fokusmarkeringen settes ikke ved museklikk, kun tastaturfokus.

--- a/packages/components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
@@ -44,12 +44,6 @@ export const Overview: Story = {
       <CheckboxGroup {...args} required />
       <CheckboxGroup {...args} tip="Dette er en hjelpetekst" />
       <CheckboxGroup {...args} errorMessage="Dette er en feilmelding" />
-
-      <CheckboxGroup
-        {...args}
-        tip="Dette er en hjelpetekst"
-        errorMessage="Dette er en feilmelding"
-      />
       <CheckboxGroup {...args} direction="column" />
     </>
   ),

--- a/packages/components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
+++ b/packages/components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
@@ -63,7 +63,6 @@ export const Overview: Story = {
       <>
         <RadioButtonGroup
           {...args}
-          direction="row"
           value={value}
           name="test"
           onChange={(_event, value) => {
@@ -77,7 +76,6 @@ export const Overview: Story = {
         <RadioButtonGroup
           {...args}
           tip="Dette er en hjelpetekst"
-          direction="row"
           value={value}
           name="test2"
           onChange={(_event, value) => {
@@ -91,24 +89,8 @@ export const Overview: Story = {
         <RadioButtonGroup
           {...args}
           errorMessage="Dette er en feilmelding"
-          direction="row"
           value={value}
           name="test4"
-          onChange={(_event, value) => {
-            setValue(value);
-          }}
-        >
-          <RadioButton label="Option 1" value={1} />
-          <RadioButton label="Option 2" value={2} />
-          <RadioButton label="Option 3" value={3} />
-        </RadioButtonGroup>
-        <RadioButtonGroup
-          {...args}
-          errorMessage="Dette er en feilmelding"
-          tip="Dette er en hjelpetekst"
-          direction="row"
-          value={value}
-          name="test6"
           onChange={(_event, value) => {
             setValue(value);
           }}

--- a/packages/components/src/components/SelectionControl/SelectionControl.styles.tsx
+++ b/packages/components/src/components/SelectionControl/SelectionControl.styles.tsx
@@ -71,7 +71,7 @@ export const Container = styled.label<{
     }
   }
 
-  &:focus-within {
+  input:enabled:focus-visible ~ ${CustomSelectionControl} {
     ${focusVisible}
     @media (prefers-reduced-motion: no-preference) {
       transition: ${focusVisibleTransitionValue};
@@ -105,17 +105,19 @@ export const Container = styled.label<{
   ${({ $error }) =>
     $error &&
     css`
-      &:hover input:enabled ~ ${CustomSelectionControl} {
+      &:hover
+        input:enabled:not(:focus-visible):not(:checked)
+        ~ ${CustomSelectionControl} {
         background-color: ${selectionControl.hover.danger.backgroundColor};
         box-shadow: ${selectionControl.hover.danger.boxShadow};
         border-color: ${selectionControl.hover.danger.borderColor};
       }
-      input
+      input:not(:focus-visible)
         ~ ${CustomSelectionControl},
-        input:checked:enabled
+        input:checked:enabled:not(:focus-visible)
         ~ ${CustomSelectionControl},
         &:hover
-        input:checked:enabled
+        input:checked:enabled:not(:focus-visible)
         ~ ${CustomSelectionControl} {
         box-shadow: ${selectionControl.danger.boxShadow};
         border-color: ${selectionControl.danger.borderColor};


### PR DESCRIPTION
Endrer fokusmarkering i `<Checkbox />` og `<RadioButton />` til å markere kun inputelementet, ikke ledetekst. Fokusmarkeringen settes ikke ved museklikk, kun tastaturfokus.