### PR TITLE
ELSA1-401 Støtte for tegnteller i `<TextArea>`

### DIFF
--- a/.changeset/dull-olives-visit.md
+++ b/.changeset/dull-olives-visit.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for å vise tegnteller i `<TextArea>` ved bruk av `maxLength` prop. Inkluderer støtte for `withCharacterCounter` prop for å kunne slå av visning av tegnteller.

--- a/packages/components/src/components/TextArea/TextArea.module.css
+++ b/packages/components/src/components/TextArea/TextArea.module.css
@@ -5,3 +5,8 @@
   vertical-align: bottom;
   padding-bottom: var(--dds-spacing-x0-5);
 }
+
+.message-container {
+  display: flex;
+  justify-content: space-between;
+}

--- a/packages/components/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/components/src/components/TextArea/TextArea.stories.tsx
@@ -11,6 +11,7 @@ export default {
     tip: { control: 'text' },
     errorMessage: { control: 'text' },
     width: { control: 'text' },
+    maxLength: { control: 'number' },
     required: { control: 'boolean' },
     disabled: { control: 'boolean' },
     readOnly: { control: 'boolean' },
@@ -42,12 +43,21 @@ export const Overview: Story = {
             args.errorMessage ?? 'Dette er en feilmelding ved valideringsfeil'
           }
         />
+        <TextArea
+          {...args}
+          maxLength={200}
+          tip={'Dette er en hjelpetekst med tegnteller'}
+        />
       </StoryVStack>
       <StoryVStack>
         <TextArea {...args} required value="Påkrevd" />
         <TextArea {...args} readOnly value="Readonly" />
-        <TextArea {...args} tip={args.tip ?? 'Dette er en hjelpetekst'} />
+        <TextArea {...args} tip={'Dette er en hjelpetekst'} />
       </StoryVStack>
     </StoryHStack>
   ),
+};
+
+export const WithCharacterCount: Story = {
+  args: { label: 'Label', maxLength: 200 },
 };

--- a/packages/components/src/components/TextInput/TextInput.module.css
+++ b/packages/components/src/components/TextInput/TextInput.module.css
@@ -103,7 +103,3 @@
   justify-content: space-between;
   gap: var(--dds-spacing-x0-5);
 }
-
-.char-counter {
-  margin-left: auto;
-}

--- a/packages/components/src/components/TextInput/TextInput.tsx
+++ b/packages/components/src/components/TextInput/TextInput.tsx
@@ -8,7 +8,6 @@ import React, {
   useState,
 } from 'react';
 
-import CharCounter from './CharCounter';
 import styles from './TextInput.module.css';
 import { type TextInputProps } from './TextInput.types';
 import {
@@ -17,7 +16,7 @@ import {
   spaceSeparatedIdListGenerator,
 } from '../../utils';
 import { getFormInputIconSize } from '../../utils/icon';
-import { StatefulInput, getDefaultText } from '../helpers';
+import { StatefulInput, getDefaultText, renderCharCounter } from '../helpers';
 import inputStyles from '../helpers/Input/Input.module.css';
 import { Icon } from '../Icon';
 import { renderInputMessage } from '../InputMessage';
@@ -88,11 +87,6 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
     const hasMessage = hasErrorMessage || hasTip || !!maxLength;
     const hasIcon = !!icon;
     const hasAffix = !!(prefix ?? suffix);
-    const hasCharCounter =
-      !!maxLength &&
-      Number.isInteger(maxLength) &&
-      maxLength > 0 &&
-      withCharacterCounter;
 
     const characterCounterId = derivativeIdGenerator(
       uniqueId,
@@ -256,12 +250,11 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
         {hasMessage && (
           <div className={styles['message-container']}>
             {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
-            {hasCharCounter && (
-              <CharCounter
-                id={characterCounterId}
-                current={text.length}
-                max={maxLength}
-              />
+            {renderCharCounter(
+              characterCounterId,
+              withCharacterCounter,
+              text.length,
+              maxLength,
             )}
           </div>
         )}

--- a/packages/components/src/components/helpers/Input/CharCounter.tsx
+++ b/packages/components/src/components/helpers/Input/CharCounter.tsx
@@ -1,9 +1,9 @@
 import { useId } from 'react';
 
-import styles from './TextInput.module.css';
-import { type BaseComponentProps, getBaseHTMLProps } from '../../types';
-import { cn } from '../../utils';
-import { Typography } from '../Typography';
+import styles from './Input.module.css';
+import { type BaseComponentProps, getBaseHTMLProps } from '../../../types';
+import { cn } from '../../../utils';
+import { Typography } from '../../Typography';
 
 type Props = BaseComponentProps<
   HTMLElement,
@@ -13,7 +13,7 @@ type Props = BaseComponentProps<
   }
 >;
 
-function CharCounter(props: Props) {
+export function CharCounter(props: Props) {
   const { current, max, id, className, htmlProps, ...rest } = props;
 
   const generatedId = useId();
@@ -36,4 +36,12 @@ function CharCounter(props: Props) {
   );
 }
 
-export default CharCounter;
+export const renderCharCounter = (
+  id: string,
+  isShown: boolean,
+  textLength: number,
+  maxLength?: number,
+) => {
+  if (!!maxLength && Number.isInteger(maxLength) && maxLength > 0 && isShown)
+    return <CharCounter id={id} max={maxLength} current={textLength} />;
+};

--- a/packages/components/src/components/helpers/Input/Input.module.css
+++ b/packages/components/src/components/helpers/Input/Input.module.css
@@ -111,3 +111,7 @@
 .label {
   display: block;
 }
+
+.char-counter {
+  margin-left: auto;
+}

--- a/packages/components/src/components/helpers/Input/index.ts
+++ b/packages/components/src/components/helpers/Input/index.ts
@@ -1,3 +1,4 @@
 export * from './Input';
+export * from './CharCounter';
 export * from './Input.types';
 export * from './Input.utils';


### PR DESCRIPTION
Viser tegnteller ved `maxLength`, som i `<TextInput>`.

Flytter `<CharCounter>` til helpers og refaktorerer `<TextArea>` i samme slengen.