### PR TITLE
ELSA1-403 Bug bredde i `<TextInput>`

### DIFF
--- a/.changeset/green-schools-lie.md
+++ b/.changeset/green-schools-lie.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug som satt feil bredde i `<TextInput>` ved bruk av ikon og suffiks.

--- a/packages/components/src/components/TextInput/TextInput.module.css
+++ b/packages/components/src/components/TextInput/TextInput.module.css
@@ -36,6 +36,10 @@
   }
 }
 
+.input--extended {
+  width: 100%;
+}
+
 .icon {
   position: absolute;
   z-index: 1;

--- a/packages/components/src/components/TextInput/TextInput.tsx
+++ b/packages/components/src/components/TextInput/TextInput.tsx
@@ -164,7 +164,11 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             onChange={onChangeHandler}
             type={type}
             componentSize={componentSize}
-            className={cn(styles.input, styles[`with-icon--${componentSize}`])}
+            className={cn(
+              styles.input,
+              styles[`with-icon--${componentSize}`],
+              styles['input--extended'],
+            )}
             {...generalInputProps}
           />
         </div>
@@ -198,6 +202,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
               paddingInlineStart: preffixPaddingInlineStart,
               paddingInlineEnd: suffixPaddingInlineEnd,
             }}
+            className={styles['input--extended']}
           />
           {suffix && (
             <span


### PR DESCRIPTION
Fikser bug som satt feil bredde i `<TextInput>` ved bruk av ikon og suffiks.
Før:
![bilde](https://github.com/domstolene/designsystem/assets/71430829/08d3eb1f-6e4b-418b-8238-6043c023f948)
Etter:
![bilde](https://github.com/domstolene/designsystem/assets/71430829/cf29eb41-0b91-480d-90aa-f0638f74b8b9)
