### PR TITLE
peerDependency bump fix

### DIFF
--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -48,8 +48,8 @@
     "vitest": "^1.6.0"
   },
   "peerDependencies": {
-    "@norges-domstoler/dds-components": ">=16.0.0",
-    "@norges-domstoler/development-utils": ">=1.3.0",
+    "@norges-domstoler/dds-components": ">=16",
+    "@norges-domstoler/development-utils": ">=1",
     "react": "^16 || ^17 || ^18",
     "react-dom": "^16 || ^17 || ^18",
     "styled-components": "^5 || ^6"


### PR DESCRIPTION
Fikser dds-components peerDependency i app-shell slik at den ikke trenger å bumpe versjon.