### PR TITLE
ELSA1-392 Style fixes

### DIFF
--- a/.changeset/new-hats-fly.md
+++ b/.changeset/new-hats-fly.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Bruker `<h2>` istedenfor `<h5>` som default for tittel i `<EmptyContent>`. På denne måten vil den ikke bryte UU uansett oversiktshierarki.

--- a/.changeset/odd-countries-suffer.md
+++ b/.changeset/odd-countries-suffer.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Mindre justeringer på spacing, farger og ikonstørrelser i en rekke komponenter.

--- a/packages/components/src/components/Button/Button.module.css
+++ b/packages/components/src/components/Button/Button.module.css
@@ -73,7 +73,7 @@
   }
 
   &.with-text-and-icon {
-    gap: var(--dds-spacing-x0-5);
+    gap: var(--dds-spacing-x0-25);
 
     &.with-icon-left {
       padding: var(--dds-spacing-x0-5) var(--dds-spacing-x0-75)

--- a/packages/components/src/components/Chip/Chip.tsx
+++ b/packages/components/src/components/Chip/Chip.tsx
@@ -4,7 +4,7 @@ import styles from './Chip.module.css';
 import { type BaseComponentProps, getBaseHTMLProps } from '../../types';
 import { cn } from '../../utils/dom';
 import { Button } from '../Button';
-import { CloseIcon } from '../Icon/icons';
+import { CloseSmallIcon } from '../Icon/icons';
 import { TextOverflowEllipsisInner } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
@@ -47,7 +47,7 @@ export const Chip = forwardRef<HTMLDivElement, ChipProps>((props, ref) => {
       </TextOverflowEllipsisInner>
       <Button
         size="tiny"
-        icon={CloseIcon}
+        icon={CloseSmallIcon}
         purpose="tertiary"
         onClick={onClick}
         aria-label={ariaLabel ?? `Fjern ${text ? `chip ${text}` : 'chip'}`}

--- a/packages/components/src/components/EmptyContent/EmptyContent.tsx
+++ b/packages/components/src/components/EmptyContent/EmptyContent.tsx
@@ -16,7 +16,7 @@ export type EmptyContentProps = {
 export function EmptyContent({
   title,
   message,
-  titleHeadingLevel = 5,
+  titleHeadingLevel = 2,
   className,
   ...rest
 }: EmptyContentProps) {

--- a/packages/components/src/components/Feedback/Feedback.module.css
+++ b/packages/components/src/components/Feedback/Feedback.module.css
@@ -20,5 +20,28 @@
 }
 
 .button {
-  padding: 0 !important;
+  border-radius: var(--dds-border-radius-1);
+  color: var(--dds-color-text-default);
+
+  &:hover {
+    background-color: var(--dds-color-surface-hover-default);
+    color: var(--dds-color-icon-action-hover);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition:
+      background-color 0.2s,
+      color 0.2s,
+      var(--dds-focus-transition);
+  }
+}
+
+.button--horizontal {
+  width: var(--dds-icon-size-medium);
+  height: var(--dds-icon-size-medium);
+}
+
+.button--vertical {
+  width: var(--dds-icon-size-large);
+  height: var(--dds-icon-size-large);
 }

--- a/packages/components/src/components/Feedback/RatingComponent.tsx
+++ b/packages/components/src/components/Feedback/RatingComponent.tsx
@@ -1,7 +1,9 @@
 import styles from './Feedback.module.css';
 import { type Layout, type Rating } from './Feedback.types';
 import { cn } from '../../utils';
-import { Button } from '../Button';
+import { focusable } from '../helpers/styling/focus.module.css';
+import utilStyles from '../helpers/styling/utilStyles.module.css';
+import { Icon } from '../Icon';
 import { ThumbDownIcon, ThumbUpIcon } from '../Icon/icons';
 import { Spinner } from '../Spinner';
 import { HStack } from '../Stack';
@@ -26,6 +28,27 @@ export const RatingComponent = ({
   handleRatingChange,
 }: RatingComponentType) => {
   const layoutCn = layout === 'vertical' ? 'column' : 'row';
+  type Purpose = 'up' | 'down';
+
+  const button = (purpose: Purpose, layout: Layout) => (
+    <button
+      aria-label={purpose === 'up' ? thumbUpTooltip : thumbDownTooltip}
+      onClick={() =>
+        handleRatingChange(purpose === 'up' ? 'positive' : 'negative')
+      }
+      className={cn(
+        utilStyles['remove-button-styling'],
+        styles.button,
+        styles[`button--${layout}`],
+        focusable,
+      )}
+    >
+      <Icon
+        icon={purpose === 'up' ? ThumbUpIcon : ThumbDownIcon}
+        iconSize={layout === 'vertical' ? 'large' : 'medium'}
+      />
+    </button>
+  );
 
   return (
     <div
@@ -39,27 +62,9 @@ export const RatingComponent = ({
         <Spinner tooltip="Laster opp tilbakemelding ..." />
       ) : (
         <HStack gap="x1">
-          <Tooltip text={thumbUpTooltip}>
-            <Button
-              htmlProps={{ 'aria-label': thumbUpTooltip }}
-              icon={ThumbUpIcon}
-              purpose="tertiary"
-              onClick={() => handleRatingChange('positive')}
-              size="large"
-              className={styles.button}
-            />
-          </Tooltip>
+          <Tooltip text={thumbUpTooltip}>{button('up', layout)}</Tooltip>
           <Tooltip text={thumbDownTooltip}>
-            <div>
-              <Button
-                htmlProps={{ 'aria-label': thumbDownTooltip }}
-                icon={ThumbDownIcon}
-                purpose="tertiary"
-                onClick={() => handleRatingChange('negative')}
-                size="large"
-                className={styles.button}
-              />
-            </div>
+            <div>{button('down', layout)}</div>
           </Tooltip>
         </HStack>
       )}

--- a/packages/components/src/components/LocalMessage/LocalMessage.tsx
+++ b/packages/components/src/components/LocalMessage/LocalMessage.tsx
@@ -110,7 +110,7 @@ export const LocalMessage = forwardRef<HTMLDivElement, LocalMessageProps>(
       >
         <Icon
           icon={purposeVariants[purpose].icon}
-          className={styles.container__icon}
+          className={cn(styles.icon, styles.container__icon)}
         />
         <div className={styles.container__text}>
           {children ?? <span>{message}</span>}

--- a/packages/components/src/components/Pagination/Pagination.tsx
+++ b/packages/components/src/components/Pagination/Pagination.tsx
@@ -293,13 +293,14 @@ export const Pagination = forwardRef<HTMLElement, PaginationProps>(
             <Select
               options={selectOptions}
               isSearchable={false}
-              width="88px"
+              width="74px"
               defaultValue={{
                 label: itemsPerPage.toString(),
                 value: itemsPerPage,
               }}
               isClearable={false}
               onChange={handleSelectChange}
+              componentSize="small"
               aria-label="Antall elementer per side"
             />
           )}

--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -114,7 +114,7 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         style={{ ...htmlProps.style, ...floatingStyles.floating, ...sizeProps }}
         role="dialog"
         elevation={3}
-        border="default"
+        border="subtle"
         className={cn(
           styles.container,
           utilStyles['visibility-transition'],

--- a/packages/components/src/components/Select/Select.module.css
+++ b/packages/components/src/components/Select/Select.module.css
@@ -18,6 +18,8 @@
 
 .icon {
   margin-right: var(--dds-spacing-x0-5);
+  /* Ikon har samme plassering som i TextInput */
+  margin-left: -1px;
 }
 
 .control {

--- a/packages/components/src/components/SelectionControl/SelectionControl.module.css
+++ b/packages/components/src/components/SelectionControl/SelectionControl.module.css
@@ -37,7 +37,7 @@
     }
   }
 
-  &:hover input:enabled ~ .selection-control {
+  &:hover input:enabled:not(:checked) ~ .selection-control {
     background-color: var(--dds-color-surface-hover-default);
     box-shadow: inset 0 0 0 1px var(--dds-color-border-action-hover);
     border-color: var(--dds-color-border-action-hover);
@@ -49,7 +49,7 @@
     background-color: var(--dds-color-surface-action-selected);
   }
 
-  &:hover input:checked:enabled ~ .selection-control,
+  &:hover input:checked:enabled[type='checkbox'] ~ .selection-control,
   &:hover input:enabled[data-indeterminate='true'] ~ .selection-control {
     background-color: var(--dds-color-surface-action-hover);
     border-color: var(--dds-color-surface-action-hover);

--- a/packages/components/src/components/TextInput/TextInput.module.css
+++ b/packages/components/src/components/TextInput/TextInput.module.css
@@ -46,7 +46,7 @@
 
 .icon--small {
   left: var(--dds-spacing-x0-75);
-  top: calc(50% - (var(--dds-icon-size-small) / 2));
+  top: calc(50% - (var(--dds-icon-size-medium) / 2));
 }
 
 .icon--tiny {

--- a/packages/components/src/components/Tooltip/Tooltip.module.css
+++ b/packages/components/src/components/Tooltip/Tooltip.module.css
@@ -3,7 +3,7 @@
 }
 
 .svg-arrow__border {
-  fill: var(--dds-color-border-default);
+  fill: var(--dds-color-border-subtle);
 }
 
 .svg-arrow__background {

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -163,7 +163,7 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
         <Paper
           {...wrapperProps}
           elevation={1}
-          border="default"
+          border="subtle"
           className={cn(
             styles.paper,
             typographyStyles['body-sans-02'],

--- a/packages/components/src/components/date-inputs/DatePicker/DateField/CalendarButton.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/DateField/CalendarButton.tsx
@@ -19,7 +19,7 @@ export function CalendarButton({
   const ref = useRef<HTMLButtonElement>(null);
   const { buttonProps } = useButton(props, ref);
 
-  const size = componentSize === 'medium' ? 'medium' : 'small';
+  const size = componentSize === 'tiny' ? 'small' : 'medium';
 
   return (
     <button

--- a/packages/components/src/components/date-inputs/TimePicker/TimePicker.tsx
+++ b/packages/components/src/components/date-inputs/TimePicker/TimePicker.tsx
@@ -33,7 +33,7 @@ function _TimePicker(
     ref,
   );
 
-  const iconSize = componentSize === 'medium' ? 'medium' : 'small';
+  const iconSize = componentSize === 'tiny' ? 'small' : 'medium';
   const disabled = props.isDisabled || !!fieldProps['aria-disabled'];
 
   return (

--- a/packages/components/src/components/date-inputs/common/DateInput.module.css
+++ b/packages/components/src/components/date-inputs/common/DateInput.module.css
@@ -3,7 +3,7 @@
 }
 
 .container--small {
-  width: 140px;
+  width: 148px;
 }
 
 .container--tiny {

--- a/packages/components/src/utils/icon.ts
+++ b/packages/components/src/utils/icon.ts
@@ -6,7 +6,7 @@ export const getFormInputIconSize = (componentSize: InputSize): IconSize => {
     case 'medium':
       return 'medium';
     case 'small':
-      return 'small';
+      return 'medium';
     case 'tiny':
       return 'small';
   }


### PR DESCRIPTION
Mindre styling fixes på ting som ble litt feil under CSS-migreringen:

- Spacing mellom icon og text i Small `<Button size="small">` skal være `0_25`, ikke `0_5`
- `<EmptyContent>`: `<h2>` for tittel som default med `typographyType="headingSans02"`.
- `<Feedback>`: ikke bruke `<Button>`, den passer ikke i denne konteksten; gi ikonet action-hover farge på på hover.
- `<LocalMessage>`: bruke riktig fargetokens for ikonet
- Bruke subtle border i `<Popover>`
- Fjerne hover på selected i `<RadioButton>`
- Bruke medium ikon i small-varianten av skjemakomponenter som kan ha et ikon.
- Bruke subtle border i `<Tooltip>`
- Paginering: <Select> skal ha samme størrelse som knapper

