### PR TITLE
ELSA1-376 `width`-prop påvirker selve inputfeltet

### DIFF
--- a/.changeset/cold-cooks-wonder.md
+++ b/.changeset/cold-cooks-wonder.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+`width`-prop i `<TextInput>`, `<TextArea>`, `<TimePicker>` og `<DatePicker>` påvirker nå kun selve inputfeltet. Det betyr at hele komponenten tar den bredden den får tilgjengelig. Ledetekst, feilmeding og hjelpetekst kan bli bredere enn inputfeltet.

--- a/packages/components/src/components/TextArea/TextArea.module.css
+++ b/packages/components/src/components/TextArea/TextArea.module.css
@@ -1,8 +1,5 @@
-.container {
-  width: var(--dds-input-default-width);
-}
-
 .textarea {
+  width: var(--dds-text-area-width);
   height: auto;
   resize: vertical;
   vertical-align: bottom;

--- a/packages/components/src/components/TextArea/TextArea.tsx
+++ b/packages/components/src/components/TextArea/TextArea.tsx
@@ -1,3 +1,4 @@
+import { type Properties } from 'csstype';
 import { forwardRef, useEffect, useId, useRef, useState } from 'react';
 import { type TextareaHTMLAttributes } from 'react';
 
@@ -93,13 +94,23 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
       ...rest,
     };
 
+    const styleVariables: Properties = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ['--dds-text-area-width' as any]:
+        width ?? 'var(--dds-input-default-width)',
+    };
+
     return (
       <div
-        className={cn(className, inputStyles.container, styles.container)}
-        style={{ ...style, width }}
+        className={cn(className, inputStyles.container)}
+        style={{ ...style }}
       >
         {hasLabel && (
-          <Label showRequiredStyling={showRequiredStyling} htmlFor={uniqueId}>
+          <Label
+            showRequiredStyling={showRequiredStyling}
+            htmlFor={uniqueId}
+            className={inputStyles.label}
+          >
             {label}
           </Label>
         )}
@@ -113,6 +124,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             typographyStyles[getTypographyCn(inputTypographyTypes['medium'])],
             focusable,
           )}
+          style={styleVariables}
         />
         {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
       </div>

--- a/packages/components/src/components/TextInput/TextInput.module.css
+++ b/packages/components/src/components/TextInput/TextInput.module.css
@@ -1,5 +1,4 @@
 .container--medium {
-  width: var(--dds-input-default-width);
 }
 
 .container--tiny {
@@ -10,6 +9,10 @@
   position: relative;
   display: flex;
   align-items: center;
+}
+
+.input-width {
+  width: var(--dds-textinput-width);
 }
 
 .input {
@@ -54,6 +57,10 @@
   top: calc(50% - (var(--dds-icon-size-small) / 2));
 }
 
+.label {
+  display: block;
+}
+
 .affix {
   position: absolute;
   height: 100%;
@@ -94,6 +101,7 @@
 .message-container {
   display: flex;
   justify-content: space-between;
+  gap: var(--dds-spacing-x0-5);
 }
 
 .char-counter {

--- a/packages/components/src/components/TextInput/TextInput.tsx
+++ b/packages/components/src/components/TextInput/TextInput.tsx
@@ -1,5 +1,5 @@
 import { ddsTokens } from '@norges-domstoler/dds-design-tokens';
-import { type Property } from 'csstype';
+import { type Properties, type Property } from 'csstype';
 import React, {
   forwardRef,
   useId,
@@ -103,6 +103,15 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 
     const widthCn = componentSize === 'tiny' ? componentSize : 'medium';
 
+    const styleVariables: Properties = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ['--dds-textinput-width' as any]: width
+        ? width
+        : componentSize === 'tiny'
+          ? '210px'
+          : 'var(--dds-input-default-width)',
+    };
+
     const generalInputProps = {
       id: uniqueId,
       hasErrorMessage,
@@ -145,7 +154,10 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
 
     if (hasIcon) {
       extendedInput = (
-        <div className={inputStyles['input-group']}>
+        <div
+          className={cn(styles['input-width'], inputStyles['input-group'])}
+          style={styleVariables}
+        >
           {
             <Icon
               icon={icon}
@@ -165,7 +177,10 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
       );
     } else if (hasAffix) {
       extendedInput = (
-        <div className={styles['affix-container']}>
+        <div
+          className={cn(styles['affix-container'], styles['input-width'])}
+          style={styleVariables}
+        >
           {prefix && (
             <span
               ref={prefixRef}
@@ -214,10 +229,14 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
           inputStyles.container,
           styles[`container--${widthCn}`],
         )}
-        style={{ ...style, width }}
+        style={style}
       >
         {hasLabel && (
-          <Label htmlFor={uniqueId} showRequiredStyling={showRequiredStyling}>
+          <Label
+            htmlFor={uniqueId}
+            showRequiredStyling={showRequiredStyling}
+            className={styles.label}
+          >
             {label}
           </Label>
         )}
@@ -230,6 +249,8 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             type={type}
             componentSize={componentSize}
             {...generalInputProps}
+            style={styleVariables}
+            className={styles['input-width']}
           />
         )}
         {hasMessage && (

--- a/packages/components/src/components/date-inputs/common/DateInput.module.css
+++ b/packages/components/src/components/date-inputs/common/DateInput.module.css
@@ -1,20 +1,9 @@
-.container--medium {
-  width: 160px;
-}
-
-.container--small {
-  width: 148px;
-}
-
-.container--tiny {
-  width: 125px;
-}
-
 .date-input {
   display: inline-flex;
   flex-direction: row;
   align-items: center;
   gap: var(--dds-spacing-x0-25);
+  width: var(--dds-date-input-width);
 }
 
 .date-input--medium {

--- a/packages/components/src/components/date-inputs/common/DateInput.tsx
+++ b/packages/components/src/components/date-inputs/common/DateInput.tsx
@@ -1,4 +1,5 @@
 import { type useDateField, type useDatePicker } from '@react-aria/datepicker';
+import { type Properties } from 'csstype';
 import {
   type ForwardRefExoticComponent,
   type ReactNode,
@@ -67,25 +68,35 @@ function _DateInput(
 
   const { isOpen } = useContext(CalendarPopoverContext);
 
+  const styleVariables: Properties = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ['--dds-date-input-width' as any]: width
+      ? width
+      : componentSize === 'small'
+        ? '148px'
+        : componentSize === 'tiny'
+          ? '125px'
+          : '160px',
+  };
+
   return (
     <div
       {...groupProps}
-      className={cn(
-        className,
-        inputStyles.container,
-        styles[`container--${componentSize}`],
-      )}
+      className={cn(className, inputStyles.container)}
       ref={forwardedRef}
-      style={{ width }}
     >
       {hasLabel && (
-        <Label {...labelProps} showRequiredStyling={required}>
+        <Label
+          {...labelProps}
+          showRequiredStyling={required}
+          className={inputStyles.label}
+        >
           {props.label}
         </Label>
       )}
       <div
         {...fieldProps}
-        style={style}
+        style={{ ...style, ...styleVariables }}
         ref={internalRef}
         className={cn(
           inputStyles.input,

--- a/packages/components/src/components/helpers/Input/Input.module.css
+++ b/packages/components/src/components/helpers/Input/Input.module.css
@@ -18,7 +18,6 @@
   padding: var(--dds-spacing-x0-75) var(--dds-spacing-x1)
     var(--dds-spacing-x0-75) var(--dds-spacing-x0-75);
   border-radius: var(--dds-border-radius-1);
-  width: 100%;
   margin: 0;
   box-sizing: border-box;
   box-shadow: none;
@@ -107,4 +106,8 @@
 
 .input--with-affix {
   gap: var(--dds-spacing-x1);
+}
+
+.label {
+  display: block;
 }


### PR DESCRIPTION
`width`-prop i `<TextInput>`, `<TextArea>`, `<TimePicker>` og `<DatePicker>` påvirker nå kun selve inputfeltet. Det betyr at hele komponenten tar den bredden den får tilgjengelig. Ledetekst, feilmeding og hjelpetekst kan bli bredere enn inputfeltet.