### PR TITLE
Fikser feil versjon av `@storybook/addon-links`

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from "path";
+import { dirname, join } from 'path';
 import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
@@ -8,14 +8,13 @@ const config: StorybookConfig = {
     '../stories/*.@(md|mdx)',
     '../packages/*/src/**/*.stories.@(js|jsx|ts|tsx)',
     '../packages/*/src/**/*.mdx',
-    '../packages/*/stories/**/*.stories.@(js|jsx|ts|tsx)',
     '../packages/*/stories/**/*.mdx',
   ],
   staticDirs: ['./images'],
   addons: [
-    getAbsolutePath("@storybook/addon-links"),
-    getAbsolutePath("@storybook/addon-a11y"),
-    getAbsolutePath("@storybook/addon-essentials"),
+    getAbsolutePath('@storybook/addon-links'),
+    getAbsolutePath('@storybook/addon-a11y'),
+    getAbsolutePath('@storybook/addon-essentials'),
     {
       name: '@storybook/addon-storysource',
       options: {
@@ -24,10 +23,10 @@ const config: StorybookConfig = {
         },
       },
     },
-    getAbsolutePath("@storybook/addon-mdx-gfm")
+    getAbsolutePath('@storybook/addon-mdx-gfm'),
   ],
   framework: {
-    name: getAbsolutePath("@storybook/react-vite"),
+    name: getAbsolutePath('@storybook/react-vite'),
     options: {},
   },
   typescript: {
@@ -46,5 +45,5 @@ const config: StorybookConfig = {
 export default config;
 
 function getAbsolutePath(value: string): any {
-  return dirname(require.resolve(join(value, "package.json")));
+  return dirname(require.resolve(join(value, 'package.json')));
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@storybook/addon-a11y": "8.1.11",
     "@storybook/addon-docs": "8.1.11",
     "@storybook/addon-essentials": "8.1.11",
-    "@storybook/addon-links": "^8.1.11",
+    "@storybook/addon-links": "8.1.11",
     "@storybook/addon-mdx-gfm": "8.1.11",
     "@storybook/addon-storysource": "8.1.11",
     "@storybook/blocks": "8.1.11",


### PR DESCRIPTION
Alle storybook-pakker har spesifikk versjon i `package.json`, mens addon-links hadde med `^`; dle ble feil versjon på den. Fjerner caret.

Fjerner også story path som ikke eksisterer.