### PR TITLE
ELSA1-411 Utvider `message` type i `EmptyContent`

### DIFF
--- a/.changeset/tough-readers-repeat.md
+++ b/.changeset/tough-readers-repeat.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Utvider typen til `message` i `EmptyContent` til `ReactNode`, slik at den kan støtte variert innhold og ikke kun `string`.

--- a/packages/components/src/components/EmptyContent/EmptyContent.mdx
+++ b/packages/components/src/components/EmptyContent/EmptyContent.mdx
@@ -7,12 +7,21 @@ import * as EmptyContentStories from './EmptyContent.stories';
 # EmptyContent
 
 <ComponentLinkRow
+  withBottomSpacing
   docsHref="https://design.domstol.no/987b33f71/p/92d5ef-emptycontentview/b/007750"
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/DDS-Komponenter?node-id=12387%3A221195&t=ygT73thALrQ1LGjN-1"
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/EmptyContent"
 />
 
+Komponenten brukes som en empty state når brukeren er forventet å velge innhold fra en liste eller lignende.
+
 ## Props
 
 <Canvas of={EmptyContentStories.Default} sourceState="shown" />
 <Controls of={EmptyContentStories.Default} />
+
+## Eksempler
+
+### Kompleks innhold
+
+<Canvas of={EmptyContentStories.ComplexContent} />

--- a/packages/components/src/components/EmptyContent/EmptyContent.spec.tsx
+++ b/packages/components/src/components/EmptyContent/EmptyContent.spec.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Link } from '../Typography';
+
+import { EmptyContent } from '.';
+
+describe('<EmptyContent />', () => {
+  it('should render message text', () => {
+    const message = 'message';
+    render(<EmptyContent message={message} />);
+    expect(screen.getByText(message)).toBeInTheDocument();
+  });
+  it('should render title text', () => {
+    const message = 'message';
+    const title = 'title';
+    render(<EmptyContent message={message} title={title} />);
+    expect(screen.getByText(title)).toBeInTheDocument();
+  });
+  it('should render message link', () => {
+    const linkText = 'link';
+    const message = (
+      <>
+        Tekst <Link href="/">{linkText}</Link>
+      </>
+    );
+    render(<EmptyContent message={message} />);
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    expect(screen.getByText(linkText)).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/components/EmptyContent/EmptyContent.stories.tsx
+++ b/packages/components/src/components/EmptyContent/EmptyContent.stories.tsx
@@ -2,6 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 
 import { EmptyContent } from './EmptyContent';
 import { StoryVStack } from '../Stack/utils';
+import { Link } from '../Typography';
 
 export default {
   title: 'dds-components/EmptyContent',
@@ -37,14 +38,14 @@ export const Overview: Story = {
       <EmptyContent
         {...args}
         message={`Dette er en lang tekst. Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-        Donec tempus imperdiet leo, eget tempus nulla suscipit vel. 
-        Curabitur accumsan dapibus elit, eu semper massa pulvinar vitae.
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-        Donec tempus imperdiet leo, eget tempus nulla suscipit vel. 
-        Curabitur accumsan dapibus elit, eu semper massa pulvinar vitae.
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
-        Donec tempus imperdiet leo, eget tempus nulla suscipit vel. 
-        Curabitur accumsan dapibus elit, eu semper massa pulvinar vitae.`}
+          Donec tempus imperdiet leo, eget tempus nulla suscipit vel. 
+          Curabitur accumsan dapibus elit, eu semper massa pulvinar vitae.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+          Donec tempus imperdiet leo, eget tempus nulla suscipit vel. 
+          Curabitur accumsan dapibus elit, eu semper massa pulvinar vitae.
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+          Donec tempus imperdiet leo, eget tempus nulla suscipit vel. 
+          Curabitur accumsan dapibus elit, eu semper massa pulvinar vitae.`}
       />
 
       <div style={{ height: '25rem', width: '500px' }}>
@@ -55,4 +56,16 @@ export const Overview: Story = {
       </div>
     </StoryVStack>
   ),
+};
+
+export const ComplexContent: Story = {
+  args: {
+    title: 'Tittel',
+    message: (
+      <>
+        Dette er en forklaring. Du kan <Link href="/">registrere en aktør</Link>
+        .
+      </>
+    ),
+  },
 };

--- a/packages/components/src/components/EmptyContent/EmptyContent.tsx
+++ b/packages/components/src/components/EmptyContent/EmptyContent.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes } from 'react';
+import { type HTMLAttributes, type ReactNode } from 'react';
 
 import styles from './EmptyContent.module.css';
 import { cn } from '../../utils';
@@ -9,8 +9,8 @@ export type EmptyContentProps = {
   title?: string;
   /**Nivå på overskriften. Sørg for at den følger hierarkiet på siden. */
   titleHeadingLevel?: HeadingLevel;
-  /**Melding - beskrivelse og forklaring på hvordan brukeren kan få innhold. */
-  message: string;
+  /**Melding - beskrivelse og forklaring på hvordan brukeren kan få innhold. Kan inneholde lenker og andre interaktive elementer. */
+  message: ReactNode;
 } & HTMLAttributes<HTMLDivElement>;
 
 export function EmptyContent({

--- a/packages/storybook-components/src/StorybookLinkRow.tsx
+++ b/packages/storybook-components/src/StorybookLinkRow.tsx
@@ -2,7 +2,9 @@ import type { ComponentProps } from 'react';
 
 import { StorybookLink } from './StorybookLink';
 
-export const StorybookLinkRow = (props: ComponentProps<'div'>) => (
+export const StorybookLinkRow = (
+  props: ComponentProps<'div'> & { withBottomSpacing?: boolean },
+) => (
   <div
     {...props}
     style={{
@@ -10,6 +12,9 @@ export const StorybookLinkRow = (props: ComponentProps<'div'>) => (
       flexWrap: 'wrap',
       alignItems: 'center',
       gap: 'var(--dds-spacing-x0-75)',
+      marginBottom: props.withBottomSpacing
+        ? 'var(--dds-spacing-x2)'
+        : undefined,
     }}
   />
 );
@@ -18,14 +23,16 @@ interface props {
   docsHref: string;
   figmaHref?: string;
   githubHref: string;
+  withBottomSpacing?: boolean;
 }
 
 export const ComponentLinkRow = ({
   docsHref,
   figmaHref,
   githubHref,
+  withBottomSpacing,
 }: props) => (
-  <StorybookLinkRow>
+  <StorybookLinkRow withBottomSpacing={withBottomSpacing}>
     <StorybookLink
       size="small"
       text="Docs"


### PR DESCRIPTION
Utvider typen til `message` i `EmptyContent` til `ReactNode`, slik at den kan støtte variert innhold og ikke kun `string`.