### PR TITLE
Fikser svg sizing bug

### DIFF
--- a/packages/components/src/components/Card/CardAccordion/CardAccordionHeader.tsx
+++ b/packages/components/src/components/Card/CardAccordion/CardAccordionHeader.tsx
@@ -1,3 +1,4 @@
+import { ddsTokens } from '@norges-domstoler/dds-design-tokens';
 import { type Properties, type Property } from 'csstype';
 import { type ButtonHTMLAttributes, forwardRef } from 'react';
 
@@ -89,8 +90,8 @@ export const CardAccordionHeader = forwardRef<
         <div className={styles.header__content}>{children}</div>
         <span className={styles.header__chevron}>
           <AnimatedChevronUpDown
-            width="var(--dds-icon-size-medium)"
-            height="var(--dds-spacing-x0-5)"
+            width={ddsTokens.DdsIconSizeMedium}
+            height={ddsTokens.DdsSpacingX05}
             isUp={isExpanded}
           />
         </span>

--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -1,3 +1,5 @@
+import { ddsTokens } from '@norges-domstoler/dds-design-tokens';
+
 import { type SvgIcon } from './utils';
 import { type BaseComponentProps, getBaseHTMLProps } from '../../types';
 import { type TextColor } from '../../utils';
@@ -5,15 +7,15 @@ import { type TextColor } from '../../utils';
 const getSize = (iconSize: IconSize): string => {
   switch (iconSize) {
     case 'small':
-      return 'var(--dds-icon-size-small)';
+      return ddsTokens.DdsIconSizeSmall;
     case 'medium':
-      return 'var(--dds-icon-size-medium)';
+      return ddsTokens.DdsIconSizeMedium;
     case 'large':
-      return 'var(--dds-icon-size-large)';
+      return ddsTokens.DdsIconSizeLarge;
     case 'inherit':
       return '1em';
     default:
-      return 'var(--dds-icon-size-medium)';
+      return ddsTokens.DdsIconSizeMedium;
   }
 };
 

--- a/packages/components/src/components/Spinner/Spinner.tsx
+++ b/packages/components/src/components/Spinner/Spinner.tsx
@@ -1,3 +1,4 @@
+import { ddsTokens } from '@norges-domstoler/dds-design-tokens';
 import { type Property } from 'csstype';
 import { useId, useRef } from 'react';
 
@@ -19,7 +20,7 @@ export type SpinnerProps = BaseComponentProps<
 
 export function Spinner(props: SpinnerProps) {
   const {
-    size = 'var(--dds-icon-size-medium)',
+    size = ddsTokens.DdsIconSizeMedium,
     color = 'iconActionResting',
     tooltip = 'Innlasting pågår',
     id,

--- a/packages/components/src/utils/color.tsx
+++ b/packages/components/src/utils/color.tsx
@@ -1,3 +1,4 @@
+import { ddsTokens } from '@norges-domstoler/dds-design-tokens';
 import { type Property } from 'csstype';
 
 export type ColorAlphaFormat = 'hex8' | 'decimal';
@@ -100,6 +101,37 @@ export const textColors = {
   iconMedium: 'var(--dds-color-icon-medium)',
 };
 
+export const textColorsJS = {
+  textOnAction: ddsTokens.DdsColorTextOnAction,
+  textOnInverse: ddsTokens.DdsColorTextOnInverse,
+  textOnStatusDefault: ddsTokens.DdsColorTextOnStatusDefault,
+  textOnStatusStrong: ddsTokens.DdsColorTextOnStatusStrong,
+  textActionResting: ddsTokens.DdsColorTextActionResting,
+  textActionHover: ddsTokens.DdsColorTextActionHover,
+  textActionVisited: ddsTokens.DdsColorTextActionVisited,
+  textDefault: ddsTokens.DdsColorTextDefault,
+  textRequiredfield: ddsTokens.DdsColorTextRequiredfield,
+  textSubtle: ddsTokens.DdsColorTextSubtle,
+  textMedium: ddsTokens.DdsColorTextMedium,
+  textOnNotification: ddsTokens.DdsColorTextOnNotification,
+
+  iconOnAction: ddsTokens.DdsColorIconOnAction,
+  iconOnInfoDefault: ddsTokens.DdsColorIconOnInfoDefault,
+  iconOnSuccessDefault: ddsTokens.DdsColorIconOnSuccessDefault,
+  iconOnDangerDefault: ddsTokens.DdsColorIconOnDangerDefault,
+  iconOnWarningDefault: ddsTokens.DdsColorIconOnWarningDefault,
+  iconOnInfoStrong: ddsTokens.DdsColorIconOnInfoStrong,
+  iconOnSuccessStrong: ddsTokens.DdsColorIconOnSuccessStrong,
+  iconOnDangerStrong: ddsTokens.DdsColorIconOnDangerStrong,
+  iconOnWarningStrong: ddsTokens.DdsColorIconOnWarningStrong,
+  iconOnInverse: ddsTokens.DdsColorIconOnInverse,
+  iconActionResting: ddsTokens.DdsColorIconActionResting,
+  iconActionHover: ddsTokens.DdsColorIconActionHover,
+  iconDefault: ddsTokens.DdsColorIconDefault,
+  iconSubtle: ddsTokens.DdsColorIconSubtle,
+  iconMedium: ddsTokens.DdsColorIconMedium,
+};
+
 export type DDSTextColor =
   | 'textOnAction'
   | 'textOnInverse'
@@ -168,5 +200,10 @@ export function isTextColor(color: string): color is DDSTextColor {
 
 export const getTextColor = (color: TextColor): TextColor => {
   if (isTextColor(color)) return textColors[color];
+  return color;
+};
+
+export const getJSTextColor = (color: TextColor): TextColor => {
+  if (isTextColor(color)) return textColorsJS[color];
   return color;
 };


### PR DESCRIPTION
svg kan ikke ta CSS variabel som width eller height-atributt, må være en streng. Bytter til ddsTokens i JS i relevante komponenter.