### PR TITLE
OBYGG-112 - Eget PROTOTYPE env for banner

### DIFF
--- a/.changeset/stupid-impalas-wave.md
+++ b/.changeset/stupid-impalas-wave.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/development-utils': minor
+---
+
+Environment banner now supports PROTOTYPE env

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Start opp storybook
 pnpm storybook
 ```
 
+#### Finner ikke @norges-domstol\dds-token
+
+Skal ikke egentlig være nødvendig, men hvis du får en feilmeldinger om at den ikke finner @norges-domstol\dds-token kan du prøve:
+
+```bash
+pnpm build
+```
+
 #### Legge til change notes
 
 Når du er ferdig med PR, legg til [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md):

--- a/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBanner.tsx
+++ b/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBanner.tsx
@@ -1,6 +1,13 @@
 import styled from 'styled-components';
 
-export const environments = ['LOKAL', 'TEST', 'AT', 'KURS', 'PROD'] as const;
+export const environments = [
+  'LOKAL',
+  'TEST',
+  'AT',
+  'KURS',
+  'PROD',
+  'PROTOTYPE',
+] as const;
 export type Environment = (typeof environments)[number];
 type NonProdEnvironment = Exclude<Environment, 'PROD'>;
 
@@ -31,6 +38,8 @@ function getBannerColor(environment: NonProdEnvironment): {
       return { background: '#7AB73D', text: '#2B4116' };
     case 'LOKAL':
       return { background: '#F2D32C', text: '#695B07' };
+    case 'PROTOTYPE':
+      return { background: '#E9E1FB', text: '#5E032F' };
   }
 }
 


### PR DESCRIPTION
For prototyper som ikke har test-data ønsker man å ha et PROTOTYPE enviornment som er lilla.

![image](https://github.com/domstolene/designsystem/assets/464589/1aba1d6f-31c3-469a-b679-ddbda7b2fdad)

refs: https://domstol.atlassian.net/browse/OBYGG-112