### PR TITLE
ELSA1-417 Fikser visuell bug i navigation Card

### DIFF
--- a/.changeset/silly-swans-clap.md
+++ b/.changeset/silly-swans-clap.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Setter `display: block;` i CSS for `<Card cardType="navigation">`, da den returnerer `<a>` og er i utganspunktet et inline-element.

--- a/packages/components/src/components/Card/Card.module.css
+++ b/packages/components/src/components/Card/Card.module.css
@@ -20,6 +20,7 @@
 
 .container--navigation {
   text-decoration: none;
+  display: block;
   &:hover {
     border-color: var(--dds-color-border-action-hover);
     box-shadow: inset 0 0 0 1px var(--dds-color-border-action-hover);


### PR DESCRIPTION
Setter `display: block;` i CSS for `<Card cardType="navigation">`, da den returnerer `<a>` og er i utganspunktet et inline-element.
Før:
![Navnløs](https://github.com/user-attachments/assets/bcf0fa3f-79fa-4c04-803a-bf06a435d3e7)
Etter:
![bilde](https://github.com/user-attachments/assets/56808417-5741-4378-b992-6649e497b70f)
