### PR TITLE
legge til `textAreaTip`-prop

### DIFF
--- a/.changeset/heavy-zoos-deliver.md
+++ b/.changeset/heavy-zoos-deliver.md
@@ -1,0 +1,5 @@
+---
+"@norges-domstoler/dds-components": minor
+---
+
+Legger til prop, `textAreaTip`, i `<Feedback>`-komponenten som kan brukes for å sette tip-teksten på tekstfeltet på kommenteringssteget.

--- a/packages/components/src/components/Feedback/CommentComponent.tsx
+++ b/packages/components/src/components/Feedback/CommentComponent.tsx
@@ -15,6 +15,7 @@ interface CommentComponentType {
   positiveFeedbackLabel: string;
   negativeFeedbackLabel: string;
   ratingSubmittedTitle: string;
+  textAreaTip: string;
   loading: boolean;
   handleSubmit: () => void;
   handleFeedbackTextChange: (newText: string) => void;
@@ -26,6 +27,7 @@ export const CommentComponent = ({
   positiveFeedbackLabel,
   negativeFeedbackLabel,
   ratingSubmittedTitle,
+  textAreaTip,
   loading,
   handleSubmit,
   handleFeedbackTextChange,
@@ -47,7 +49,7 @@ export const CommentComponent = ({
         label={
           rating === 'positive' ? positiveFeedbackLabel : negativeFeedbackLabel
         }
-        tip="Ikke send inn personopplysninger eller annen sensitiv informasjon"
+        tip={textAreaTip}
       />
 
       <Button

--- a/packages/components/src/components/Feedback/Feedback.stories.tsx
+++ b/packages/components/src/components/Feedback/Feedback.stories.tsx
@@ -48,6 +48,9 @@ export default {
     submittedTitle: {
       control: 'text',
     },
+    textAreaTip: {
+      control: 'text',
+    },
     feedbackTextAreaExcluded: {
       control: 'boolean',
     },

--- a/packages/components/src/components/Feedback/Feedback.tsx
+++ b/packages/components/src/components/Feedback/Feedback.tsx
@@ -12,6 +12,7 @@ export const Feedback = ({
   negativeFeedbackLabel = 'Hva kan vi forbedre? (valgfritt)',
   ratingSubmittedTitle = 'Tusen takk! Tilbakemeldingen din hjelper oss å forbedre løsningen',
   submittedTitle = 'Tusen takk! Tilbakemeldingen din hjelper oss å forbedre løsningen',
+  textAreaTip = 'Ikke send inn personopplysninger eller annen sensitiv informasjon',
   ratingValue: ratingProp,
   feedbackTextValue: feedbackTextProp,
   thumbUpTooltip = 'Bra',
@@ -79,6 +80,7 @@ export const Feedback = ({
         positiveFeedbackLabel={positiveFeedbackLabel}
         negativeFeedbackLabel={negativeFeedbackLabel}
         ratingSubmittedTitle={ratingSubmittedTitle}
+        textAreaTip={textAreaTip}
         loading={loading}
         handleSubmit={handleSubmit}
         handleFeedbackTextChange={handleFeedbackTextChange}

--- a/packages/components/src/components/Feedback/Feedback.types.tsx
+++ b/packages/components/src/components/Feedback/Feedback.types.tsx
@@ -11,6 +11,8 @@ export interface FeedbackProps {
   ratingSubmittedTitle?: string;
   /**Tittel som vises når bruker har gitt feedback (inkl. eventuell kommentar) */
   submittedTitle?: string;
+  /**Tip som vises under tekstfeltet når bruker skal sende inn kommentar  */
+  textAreaTip?: string;
   /**Om tommel opp eller ned er valgt. Brukes når komponenten skal være styrt utenfra. */
   ratingValue?: Rating | null;
   /**Verdien til fritekstfeltet. Brukes når komponenten skal være styrt utenfra. */


### PR DESCRIPTION
I overbygg begynner vi nå å legge inn oversettelser og da er det nyttig å kunne endre teksten på tipen til `<TextArea>`-et i `<Feedback>`-komponenten.