### PR TITLE
ELSA1-418 `<h2>`som header i flate-komponenter

### DIFF
--- a/.changeset/giant-plums-search.md
+++ b/.changeset/giant-plums-search.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Default tittel/header i `<Drawer>`, `<Modal>` og `<Popover>` returnerer nå `<h2>`, slik at overskriftshierarkiet opprettholdes uansett kontekst. På denne måten unngår vi problemer rundt universell utforming.

--- a/packages/components/src/components/Drawer/Drawer.tsx
+++ b/packages/components/src/components/Drawer/Drawer.tsx
@@ -20,7 +20,7 @@ import { Paper } from '../helpers';
 import focusStyles from '../helpers/styling/focus.module.css';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { CloseIcon } from '../Icon/icons';
-import { Typography } from '../Typography';
+import { Heading } from '../Typography';
 export type DrawerSize = 'small' | 'medium' | 'large';
 export type DrawerPlacement = 'left' | 'right';
 export interface WidthProps {
@@ -132,9 +132,9 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
             {hasHeader && (
               <div id={headerId}>
                 {typeof header === 'string' ? (
-                  <Typography typographyType="headingSans03">
+                  <Heading level={2} typographyType="headingSans03">
                     {header}
-                  </Typography>
+                  </Heading>
                 ) : (
                   header
                 )}

--- a/packages/components/src/components/LocalMessage/LocalMessage.stories.tsx
+++ b/packages/components/src/components/LocalMessage/LocalMessage.stories.tsx
@@ -3,7 +3,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { LocalMessage } from './LocalMessage';
 import { List, ListItem } from '../List';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
-import { Typography } from '../Typography';
+import { Heading, Paragraph } from '../Typography';
 
 export default {
   title: 'dds-components/LocalMessage',
@@ -70,10 +70,10 @@ export const ComplexContent: Story = {
   args: {},
   render: args => (
     <LocalMessage {...args} purpose={args.purpose} layout="vertical" closable>
-      <Typography typographyType="headingSans03" withMargins>
+      <Heading level={2} typographyType="headingSans03" withMargins>
         Dette er en viktig melding
-      </Typography>
-      <Typography withMargins>Meldingen har en liste i seg:</Typography>
+      </Heading>
+      <Paragraph withMargins>Meldingen har en liste i seg:</Paragraph>
       <List>
         <ListItem>Noe her</ListItem>
         <ListItem>Og også her</ListItem>

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -28,7 +28,7 @@ import { Button } from '../Button';
 import { Paper } from '../helpers';
 import { focusable } from '../helpers/styling/focus.module.css';
 import { CloseIcon } from '../Icon/icons';
-import { Typography } from '../Typography';
+import { Heading } from '../Typography';
 
 export type ModalProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
@@ -121,9 +121,9 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>((props, ref) => {
               {header && (
                 <div id={headerId} className={styles.header}>
                   {typeof header === 'string' ? (
-                    <Typography typographyType="headingSans03">
+                    <Heading level={2} typographyType="headingSans03">
                       {header}
-                    </Typography>
+                    </Heading>
                   ) : (
                     header
                   )}

--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -21,7 +21,7 @@ import { Paper } from '../helpers';
 import focusStyles from '../helpers/styling/focus.module.css';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { CloseIcon } from '../Icon/icons';
-import { Typography } from '../Typography';
+import { Heading } from '../Typography';
 
 export interface PopoverSizeProps {
   width?: Property.Width;
@@ -127,7 +127,9 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
         {title && (
           <div className={styles.title}>
             {typeof title === 'string' ? (
-              <Typography typographyType="headingSans02">{title}</Typography>
+              <Heading level={2} typographyType="headingSans02">
+                {title}
+              </Heading>
             ) : (
               title
             )}

--- a/packages/components/src/components/SkipToContent/SkipToContent.stories.tsx
+++ b/packages/components/src/components/SkipToContent/SkipToContent.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import { Typography } from '../Typography';
+import { Heading } from '../Typography';
 
 import { SkipToContent } from '.';
 
@@ -52,9 +52,9 @@ export const Example: Story = {
       <SkipToContent {...args} />
       'Tab' når du er i frame for å se komponenten; 'Enter' for å åpne i ny side
       og teste
-      <Typography typographyType="headingSans08" withMargins>
+      <Heading level={2} typographyType="headingSans08" withMargins>
         Placeholder
-      </Typography>
+      </Heading>
       <div
         style={{
           height: '1000px',


### PR DESCRIPTION
Default tittel/header i `<Drawer>`, `<Modal>` og `<Popover>` returnerer nå `<h2>`, slik at overskriftshierarkiet opprettholdes uansett kontekst. På denne måten unngår vi problemer rundt universell utforming.