### PR TITLE
ELSA1-423 `smallScreenBreakpoint` prop

### DIFF
--- a/.changeset/khaki-spiders-agree.md
+++ b/.changeset/khaki-spiders-agree.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': major
+---
+
+Prop `smallScreen` i komponentene `<Breadcrumbs>`, `<InternalHeader>` og `<Pagination>` gjøres om til `smallScreenBreakpoint`; den tar inn navn på et brekkpunkt og gjør komponenten responsiv, slik at versjonen for liten skjerm vises ved oppgitte brekkpunket og nedover vha kun CSS.

--- a/packages/components/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/packages/components/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -22,6 +22,8 @@ Komponenten består av to subkomponenter:
 
 Siste `<Breadcrumb>` skal være den siden brukeren er på, uten oppgitt URL.
 
+Komponenten kan være responsiv hvis et brekkepunkt er spesifisert.
+
 ## Props
 
 ### Breadcrumbs

--- a/packages/components/src/components/Breadcrumbs/Breadcrumbs.module.css
+++ b/packages/components/src/components/Breadcrumbs/Breadcrumbs.module.css
@@ -5,6 +5,66 @@
   gap: var(--dds-spacing-x0-5);
 }
 
+.list--large-screen-hide-xs {
+  @media only screen and (max-width: 600px) {
+    display: none;
+  }
+}
+
+.list--large-screen-hide-sm {
+  @media only screen and (max-width: 960px) {
+    display: none;
+  }
+}
+
+.list--large-screen-hide-md {
+  @media only screen and (max-width: 1280px) {
+    display: none;
+  }
+}
+
+.list--large-screen-hide-lg {
+  @media only screen and (max-width: 1920px) {
+    display: none;
+  }
+}
+
+.list--large-screen-hide-xl {
+  display: none;
+}
+
+.list--small-screen {
+  display: none;
+}
+
+.list--small-screen-show-xs {
+  @media only screen and (max-width: 600px) {
+    display: flex;
+  }
+}
+
+.list--small-screen-show-sm {
+  @media only screen and (max-width: 960px) {
+    display: flex;
+  }
+}
+
+.list--small-screen-show-md {
+  @media only screen and (max-width: 1280px) {
+    display: flex;
+  }
+}
+
+.list--small-screen-show-lg {
+  @media only screen and (max-width: 1920px) {
+    display: flex;
+  }
+}
+
+.list--small-screen-show-xl {
+  display: flex;
+}
+
 .list-item {
   align-items: center;
   display: flex;

--- a/packages/components/src/components/Breadcrumbs/Breadcrumbs.spec.tsx
+++ b/packages/components/src/components/Breadcrumbs/Breadcrumbs.spec.tsx
@@ -22,7 +22,7 @@ const TestComponent = () => {
 
 const TestComponentSmallScreen = () => {
   return (
-    <Breadcrumbs smallScreen>
+    <Breadcrumbs smallScreenBreakpoint="sm">
       <Breadcrumb>{page1}</Breadcrumb>
       <Breadcrumb>{page2}</Breadcrumb>
       <Breadcrumb>{page3}</Breadcrumb>
@@ -31,31 +31,22 @@ const TestComponentSmallScreen = () => {
   );
 };
 
-describe('Breadcrumbs', () => {
+describe('<Breadcrumbs>', () => {
   it('has aria-label', () => {
     render(<TestComponent />);
     const breadcrumbs = screen.getByLabelText('brødsmulesti');
     expect(breadcrumbs).toHaveAttribute('aria-label', 'brødsmulesti');
   });
-  it('should render four breadcrumbs', () => {
+  it('should render 4 breadcrumbs', () => {
     render(<TestComponent />);
     const breadcrumbItems = screen.getAllByRole('listitem');
     expect(breadcrumbItems[0].textContent).toBe(page1);
     expect(breadcrumbItems).toHaveLength(4);
     expect(breadcrumbItems[1].textContent).toBe(page2);
     expect(breadcrumbItems[2].textContent).toBe(page3);
-    expect(breadcrumbItems[3].textContent).toBe('Side 4');
+    expect(breadcrumbItems[3].textContent).toBe(page4);
   });
-  describe('Breadcrumbs smallScreen', () => {
-    it('should render three items', () => {
-      render(<TestComponentSmallScreen />);
-      const breadcrumbItems = screen.queryAllByRole('listitem');
-      expect(breadcrumbItems).toHaveLength(3);
-      expect(breadcrumbItems[0].textContent).toBe(page1);
-      expect(breadcrumbItems[1].textContent).toBe(page2 + page3);
-      expect(breadcrumbItems[2].textContent).toBe(page4);
-      expect(breadcrumbItems[3]).not.toBeInTheDocument;
-    });
+  describe('Breadcrumbs with small screen variant', () => {
     it('should render button for truncated children', () => {
       render(<TestComponentSmallScreen />);
       const button = screen.getByRole('button');
@@ -79,16 +70,33 @@ describe('Breadcrumbs', () => {
     });
     it('should have truncated child with text and href', async () => {
       render(
-        <Breadcrumbs smallScreen>
+        <Breadcrumbs smallScreenBreakpoint="xl">
           <Breadcrumb>Side 1</Breadcrumb>
           <Breadcrumb>Side 2</Breadcrumb>
-          <Breadcrumb href="#">Side 3</Breadcrumb>
+          <Breadcrumb href="#">{page3}</Breadcrumb>
           <Breadcrumb>Side 4</Breadcrumb>
         </Breadcrumbs>,
       );
-      const element = screen.getByText('Side 3');
-      expect(element).toBeInTheDocument();
-      expect(element).toHaveAttribute('href', '#');
+      const button = screen.getByRole('button');
+
+      await userEvent.click(button!);
+      const menuitems = screen.getAllByRole('menuitem');
+      expect(menuitems[1].textContent).toBe(page3);
+      expect(menuitems[1]).toHaveAttribute('href', '#');
+    });
+    it('should render 7 breadcrumbs', () => {
+      render(<TestComponentSmallScreen />);
+
+      const breadcrumbItems = screen.getAllByRole('listitem');
+      expect(breadcrumbItems[0].textContent).toBe(page1);
+      expect(breadcrumbItems[1].textContent).toBe(page2);
+      expect(breadcrumbItems[2].textContent).toBe(page3);
+      expect(breadcrumbItems[3].textContent).toBe(page4);
+      // Teller elementer fra begge listene
+      expect(breadcrumbItems[4].textContent).toBe(page1);
+      expect(breadcrumbItems[5].textContent).toBe(page2 + page3);
+      expect(breadcrumbItems[6].textContent).toBe(page4);
+      expect(breadcrumbItems).toHaveLength(7);
     });
   });
 });

--- a/packages/components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -13,7 +13,6 @@ export default {
       canvas: { sourceState: 'shown' },
     },
   },
-  argTypes: { smallScreen: { control: { type: 'boolean' } } },
 } satisfies Meta<typeof Breadcrumbs>;
 
 type Story = StoryObj<typeof Breadcrumbs>;
@@ -38,7 +37,7 @@ export const Overview: Story = {
   render: args => (
     <StoryVStack>
       <Breadcrumbs {...args} />
-      <Breadcrumbs {...args} smallScreen />
+      <Breadcrumbs {...args} smallScreenBreakpoint="xl" />
     </StoryVStack>
   ),
 };
@@ -46,6 +45,13 @@ export const Overview: Story = {
 export const SmallScreen: Story = {
   args: {
     children,
-    smallScreen: true,
+    smallScreenBreakpoint: 'xl',
+  },
+};
+
+export const responsive: Story = {
+  args: {
+    children,
+    smallScreenBreakpoint: 'sm',
   },
 };

--- a/packages/components/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/components/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../types';
 import { cn } from '../../utils';
 import { Button } from '../Button';
+import { type ScreenSizeLiteral } from '../helpers';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { Icon } from '../Icon';
 import { ChevronRightIcon, MoreHorizontalIcon } from '../Icon/icons';
@@ -21,16 +22,23 @@ export type BreadcrumbsProps = BaseComponentPropsWithChildren<
   HTMLElement,
   {
     /**
-     * Om variant for mindre skjerm skal vises.
-     * Trunkerer barn unntatt første og siste; trunkerte barn er tigjengelige ved å trykke på trukeringsknappen.
+     * Spesifiserer ved hvilket brekkpunkt og nedover versjonen for små skjermer skal vises.
+     * Trunkerer barn unntatt første og siste; trunkerte barn er tilgjengelige ved å trykke på trunkeringsknappen.
      */
-    smallScreen?: boolean;
+    smallScreenBreakpoint?: ScreenSizeLiteral;
   }
 >;
 
 export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
   (props, ref) => {
-    const { children, smallScreen, id, className, htmlProps, ...rest } = props;
+    const {
+      children,
+      smallScreenBreakpoint,
+      id,
+      className,
+      htmlProps,
+      ...rest
+    } = props;
 
     const chevronIcon = (
       <Icon
@@ -41,14 +49,13 @@ export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
     );
 
     const childrenArray = Children.toArray(children);
-    const listItemCn = cn(
-      styles['list-item'],
-      !smallScreen && styles[`list-item--large-screen`],
-    );
 
     const breadcrumbChildren = childrenArray.map((item, index) => {
       return (
-        <li key={`breadcrumb-${index}`} className={listItemCn}>
+        <li
+          key={`breadcrumb-${index}`}
+          className={cn(styles['list-item'], styles[`list-item--large-screen`])}
+        >
           {index !== 0 && chevronIcon}
           {item}
         </li>
@@ -70,9 +77,9 @@ export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
 
     const breadcrumbChildrenSmallScreen = (
       <>
-        <li className={listItemCn}>{childrenArray[0]}</li>
+        <li className={styles['list-item']}>{childrenArray[0]}</li>
         {breadcrumbChildrenTruncated.length > 0 && (
-          <li className={listItemCn}>
+          <li className={styles['list-item']}>
             {chevronIcon}
             <OverflowMenuGroup>
               <Button
@@ -89,12 +96,14 @@ export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
             </OverflowMenuGroup>
           </li>
         )}
-        <li className={listItemCn}>
+        <li className={styles['list-item']}>
           {chevronIcon}
           {childrenArray[childrenArray.length - 1]}
         </li>
       </>
     );
+
+    const hasSmallScreenBreakpoint = !!smallScreenBreakpoint;
 
     return (
       <nav
@@ -102,9 +111,28 @@ export const Breadcrumbs = forwardRef<HTMLElement, BreadcrumbsProps>(
         ref={ref}
         aria-label="brødsmulesti"
       >
-        <ul className={cn(styles.list, utilStyles['remove-list-styling'])}>
-          {smallScreen ? breadcrumbChildrenSmallScreen : breadcrumbChildren}
+        <ul
+          className={cn(
+            styles.list,
+            utilStyles['remove-list-styling'],
+            hasSmallScreenBreakpoint &&
+              styles[`list--large-screen-hide-${smallScreenBreakpoint}`],
+          )}
+        >
+          {breadcrumbChildren}
         </ul>
+        {hasSmallScreenBreakpoint && (
+          <ul
+            className={cn(
+              styles.list,
+              utilStyles['remove-list-styling'],
+              styles['list--small-screen'],
+              styles[`list--small-screen-show-${smallScreenBreakpoint}`],
+            )}
+          >
+            {breadcrumbChildrenSmallScreen}
+          </ul>
+        )}
       </nav>
     );
   },

--- a/packages/components/src/components/Grid/Grid.stories.tsx
+++ b/packages/components/src/components/Grid/Grid.stories.tsx
@@ -81,7 +81,6 @@ export const PageExample: Story = {
   render: args => {
     const screenSize = useScreenSize();
     const isXSmall = screenSize === ScreenSize.XSmall;
-    const smallScreenVersion = isXSmall ? true : undefined;
     return (
       <>
         <InternalHeader
@@ -91,9 +90,16 @@ export const PageExample: Story = {
             { title: 'Advokater', href: '/' },
             { title: 'Saker', href: '/' },
           ]}
-          smallScreen={smallScreenVersion}
+          smallScreenBreakpoint="xs"
         />
-        <Grid {...args} style={{ marginTop: isXSmall ? '16px' : '32px' }}>
+        <Grid
+          {...args}
+          style={{
+            marginTop: isXSmall
+              ? 'var(--dds-spacing-x1)'
+              : 'var(--dds-spacing-x2)',
+          }}
+        >
           <GridChild
             columnsOccupied={{
               xs: '1/-1',
@@ -151,7 +157,7 @@ export const PageExample: Story = {
             <Pagination
               itemsAmount={20}
               withCounter
-              smallScreen={smallScreenVersion}
+              smallScreenBreakpoint="xs"
             />
           </GridChild>
         </Grid>

--- a/packages/components/src/components/InternalHeader/InternalHeader.mdx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.mdx
@@ -22,6 +22,8 @@ webapplikasjoner.
 
 Komponenten støtter horisontal navigasjon med lenker, og den kan også ha en kontekstmeny på høyresiden. Denne menyen kan inneholde enten en lenke eller statisk tekst som viser brukernavnet, i tillegg til en liste med lenker eller knapper. Du finner detaljene i Props-seksjonen.
 
+`<InternalHeader>` kan være responsiv og legger navigasjonen i kontekstmenyen hvis et brekkepunkt er spesifisert.
+
 Ettersom Lovisa Next kommer på plass
 vil `<InternalHeader>` også bli videreutviklet til å bli et felles
 navigasjonspunkt mellom ulike tjenester og applikasjoner. Lenker ti andre
@@ -75,19 +77,15 @@ applikasjoner vil være tilgjengelige ved å trykke på det som i dag er navn p�
 
 ### Navigasjon og kontekstmeny
 
-{' '}
-
 <Canvas of={InternalHeaderStories.WithNavigationAndContextMenu} />
 
-### Navigasjon og kontekstmeny - liten skjerm
+### Navigasjon og kontekstmeny - responsiv
 
-{' '}
-
-<Canvas of={InternalHeaderStories.SmallScreenWithNavigationAndContextMenu} />
+<Canvas of={InternalHeaderStories.ResponsiveWithNavigationAndContextMenu} />
 
 ## Retningslinjer
 
 - Bruk `<SkipToContent>`-komponenten over `<InternalHeader>` slik at brukeren kan hoppe rett til innholdet.
-- Ikke bruk `smallScreen`-prop på store skjermer og så lenge alle navigasjonselementer vises på én linje - navigasjonen skal ikke skjules hvis det er nok plass til å vise den.
+- Ikke bruk `smallScreenBreapoint`-prop for store skjermer og så lenge alle navigasjonselementer vises på én linje - navigasjonen skal ikke skjules hvis det er nok plass til å vise den.
 - Sørg for at hvert klikkbart element har størrelse på minst 1cmx1cm.
 - Bruk `currentPageHref` prop til å markere i navigasjonen hvilken side brukeren er på for å ha en visuell indikator.

--- a/packages/components/src/components/InternalHeader/InternalHeader.module.css
+++ b/packages/components/src/components/InternalHeader/InternalHeader.module.css
@@ -11,7 +11,39 @@
   }
 }
 
-.bar--small-screen {
+.bar--small-screen-xs {
+  @media only screen and (max-width: 600px) {
+    gap: var(--dds-spacing-x1);
+    padding-inline-start: var(--dds-spacing-x1);
+    padding-inline-end: var(--dds-spacing-x0-5);
+  }
+}
+
+.bar--small-screen-sm {
+  @media only screen and (max-width: 960px) {
+    gap: var(--dds-spacing-x1);
+    padding-inline-start: var(--dds-spacing-x1);
+    padding-inline-end: var(--dds-spacing-x0-5);
+  }
+}
+
+.bar--small-screen-md {
+  @media only screen and (max-width: 1280px) {
+    gap: var(--dds-spacing-x1);
+    padding-inline-start: var(--dds-spacing-x1);
+    padding-inline-end: var(--dds-spacing-x0-5);
+  }
+}
+
+.bar--small-screen-lg {
+  @media only screen and (max-width: 1920px) {
+    gap: var(--dds-spacing-x1);
+    padding-inline-start: var(--dds-spacing-x1);
+    padding-inline-end: var(--dds-spacing-x0-5);
+  }
+}
+
+.bar--small-screen-xl {
   gap: var(--dds-spacing-x1);
   padding-inline-start: var(--dds-spacing-x1);
   padding-inline-end: var(--dds-spacing-x0-5);
@@ -43,6 +75,89 @@
 .nav-list--small-screen {
   align-items: initial;
   flex-direction: column;
+}
+
+.nav-list--small-screen-xs,
+.context-menu-button-without-nav-xs {
+  @media only screen and (max-width: 600px) {
+    display: none;
+  }
+}
+
+.nav-list--small-screen-sm,
+.context-menu-button-without-nav-sm {
+  @media only screen and (max-width: 960px) {
+    display: none;
+  }
+}
+
+.nav-list--small-screen-md,
+.context-menu-button-without-nav-md {
+  @media only screen and (max-width: 1280px) {
+    display: none;
+  }
+}
+
+.nav-list--small-screen-lg,
+.context-menu-button-without-nav-lg {
+  @media only screen and (max-width: 1920px) {
+    display: none;
+  }
+}
+
+.nav-list--small-screen-xl,
+.context-menu-button-without-nav-xl {
+  display: none;
+}
+
+.nav--in-menu--small-screen,
+.context-menu-group--small-screen-only,
+.context-menu-button-with-nav,
+.menu-divider {
+  display: none;
+}
+
+.nav--in-menu--small-screen-xs,
+.context-menu-group--small-screen-only-xs,
+.context-menu-button-with-nav-xs,
+.menu-divider--small-screen-xs {
+  @media only screen and (max-width: 600px) {
+    display: block;
+  }
+}
+
+.nav--in-menu--small-screen-sm,
+.context-menu-group--small-screen-only-sm,
+.context-menu-button-with-nav-sm,
+.menu-divider--small-screen-sm {
+  @media only screen and (max-width: 960px) {
+    display: block;
+  }
+}
+
+.nav--in-menu--small-screen-md,
+.context-menu-group--small-screen-only-md,
+.context-menu-button-with-nav-md,
+.menu-divider--small-screen-md {
+  @media only screen and (max-width: 1280px) {
+    display: block;
+  }
+}
+
+.nav--in-menu--small-screen-lg,
+.context-menu-group--small-screen-only-lg,
+.context-menu-button-with-nav-lg,
+.menu-divider--small-screen-lg {
+  @media only screen and (max-width: 1920px) {
+    display: block;
+  }
+}
+
+.nav--in-menu--small-screen-xl,
+.context-menu-group--small-screen-only-xl,
+.context-menu-button-with-nav-xl,
+.menu-divider--small-screen-xl {
+  display: block;
 }
 
 .nav-list__item {

--- a/packages/components/src/components/InternalHeader/InternalHeader.spec.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.spec.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { InternalHeader } from '.';
 
-describe('<InternalHeader />', () => {
+describe('<InternalHeader>', () => {
   it('should display application name', () => {
     const appName = 'appName';
     render(<InternalHeader applicationName={appName} />);
@@ -73,7 +73,12 @@ describe('<InternalHeader />', () => {
       title: title,
       href: href,
     };
-    render(<InternalHeader navigationElements={[element]} smallScreen />);
+    render(
+      <InternalHeader
+        navigationElements={[element]}
+        smallScreenBreakpoint="xl"
+      />,
+    );
     const burgerButton = screen.getByRole('button');
     await userEvent.click(burgerButton);
     const navigationLink = screen.getByRole('menuitem', {

--- a/packages/components/src/components/InternalHeader/InternalHeader.stories.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.stories.tsx
@@ -13,7 +13,6 @@ export default {
     applicationDesc: { control: 'text' },
     currentPageHref: { control: 'text' },
     applicationHref: { control: 'text' },
-    smallScreen: { control: 'boolean' },
     navigationElements: { control: false },
     contextMenuElements: { control: false },
     userProps: { control: false },
@@ -79,6 +78,17 @@ export const WithNavigationAndContextMenu: Story = {
   },
 };
 
+export const Responsive: Story = {
+  parameters: { docs: { story: { height: '265px' } } },
+  args: {
+    applicationName: 'Lovisa',
+    applicationDesc: 'Produktnavn',
+    navigationElements: navigationLinks,
+    contextMenuElements: menuElements,
+    userProps: user,
+  },
+};
+
 export const WithCurrentPage: Story = {
   args: {
     applicationName: 'Lovisa',
@@ -132,37 +142,37 @@ export const Overview: Story = {
         navigationElements={navigationLinks}
         contextMenuElements={menuElements}
         userProps={user}
-        smallScreen
+        smallScreenBreakpoint="xs"
       />
       <InternalHeader
         {...args}
         navigationElements={navigationLinks}
         userProps={user}
-        smallScreen
+        smallScreenBreakpoint="xs"
       />
     </StoryVStack>
   ),
 };
 
-export const SmallScreenWithNavigation: Story = {
+export const ResponsiveWithNavigation: Story = {
   args: {
     applicationName: 'Lovisa',
     applicationDesc: 'Produktnavn',
     navigationElements: navigationLinks,
-    smallScreen: true,
+    smallScreenBreakpoint: 'sm',
   },
 };
 
-export const SmallScreenWithContextMenu: Story = {
+export const ResponsiveWithContextMenu: Story = {
   args: {
     applicationName: 'Lovisa',
     applicationDesc: 'Produktnavn',
     contextMenuElements: menuElements,
-    smallScreen: true,
+    smallScreenBreakpoint: 'sm',
   },
 };
 
-export const SmallScreenWithNavigationAndContextMenu: Story = {
+export const ResponsiveWithNavigationAndContextMenu: Story = {
   parameters: { docs: { story: { height: '365px' } } },
   args: {
     applicationName: 'Lovisa',
@@ -170,7 +180,7 @@ export const SmallScreenWithNavigationAndContextMenu: Story = {
     contextMenuElements: menuElements,
     navigationElements: navigationLinks,
     userProps: user,
-    smallScreen: true,
+    smallScreenBreakpoint: 'sm',
   },
 };
 

--- a/packages/components/src/components/InternalHeader/InternalHeader.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.tsx
@@ -26,7 +26,7 @@ export const InternalHeader = (props: InternalHeaderProps) => {
     applicationDesc,
     applicationName,
     applicationHref,
-    smallScreen,
+    smallScreenBreakpoint,
     navigationElements,
     contextMenuElements,
     currentPageHref,
@@ -60,38 +60,40 @@ export const InternalHeader = (props: InternalHeaderProps) => {
     !!navigationElements && navigationElements.length > 0;
   const hasContextMenuElements =
     !!contextMenuElements && contextMenuElements.length > 0;
-  const hasNavInContextMenu = smallScreen && hasNavigationElements;
+  const hasSmallScreenBreakpoint = !!smallScreenBreakpoint;
+  const hasNavInContextMenu = hasSmallScreenBreakpoint && hasNavigationElements;
 
-  const navigation =
-    hasNavigationElements && !smallScreen ? (
-      <nav aria-label="sidenavigasjon">
-        <ul
-          className={cn(
-            styles['nav-list'],
-            smallScreen && styles['nav-list--small-screen'],
-            utilStyles['remove-list-styling'],
-          )}
-        >
-          {navigationElements.map((item, index) => {
-            const { href, ...rest } = item;
-            const isCurrent = href === currentPage;
-            return (
-              <li key={index} className={styles['nav-list__item']}>
-                <NavigationItem
-                  href={href}
-                  {...rest}
-                  isCurrent={isCurrent}
-                  onClick={() => handleCurrentPageChange(href)}
-                />
-              </li>
-            );
-          })}
-        </ul>
-      </nav>
-    ) : null;
+  const navigation = hasNavigationElements ? (
+    <nav aria-label="sidenavigasjon">
+      <ul
+        className={cn(
+          styles['nav-list'],
+          hasSmallScreenBreakpoint &&
+            styles[`nav-list--small-screen-${smallScreenBreakpoint}`],
+          utilStyles['remove-list-styling'],
+        )}
+      >
+        {navigationElements.map((item, index) => {
+          const { href, ...rest } = item;
+          const isCurrent = href === currentPage;
+          return (
+            <li key={index} className={styles['nav-list__item']}>
+              <NavigationItem
+                href={href}
+                {...rest}
+                isCurrent={isCurrent}
+                onClick={() => handleCurrentPageChange(href)}
+              />
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  ) : null;
 
   const hasContextMenu =
     hasContextMenuElements || !!userProps || hasNavInContextMenu;
+  const hasContextMenuLargeScreen = hasContextMenuElements || !!userProps;
 
   return (
     <div
@@ -100,7 +102,8 @@ export const InternalHeader = (props: InternalHeaderProps) => {
         cn(
           className,
           styles.bar,
-          smallScreen && styles['bar--small-screen'],
+          hasSmallScreenBreakpoint &&
+            styles[`bar--small-screen-${smallScreenBreakpoint}`],
           !!navigation && styles['bar--with-nav'],
         ),
         htmlProps,
@@ -128,7 +131,18 @@ export const InternalHeader = (props: InternalHeaderProps) => {
       )}
       {navigation}
       {hasContextMenu && (
-        <div className={styles['context-menu-group']}>
+        <div
+          className={cn(
+            styles['context-menu-group'],
+            !hasContextMenuLargeScreen &&
+              styles['context-menu-group--small-screen-only'],
+            !hasContextMenuLargeScreen &&
+              hasSmallScreenBreakpoint &&
+              styles[
+                `context-menu-group--small-screen-only-${smallScreenBreakpoint}`
+              ],
+          )}
+        >
           <Button
             ref={buttonRef}
             icon={hasNavInContextMenu ? MenuIcon : MoreVerticalIcon}
@@ -158,7 +172,13 @@ export const InternalHeader = (props: InternalHeaderProps) => {
               </OverflowMenuList>
             )}
             {hasNavInContextMenu && (
-              <nav>
+              <nav
+                aria-label="sidenavigasjon"
+                className={cn(
+                  styles['nav--in-menu--small-screen'],
+                  styles[`nav--in-menu--small-screen-${smallScreenBreakpoint}`],
+                )}
+              >
                 <OverflowMenuList>
                   {navigationElements.map(item => (
                     <OverflowMenuLink {...item}>{item.title}</OverflowMenuLink>
@@ -167,7 +187,12 @@ export const InternalHeader = (props: InternalHeaderProps) => {
               </nav>
             )}
             {hasNavInContextMenu && hasContextMenuElements && (
-              <OverflowMenuDivider />
+              <OverflowMenuDivider
+                className={cn(
+                  styles['menu-divider'],
+                  styles[`menu-divider--small-screen-${smallScreenBreakpoint}`],
+                )}
+              />
             )}
             {hasContextMenuElements && (
               <OverflowMenuList>

--- a/packages/components/src/components/InternalHeader/InternalHeader.types.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.types.tsx
@@ -1,6 +1,7 @@
 import { type AnchorHTMLAttributes, type ButtonHTMLAttributes } from 'react';
 
 import { type BaseComponentProps } from '../../types';
+import { type ScreenSizeLiteral } from '../helpers';
 import { type SvgIcon } from '../Icon/utils';
 
 type NavigationLinkProps = {
@@ -32,8 +33,8 @@ export type InternalHeaderProps = BaseComponentProps<
     applicationDesc?: string;
     /**URL til hovedsiden. */
     applicationHref?: string;
-    /**Indikerer om versjonen for små skjermer skal vises. */
-    smallScreen?: boolean;
+    /**Spesifiserer ved hvilket brekkpunkt og nedover versjonen for små skjermer skal vises; den justerer på spacing og legger navigasjonen i kontekstmenyen. */
+    smallScreenBreakpoint?: ScreenSizeLiteral;
     /**Info om brukeren. Dukker opp som punkt på toppen av kontekstmenyen med tekst oppgitt i name. Blir en lenke hvis href er oppgitt. */
     userProps?: InternaHeaderUserProps;
     /**Lenker som skal vises i navigasjonsmenyen. */

--- a/packages/components/src/components/Pagination/Pagination.mdx
+++ b/packages/components/src/components/Pagination/Pagination.mdx
@@ -14,7 +14,10 @@ import * as PaginationStories from './Pagination.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/?node-id=2576%3A78023"
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Pagination"
   storybookHref="https://domstolene.github.io/designsystem/?path=/story/dds-components-pagination--default"
+  withBottomSpacing
 />
+
+`<Pagination>` brukes i kombinasjon med tabell eller lignende innhold som kan deles opp i lister med elementer. Komponenten er responsiv.
 
 ## Props
 
@@ -44,10 +47,14 @@ Det brukes 1-indeksering slik at sidenummeret blir brukt som label i knappene.
 
 <Canvas of={PaginationStories.CustomOptions} />
 
-### Default aktiv side
+### Custom aktiv side
 
 <Canvas of={PaginationStories.DefaultActivePage} />
 
-### Default antall elementer per side
+### Custom antall elementer per side
 
 <Canvas of={PaginationStories.DefaultItemsPerPage} />
+
+### Responsiv
+
+<Canvas of={PaginationStories.Responsive} />

--- a/packages/components/src/components/Pagination/Pagination.module.css
+++ b/packages/components/src/components/Pagination/Pagination.module.css
@@ -5,7 +5,35 @@
   flex-wrap: wrap;
 }
 
-.container--small-screen {
+.container--small-screen-xs {
+  @media only screen and (max-width: 600px) {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+.container--small-screen-sm {
+  @media only screen and (max-width: 960px) {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+.container--small-screen-md {
+  @media only screen and (max-width: 1280px) {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+.container--small-screen-lg {
+  @media only screen and (max-width: 1920px) {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
+.container--small-screen-xl {
   flex-direction: column;
   align-items: center;
 }
@@ -13,6 +41,65 @@
 .nav {
   display: flex;
   align-items: center;
+}
+
+.nav--large-screen-hide-xs {
+  @media only screen and (max-width: 600px) {
+    display: none;
+  }
+}
+
+.nav--large-screen-hide-sm {
+  @media only screen and (max-width: 960px) {
+    display: none;
+  }
+}
+
+.nav--large-screen-hide-md {
+  @media only screen and (max-width: 1280px) {
+    display: none;
+  }
+}
+
+.nav--large-screen-hide-lg {
+  @media only screen and (max-width: 1920px) {
+    display: none;
+  }
+}
+
+.nav--large-screen-hide-xl {
+  display: none;
+}
+
+.nav--small-screen {
+  display: none;
+}
+.nav--small-screen-show-xs {
+  @media only screen and (max-width: 600px) {
+    display: block;
+  }
+}
+
+.nav--small-screen-show-sm {
+  @media only screen and (max-width: 960px) {
+    display: block;
+  }
+}
+
+.nav--small-screen-show-md {
+  @media only screen and (max-width: 1280px) {
+    display: block;
+  }
+}
+
+.nav--small-screen-show-lg {
+  @media only screen and (max-width: 1920px) {
+    display: block;
+  }
+}
+
+.nav--small-screen-show-xl {
+  display: block;
 }
 
 .list {

--- a/packages/components/src/components/Pagination/Pagination.spec.tsx
+++ b/packages/components/src/components/Pagination/Pagination.spec.tsx
@@ -22,42 +22,77 @@ describe('<Pagination />', () => {
     ).toHaveAttribute('aria-label', 'Nåværende side (side 3)');
   });
   it('should render correct number of pages', () => {
+    const itemsAmount = 6;
     render(
       <Pagination
-        itemsAmount={6}
+        itemsAmount={itemsAmount}
         defaultItemsPerPage={1}
         defaultActivePage={2}
       />,
     );
-    expect(screen.getAllByRole('listitem')).toHaveLength(8); // itemsAmount + < > buttons)
+    expect(screen.getAllByRole('listitem')).toHaveLength(itemsAmount + 2); // itemsAmount + < > buttons)
   });
   it('should not render previous page-button while on first page', () => {
-    render(<Pagination itemsAmount={6} defaultItemsPerPage={1} />);
-    expect(screen.getAllByRole('listitem')).toHaveLength(7); // itemsAmount +  > button
+    const itemsAmount = 6;
+    render(<Pagination itemsAmount={itemsAmount} defaultItemsPerPage={1} />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(itemsAmount + 1); // itemsAmount +  > button
   });
   it('should not render next page-button while on last page', () => {
+    const itemsAmount = 6;
     render(
       <Pagination
-        itemsAmount={6}
+        itemsAmount={itemsAmount}
         defaultItemsPerPage={1}
         defaultActivePage={6}
       />,
     );
-    expect(screen.getAllByRole('listitem')).toHaveLength(7); // itemsAmount +  < button
+    expect(screen.getAllByRole('listitem')).toHaveLength(itemsAmount + 1); // itemsAmount +  < button
   });
-  it('should render smallScreen version with three items while on first page', () => {
-    render(<Pagination itemsAmount={6} defaultItemsPerPage={1} smallScreen />);
-    expect(screen.getAllByRole('listitem')).toHaveLength(3); // active page +  > >| buttons
-  });
-  it('should render smallScreen version with five items while neither on first or last page', () => {
-    render(
-      <Pagination
-        itemsAmount={6}
-        defaultItemsPerPage={1}
-        defaultActivePage={2}
-        smallScreen
-      />,
-    );
-    expect(screen.getAllByRole('listitem')).toHaveLength(5); // active page + |< <  > >| buttons
+  describe('pagination with small screen variant', () => {
+    it('has aria label', () => {
+      render(<Pagination itemsAmount={10} smallScreenBreakpoint="sm" />);
+      const paginations = screen.getAllByRole('navigation');
+      expect(paginations[0]).toHaveAttribute('aria-label', 'paginering');
+      expect(paginations[1]).toHaveAttribute('aria-label', 'paginering');
+    });
+    it('should render correct number of pages', () => {
+      const itemsAmount = 6;
+      render(
+        <Pagination
+          itemsAmount={itemsAmount}
+          defaultItemsPerPage={1}
+          defaultActivePage={2}
+          smallScreenBreakpoint="sm"
+        />,
+      );
+
+      // itemsAmount + < > buttons for large screen, active item + |< >| < > buttons for small screen
+      expect(screen.getAllByRole('listitem')).toHaveLength(itemsAmount + 7);
+    });
+    it('should not render previous page-button while on first page', () => {
+      const itemsAmount = 6;
+      render(
+        <Pagination
+          itemsAmount={itemsAmount}
+          defaultItemsPerPage={1}
+          smallScreenBreakpoint="sm"
+        />,
+      );
+      // itemsAmount +  > button for large screen, active item + >| > buttons for small screen
+      expect(screen.getAllByRole('listitem')).toHaveLength(itemsAmount + 4);
+    });
+    it('should not render next page-button while on last page', () => {
+      const itemsAmount = 6;
+      render(
+        <Pagination
+          itemsAmount={itemsAmount}
+          defaultItemsPerPage={1}
+          defaultActivePage={6}
+          smallScreenBreakpoint="sm"
+        />,
+      );
+      // itemsAmount +  < button for large screen, active item + |< < buttons for small screen
+      expect(screen.getAllByRole('listitem')).toHaveLength(itemsAmount + 4);
+    });
   });
 });

--- a/packages/components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/components/src/components/Pagination/Pagination.stories.tsx
@@ -11,7 +11,6 @@ export default {
     withCounter: { control: 'boolean' },
     withPagination: { control: 'boolean' },
     withSelect: { control: 'boolean' },
-    smallScreen: { control: 'boolean' },
     defaultItemsPerPage: { control: 'number' },
     defaultActivePage: { control: 'number' },
     selectOptions: { control: false },
@@ -55,10 +54,10 @@ export const OverviewMobile: Story = {
   args: { itemsAmount: 100 },
   render: args => (
     <StoryVStack gap="x3">
-      <Pagination {...args} smallScreen />
-      <Pagination {...args} smallScreen withCounter />
-      <Pagination {...args} smallScreen withSelect />
-      <Pagination {...args} smallScreen withCounter withSelect />
+      <Pagination {...args} smallScreenBreakpoint="xl" />
+      <Pagination {...args} smallScreenBreakpoint="xl" withCounter />
+      <Pagination {...args} smallScreenBreakpoint="xl" withSelect />
+      <Pagination {...args} smallScreenBreakpoint="xl" withCounter withSelect />
     </StoryVStack>
   ),
 };
@@ -75,6 +74,11 @@ export const CustomOptions: Story = {
       itemsAmount={customOptionsItemsAmount}
     />
   ),
+};
+
+export const Responsive: Story = {
+  args: { smallScreenBreakpoint: 'sm', itemsAmount: 100 },
+  render: args => <Pagination {...args} withCounter withSelect />,
 };
 
 export const DefaultActivePage: Story = {


### PR DESCRIPTION
Prop `smallScreen` i komponentene `<Breadcrumbs>`, `<InternalHeader>` og `<Pagination>` gjøres om til `smalScreenBreakpoint`; den tar inn navn på et brekkpunkt og gjør komponenten responsiv, slik at versjonen for liten skjerm vises ved oppgitte brekkpunket og nedover vha kun CSS.