### PR TITLE
ELSA1-378 Legger til `@default` i JSDoc for props

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -157,7 +157,7 @@
   }
 
   .sbdocs h4:not(.docs-story *) {
-    font: var(--dds-font-heading-sans-04);
+    font: var(--dds-font-heading-sans-03);
     letter-spacing: var(--dds-font-heading-sans-03-letter-spacing);
     margin-bottom: var(--dds-font-heading-sans-03-paragraph-spacing);
     padding-top: var(--dds-spacing-padding-top-heading);

--- a/packages/components/src/components/Button/Button.tsx
+++ b/packages/components/src/components/Button/Button.tsx
@@ -18,9 +18,7 @@ import { Spinner } from '../Spinner';
 import { type StaticTypographyType, getTypographyCn } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
-const typographyTypes: {
-  [k in ButtonSize]: StaticTypographyType;
-} = {
+const typographyTypes: Record<ButtonSize, StaticTypographyType> = {
   large: 'bodySans04',
   medium: 'bodySans02',
   small: 'bodySans01',

--- a/packages/components/src/components/Button/Button.types.tsx
+++ b/packages/components/src/components/Button/Button.types.tsx
@@ -15,17 +15,25 @@ type PickedHTMLAttributes = Pick<
 export type ButtonProps = BaseComponentProps<
   HTMLButtonElement,
   {
-    /**Størrelsen på knappen. */
+    /** Størrelsen på knappen.
+     *  @default "medium"
+     */
     size?: ButtonSize;
     /**Innhold i knappen (unntatt ikon). */
     children?: ReactNode;
-    /**Bestemmer farger basert på formål. */
+    /**Bestemmer farger basert på formål.
+     * @default "primary"
+     */
     purpose?: ButtonPurpose;
-    /**	Posisjonen til ikonet i forhold til teksten.*/
+    /**	Posisjonen til ikonet i forhold til teksten.
+     *  @default "left"
+     */
     iconPosition?: IconPosition;
     /**Indikerer en loading-knapp. */
     loading?: boolean;
-    /**Tooltip som vises ved loading. */
+    /** Tooltip som vises ved loading.
+     *  @default "Lagring pågår"
+     */
     loadingTooltip?: string;
     /**Ikonet som ligger i knappen.  */
     icon?: SvgIcon;

--- a/packages/components/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/src/components/ButtonGroup/ButtonGroup.tsx
@@ -26,15 +26,21 @@ type PickedHTMLAttributes = Pick<
 export type ButtonGroupProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
   {
-    /**Retning for gruppen. */
+    /**Retning for gruppen.
+     * @default "row"
+     */
     direction?: Direction;
-    /**Størrelse på knappene. */
+    /**Størrelse på knappene.
+     * @default "medium"
+     */
     buttonSize?: ButtonSize;
     /**Nativ `aria-label` ved behov. */
     'aria-label'?: string;
     /**Nativ `aria-labelledby` ved behov. */
     'aria-labelledby'?: string;
-    /**Nativ `role` ved behov. */
+    /**Nativ `role` ved behov.
+     * @default "group"
+     */
     role?: AriaRole;
   } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof PickedHTMLAttributes>
 >;

--- a/packages/components/src/components/Card/Card.tsx
+++ b/packages/components/src/components/Card/Card.tsx
@@ -16,7 +16,9 @@ export type CardType = 'info' | 'navigation' | 'expandable';
 type BaseCardProps<T extends HTMLElement> = BaseComponentPropsWithChildren<
   T,
   {
-    /** Utseende på komponenten. */
+    /** Utseende på komponenten.
+     * @default "filled"
+     */
     appearance?: CardAppearance;
 
     /** Referanse til komponenten. */

--- a/packages/components/src/components/Divider/Divider.tsx
+++ b/packages/components/src/components/Divider/Divider.tsx
@@ -9,7 +9,9 @@ export type DividerColor = 'default' | 'subtle' | 'onInverse';
 export type DividerProps = BaseComponentProps<
   HTMLHRElement,
   {
-    /** Farge på horisontal linje. */
+    /** Farge på horisontal linje.
+     * @default "default"
+     */
     color?: DividerColor;
   }
 >;

--- a/packages/components/src/components/Drawer/Drawer.tsx
+++ b/packages/components/src/components/Drawer/Drawer.tsx
@@ -32,9 +32,13 @@ export interface WidthProps {
 export type DrawerProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
   {
-    /**Størrelsen på `<Drawer />`. */
+    /**Størrelsen på `<Drawer>`.
+     * @default "small"
+     */
     size?: DrawerSize;
-    /** Plasseringen til `<Drawer />`. */
+    /** Plasseringen til `<Drawer>`.
+     * @default "right"
+     */
     placement?: DrawerPlacement;
     /**Header for `<Drawer />`. Har default styling hvis verdien er en string. */
     header?: string | ReactNode;
@@ -42,7 +46,9 @@ export type DrawerProps = BaseComponentPropsWithChildren<
     isOpen?: boolean;
     /**Funksjon kjørt ved lukking. **OBS!** nødvendig kun hvis `<DrawerGroup />` ikke er i bruk. */
     onClose?: () => void;
-    /**Spesifiserer hvilken DOM node `<Drawer />` skal ha som forelder via React portal. Brukes med f.eks `document.getElementById("id")` (skaper ikke ny DOM node). */
+    /**Spesifiserer hvilken DOM node `<Drawer>` skal ha som forelder via React portal. Brukes med f.eks `document.getElementById("id")` (skaper ikke ny DOM node).
+     * @default document.body
+     */
     parentElement?: HTMLElement;
     /**Custom props for breddehåndtering ved behov. */
     widthProps?: WidthProps;

--- a/packages/components/src/components/EmptyContent/EmptyContent.tsx
+++ b/packages/components/src/components/EmptyContent/EmptyContent.tsx
@@ -7,7 +7,9 @@ import { Heading, type HeadingLevel, Paragraph } from '../Typography';
 export type EmptyContentProps = {
   /**Tittel - kort oppsummering. */
   title?: string;
-  /**Nivå på overskriften. Sørg for at den følger hierarkiet på siden. */
+  /**Nivå på overskriften. Sørg for at den følger hierarkiet på siden.
+   * @default 2
+   */
   titleHeadingLevel?: HeadingLevel;
   /**Melding - beskrivelse og forklaring på hvordan brukeren kan få innhold. Kan inneholde lenker og andre interaktive elementer. */
   message: ReactNode;

--- a/packages/components/src/components/FavStar/FavStar.tsx
+++ b/packages/components/src/components/FavStar/FavStar.tsx
@@ -21,7 +21,7 @@ export interface FavStarProps
    */
   checked?: boolean;
   /**
-   * Hvis du skal bruke `<FavStar>` uncontrolled så kan denne brukes til å sette den initielle "favortitt"-statusen.
+   * Hvis du skal bruke `<FavStar>` uncontrolled så kan denne brukes til å sette den initielle "favoritt"-statusen.
    * @default false
    */
   defaultChecked?: boolean;
@@ -31,7 +31,7 @@ export interface FavStarProps
   onChange?: (checked: boolean) => void;
   /**
    * Størrelse på `<FavStar>`. `'medium'` er den mest vanlige størrelsen.
-   * @default 'medium'
+   * @default "medium"
    */
   size?: ComponentSize;
 }

--- a/packages/components/src/components/Feedback/Feedback.types.tsx
+++ b/packages/components/src/components/Feedback/Feedback.types.tsx
@@ -1,29 +1,49 @@
 export interface FeedbackProps {
   /**Om knappene skal være plassert under eller ved siden av teksten. */
   layout?: Layout;
-  /**Label som er plassert over tommel opp/ned knappene. */
+  /**Label som er plassert over tommel opp/ned knappene.
+   * @default "Hva syns du om tjenesten?"
+   */
   ratingLabel: string;
-  /**Label til fritekstfeltet når bruker har gitt tommel opp. */
+  /**Label til fritekstfeltet når bruker har gitt tommel opp.
+   * @default "Hva kan vi forbedre? (valgfritt)"
+   */
   positiveFeedbackLabel?: string;
-  /**Label til fritekstfeltet når bruker har gitt tommel ned. */
+  /**Label til fritekstfeltet når bruker har gitt tommel ned.
+   *  @default "Hva kan vi forbedre? (valgfritt)"
+   */
   negativeFeedbackLabel?: string;
-  /**Tittel som vises når bruker har gitt tommel opp/ned, og enda ikke sendt inn kommentar. */
+  /**Tittel som vises når bruker har gitt tommel opp/ned, og enda ikke sendt inn kommentar.
+   *  @default "Tusen takk! Tilbakemeldingen din hjelper oss å forbedre løsningen"
+   */
   ratingSubmittedTitle?: string;
-  /**Tittel som vises når bruker har gitt feedback (inkl. eventuell kommentar). */
+  /**Tittel som vises når bruker har gitt feedback (inkl. eventuell kommentar).
+   * @default "Tusen takk! Tilbakemeldingen din hjelper oss å forbedre løsningen"
+   */
   submittedTitle?: string;
-  /**Tip som vises under tekstfeltet når bruker skal sende inn kommentar.  */
+  /**Tip som vises under tekstfeltet når bruker skal sende inn kommentar.
+   * @default "Ikke send inn personopplysninger eller annen sensitiv informasjon"
+   */
   textAreaTip?: string;
   /**Om tommel opp eller ned er valgt. Brukes når komponenten skal være styrt utenfra. */
   ratingValue?: Rating | null;
   /**Verdien til fritekstfeltet. Brukes når komponenten skal være styrt utenfra. */
   feedbackTextValue?: string;
-  /**Tooltip-teksten til tommel-opp-knappen.*/
+  /**Tooltip-teksten til tommel-opp-knappen.
+   * @default "Bra"
+   */
   thumbUpTooltip?: string;
-  /**Tooltip-teksten til tommel-ned-knappen.*/
+  /**Tooltip-teksten til tommel-ned-knappen.
+   * @default "Dårlig"
+   */
   thumbDownTooltip?: string;
-  /**Om tilbakemeldingskomponenten skal ekskludere fritekstfeltet (i.e. kun ha tommel opp/ned).*/
+  /**Om tilbakemeldingskomponenten skal ekskludere fritekstfeltet (i.e. kun ha tommel opp/ned).
+   * @default false
+   */
   feedbackTextAreaExcluded?: boolean;
-  /**Om knappene skal vise spinner. Gjelder både tommel opp/ned knappene, og "send inn" knappen. */
+  /**Om knappene skal vise spinner. Gjelder både tommel opp/ned knappene, og "send inn" knappen.
+   * @default false
+   */
   loading?: boolean;
   /**Om tilbakemelding er sendt inn. Brukes når komponenten skal være styrt utenfra. */
   isSubmitted?: boolean;

--- a/packages/components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/components/src/components/FileUploader/FileUploader.tsx
@@ -24,19 +24,25 @@ export type FileUploaderProps = {
   id?: string;
   /**Ledetekst for filopplaster. */
   label?: string;
-  /**Ledetekst for slippsonen. Denne teksten skal, av UU-hensyn, henge sammen med den usynlige teksten: "velg fil med påfølgende knapp" */
+  /**Ledetekst for slippsonen. Denne teksten skal, av UU-hensyn, henge sammen med den usynlige teksten: "velg fil med påfølgende knapp"
+   * @default "Dra og slipp filer her eller"
+   */
   dropAreaLabel?: string;
-  /**Ledetekst for opplastingsknappen. */
+  /**Ledetekst for opplastingsknappen.
+   * @default "Velg fil"
+   */
   btnLabel?: string;
   /**Hjelpetekst. */
   tip?: string;
-  /**Om det er påkrevd med minst en fil. */
+  /**Om det er påkrevd med minst én fil. */
   required?: boolean;
   /**Callback for når fil-listen endres. */
   onChange: (newFiles: FileList) => void;
   /**Bredde for filopplasteren. */
   width?: Property.Width;
-  /**Om drag-and-drop zone skal vises. */
+  /**Om drag-and-drop zone skal vises.
+   * @default true
+   */
   withDragAndDrop?: boolean;
   /**Om listen med opplastede filer skal skjules. Brukes kun hvis listen blir vist på egen måte. */
   hideFileList?: boolean;

--- a/packages/components/src/components/Footer/Footer.mdx
+++ b/packages/components/src/components/Footer/Footer.mdx
@@ -34,7 +34,7 @@ Følgende subkomponenter er tilgjengelige:
 
 ## Demo
 
-Du kan åpne (alenestående demo)[https://domstolene.github.io/designsystem/?path=/story/dds-components-footer--default] og endre bredden til nettleservinduet for å se implementasjonen av brekkpunktene.
+Du kan åpne [alenestående demo](https://domstolene.github.io/designsystem/?path=/story/dds-components-footer--default) og endre bredden til nettleservinduet for å se implementasjonen av brekkpunktene.
 
 <Canvas of={FooterStories.Default} />
 <Controls of={FooterStories.Default} />

--- a/packages/components/src/components/GlobalMessage/GlobalMessage.tsx
+++ b/packages/components/src/components/GlobalMessage/GlobalMessage.tsx
@@ -11,20 +11,10 @@ import { Icon, type SvgIcon } from '../Icon';
 import { CloseIcon, ErrorIcon, InfoIcon, WarningIcon } from '../Icon/icons';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
-export const purposeVariants: {
-  [k in GlobalMessagePurpose]: {
-    icon: SvgIcon;
-  };
-} = {
-  info: {
-    icon: InfoIcon,
-  },
-  danger: {
-    icon: ErrorIcon,
-  },
-  warning: {
-    icon: WarningIcon,
-  },
+export const icons: Record<GlobalMessagePurpose, SvgIcon> = {
+  info: InfoIcon,
+  danger: ErrorIcon,
+  warning: WarningIcon,
 };
 
 export type GlobalMessagePurpose = 'info' | 'warning' | 'danger';
@@ -34,7 +24,9 @@ export type GlobalMessageProps = BaseComponentPropsWithChildren<
   {
     /**Meldingen som vises til brukeren. Brukes kun når meldingen er en `string`. */
     message?: string;
-    /**Formålet med meldingen. Påvirker styling. */
+    /**Formålet med meldingen. Påvirker styling.
+     * @default "info"
+     */
     purpose?: GlobalMessagePurpose;
     /**Indikerer om meldingen skal være lukkbar. */
     closable?: boolean;
@@ -80,7 +72,7 @@ export const GlobalMessage = forwardRef<HTMLDivElement, GlobalMessageProps>(
             closable && styles['content--closable'],
           )}
         >
-          <Icon icon={purposeVariants[purpose].icon} className={styles.icon} />
+          <Icon icon={icons[purpose]} className={styles.icon} />
           {children ?? <span>{message}</span>}
         </div>
 

--- a/packages/components/src/components/Grid/GridChild.tsx
+++ b/packages/components/src/components/Grid/GridChild.tsx
@@ -100,9 +100,10 @@ export const GridChild = (props: GridChildProps) => {
       : undefined,
   };
 
-  const columnsCn: {
-    [k in RelativeColumnsOccupied]: RelativeColumnsOccupiedHyphen;
-  } = {
+  const columnsCn: Record<
+    RelativeColumnsOccupied,
+    RelativeColumnsOccupiedHyphen
+  > = {
     all: 'all',
     firstHalf: 'first-half',
     secondHalf: 'second-half',

--- a/packages/components/src/components/Icon/Icon.tsx
+++ b/packages/components/src/components/Icon/Icon.tsx
@@ -26,9 +26,13 @@ export type IconProps = BaseComponentProps<
   {
     /**Ikonet importert fra `@norges-domstoler/dds-components`. */
     icon: SvgIcon;
-    /**Størrelsen på ikonet. */
+    /**Størrelsen på ikonet.
+     * @default "medium"
+     */
     iconSize?: IconSize;
-    /**Fargen på ikonet. */
+    /**Fargen på ikonet.
+     * @default "currentcolor"
+     */
     color?: TextColor;
   }
 >;

--- a/packages/components/src/components/InlineEdit/InlineEdit.types.tsx
+++ b/packages/components/src/components/InlineEdit/InlineEdit.types.tsx
@@ -11,7 +11,9 @@ export interface BaseInlineInputProps {
   error?: boolean;
   /**Feilmelding. Setter også error state. */
   errorMessage?: string;
-  /** Bredde på komponenten. */
+  /** Bredde på komponenten.
+   * @default "140px"
+   */
   width?: Property.Width;
   /**Om redigeringsikonet skal vises. */
   hideIcon?: boolean;

--- a/packages/components/src/components/InputMessage/InputMessage.tsx
+++ b/packages/components/src/components/InputMessage/InputMessage.tsx
@@ -14,7 +14,9 @@ export type InputMessageProps = BaseComponentProps<
   {
     /** Meldingen som vises til brukeren. */
     message: string;
-    /** Formålet med meldingen. Påvirker styling. */
+    /** Formålet med meldingen. Påvirker styling.
+     * @default "error"
+     */
     messageType: InputMessageType;
   }
 >;

--- a/packages/components/src/components/List/List.tsx
+++ b/packages/components/src/components/List/List.tsx
@@ -15,9 +15,13 @@ export type ListTypographyType = TypographyBodyType | 'inherit';
 export type ListProps = BaseComponentPropsWithChildren<
   HTMLUListElement | HTMLOListElement,
   {
-    /**Spesifiserer om komponenten skal returnere `<ul />` (punktliste) eller `<ol />` (nummerert liste). */
+    /**Spesifiserer om komponenten skal returnere `<ul />` (punktliste) eller `<ol />` (nummerert liste).
+     * @default "unordered"
+     */
     listType?: ListType;
-    /**Spesifiserer typografi for listen. Komponenten arver i utgangspunktet fra forelder, men hvis forelder stiller ikke med relevant styling  må det velges `TypographyBodyType` som brukes i `<body>` ellers på siden. */
+    /**Spesifiserer typografi for listen. Komponenten arver i utgangspunktet fra forelder, men hvis forelder stiller ikke med relevant styling  må det velges `TypographyBodyType` som brukes i `<body>` ellers på siden.
+     *  @default "inherit"
+     */
     typographyType?: ListTypographyType;
   }
 >;

--- a/packages/components/src/components/LocalMessage/LocalMessage.tsx
+++ b/packages/components/src/components/LocalMessage/LocalMessage.tsx
@@ -19,26 +19,12 @@ import {
 } from '../Icon/icons';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
-const purposeVariants: {
-  [k in LocalMessagePurpose]: {
-    icon: SvgIcon;
-  };
-} = {
-  info: {
-    icon: InfoIcon,
-  },
-  danger: {
-    icon: ErrorIcon,
-  },
-  warning: {
-    icon: WarningIcon,
-  },
-  success: {
-    icon: CheckCircledIcon,
-  },
-  tips: {
-    icon: TipIcon,
-  },
+const icons: Record<LocalMessagePurpose, SvgIcon> = {
+  info: InfoIcon,
+  danger: ErrorIcon,
+  warning: WarningIcon,
+  success: CheckCircledIcon,
+  tips: TipIcon,
 };
 
 export type LocalMessagePurpose =
@@ -55,13 +41,17 @@ export type LocalMessageProps = BaseComponentPropsWithChildren<
   {
     /**Meldingen som vises til brukeren. Brukes kun når meldingen er string. */
     message?: string;
-    /**Formålet med meldingen. Påvirker styling. */
+    /**Formålet med meldingen. Påvirker styling.
+     * @default "info"
+     */
     purpose?: LocalMessagePurpose;
     /** Indikerer om meldingen skal være lukkbar.*/
     closable?: boolean;
     /**Ekstra logikk å kjøre når meldingen lukkes. */
     onClose?: () => void;
-    /**Layoutet i komponenten. Ved kompleks innhold anbefales `layout='vertical'`. */
+    /**Layoutet i komponenten. Ved kompleks innhold anbefales `layout='vertical'`.
+     * @default "horisontal"
+     */
     layout?: LocalMessageLayout;
     /**Custom bredde ved behov. */
     width?: Property.Width;
@@ -109,7 +99,7 @@ export const LocalMessage = forwardRef<HTMLDivElement, LocalMessageProps>(
         style={{ ...htmlProps?.style, width }}
       >
         <Icon
-          icon={purposeVariants[purpose].icon}
+          icon={icons[purpose]}
           className={cn(styles.icon, styles.container__icon)}
         />
         <div className={styles.container__text}>

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -37,7 +37,9 @@ export type ModalProps = BaseComponentPropsWithChildren<
     isOpen?: boolean;
     /**Funksjon kjørt ved lukking; Settes hvis modal skal være lukkbar. Legger en lukkeknapp i hjørnet og kjøres ved Esc-trykk, lukkeknappklikk og museklikk utenfor. */
     onClose?: () => void;
-    /**Spesifiserer hvilken DOM node `<Modal />` skal ha som forelder via React portal. Brukes med f.eks `document.getElementById("id")` (skaper ikke ny DOM node). */
+    /**Spesifiserer hvilken DOM node `<Modal />` skal ha som forelder via React portal. Brukes med f.eks `document.getElementById("id")` (skaper ikke ny DOM node).
+     * @default document.body
+     */
     parentElement?: HTMLElement;
     /**Tittel/header i modal. Setter `aria-labelledby`. */
     header?: string | ReactNode;

--- a/packages/components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -18,6 +18,11 @@ import {
 export default {
   title: 'dds-components/OverflowMenu',
   component: OverflowMenu,
+  argTypes: {
+    offset: { control: 'number' },
+    anchorRef: { control: false },
+    htmlProps: { control: false },
+  },
   parameters: {
     docs: {
       story: { height: '350px', inline: true },

--- a/packages/components/src/components/OverflowMenu/OverflowMenu.types.tsx
+++ b/packages/components/src/components/OverflowMenu/OverflowMenu.types.tsx
@@ -26,11 +26,17 @@ export type OverflowMenuSpanProps = OverflowMenuListItemBaseProps &
 export type OverflowMenuProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
   {
-    /**Plassering av menyen i forhold til anchor-elementet. */
+    /**Plassering av menyen i forhold til anchor-elementet.
+     * @default "bottom-end"
+     */
     placement?: Placement;
-    /**Avstand fra anchor-elementet i px. */
+    /**Avstand fra anchor-elementet i px.
+     * @default 2
+     */
     offset?: number;
-    /**Spesifiserer om menyen skal vises. **OBS!** nødvendig kun hvis `<OverflowMenuGroup />` ikke brukes.  */
+    /**Spesifiserer om menyen skal vises. **OBS!** nødvendig kun hvis `<OverflowMenuGroup />` ikke brukes.
+     * @default false
+     */
     isOpen?: boolean;
     /**Callback for å lukke menyen. **OBS!** nødvendig kun hvis `<OverflowMenuGroup />` ikke brukes.  */
     onClose?: () => void;

--- a/packages/components/src/components/Pagination/Pagination.tsx
+++ b/packages/components/src/components/Pagination/Pagination.tsx
@@ -27,17 +27,30 @@ export type PaginationProps = BaseComponentProps<
   {
     /**Totalt antall elementer å paginere. */
     itemsAmount: number;
-    /**Antall elementer per side ved innlastning av komponenten. */
+    /**Antall elementer per side ved innlastning av komponenten.
+     * @default 10
+     */
     defaultItemsPerPage?: number;
-    /**Den aktive siden ved innlastning av komponenten. */
+    /**Den aktive siden ved innlastning av komponenten.
+     * @default 1
+     */
     defaultActivePage?: number;
-    /**Spesifiserer om selve pagineringen skal vises. */
+    /**Spesifiserer om selve pagineringen skal vises.
+     * @default true
+     */
     withPagination?: boolean;
     /**Spesifiserer om teksten `'Vis x-y av z'` skal vises. */
     withCounter?: boolean;
     /**Spesifiserer om `<Select />` til å velge antall resultater per side skal vises. */
     withSelect?: boolean;
-    /**Custom options for `<Select />`. **OBS!** hvis det settes custom `selectOptions` bør "alle"-alternativet inkluderes der det er relevant, da brukere ofte liker å ha muligheten. */
+    /**Custom options for `<Select />`. **OBS!** hvis det settes custom `selectOptions` bør "alle"-alternativet inkluderes der det er relevant, da brukere ofte liker å ha muligheten.
+     * @default [
+        { label: '10', value: 10 },
+        { label: '25', value: 25 },
+        { label: '50', value: 50 },
+        { label: 'Alle', value: itemsAmount },
+      ]
+     */
     selectOptions?: Array<PaginationOption>;
     /**Brukes til å hente side og eventuelt annen logikk ved endring av side. */
     onChange?: (

--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -37,15 +37,23 @@ export type PopoverProps = BaseComponentPropsWithChildren<
   {
     /**Tittel. */
     title?: string | ReactNode;
-    /** **OBS!** Propen settes automatisk av `<PopoverGroup />`. Spesifiserer om `<Popover />` skal vises. */
+    /** **OBS!** Propen settes automatisk av `<PopoverGroup />`. Spesifiserer om `<Popover />` skal vises.
+     * @default false
+     */
     isOpen?: boolean;
-    /**Om lukkeknapp skal vises. */
+    /**Om lukkeknapp skal vises.
+     * @default true
+     */
     withCloseButton?: boolean;
     /** **OBS!** Propen settes automatisk av `<PopoverGroup />`. Anchor-elementet. */
     anchorElement?: HTMLElement;
-    /**Spesifiserer hvor komponenten skal plasseres i forhold til anchor-elementet. */
+    /**Spesifiserer hvor komponenten skal plasseres i forhold til anchor-elementet.
+     * @default "bottom"
+     */
     placement?: Placement;
-    /**Avstand fra anchor-elementet i px. */
+    /**Avstand fra anchor-elementet i px.
+     * @default 8
+     */
     offset?: number;
     /** Ekstra logikk kjørt når lukkeknappen trykkes. */
     onCloseButtonClick?: () => void;

--- a/packages/components/src/components/ProgressTracker/ProgressTracker.tsx
+++ b/packages/components/src/components/ProgressTracker/ProgressTracker.tsx
@@ -23,7 +23,9 @@ import {
 export type ProgressTrackerProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
   {
-    /** Indeksen til det aktive steget. */
+    /** Indeksen til det aktive steget.
+     * @default 0
+     */
     activeStep?: number;
     /** Ekstra logikk ved klikking på et steg. */
     onStepChange?: (step: number) => void;

--- a/packages/components/src/components/ProgressTracker/ProgressTrackerItem.tsx
+++ b/packages/components/src/components/ProgressTracker/ProgressTrackerItem.tsx
@@ -41,7 +41,7 @@ type StateHyphen =
   | 'inactive-incomplete'
   | 'inactive-completed';
 
-const itemStateCn: { [k in ItemState]: StateHyphen } = {
+const itemStateCn: Record<ItemState, StateHyphen> = {
   disabled: 'disabled',
   activeCompleted: 'active-completed',
   activeIncomplete: 'active-incomplete',
@@ -52,19 +52,17 @@ const itemStateCn: { [k in ItemState]: StateHyphen } = {
 export interface BaseItemProps {
   /** Om steget er valgt eller ikke. Settes av konsument. */
   active?: boolean;
-
-  /** Om steget er ferdig eller ikke. Settes av konsument. */
+  /** Om steget er ferdig eller ikke. Settes av konsument.
+   * @default false
+   */
   completed?: boolean;
-
   /** Om steget skal være disabled. Settes av konsument.
    * @default false
    */
   disabled?: boolean;
-
   /** Ikon som skal vises istedenfor stegnummeret. Settes av konument. */
   icon?: SvgIcon;
-
-  /** Indeksen til steget. NB! Denne settes automatisk av `<ProgressTracker />` og skal ikke settes manuelt. */
+  /** Indeksen til steget. NB! Denne settes automatisk av forelder og skal ikke settes manuelt. */
   index?: number;
 }
 

--- a/packages/components/src/components/Search/Search.mdx
+++ b/packages/components/src/components/Search/Search.mdx
@@ -50,9 +50,7 @@ Ikke-compound komponenter er også støttet: `<SearchAutocompleteWrapper>`, `<Se
 
 En wrapper som håndterer autofullføring. Skal ha `<Search>` som barn.
 
-<Canvas>
-  <Story of={SearchStories.WithSuggestions} height="440px" />
-</Canvas>
+<Canvas of={SearchStories.WithSuggestions} height="440px" />
 <ArgTypes of={Search.AutocompleteWrapper} />
 
 #### Types

--- a/packages/components/src/components/Search/Search.stories.tsx
+++ b/packages/components/src/components/Search/Search.stories.tsx
@@ -127,6 +127,7 @@ export const WithButton: Story = {
 };
 
 export const WithSuggestions: Story = {
+  parameters: { docs: { story: { height: '450px' } } },
   render: args => (
     <>
       <Search.AutocompleteWrapper data={{ array }}>

--- a/packages/components/src/components/Search/Search.utils.ts
+++ b/packages/components/src/components/Search/Search.utils.ts
@@ -3,7 +3,7 @@ import { type ChangeEvent } from 'react';
 import { type SearchSize } from './Search.types';
 import { type StaticTypographyType } from '../Typography';
 
-export const typographyTypes: { [k in SearchSize]: StaticTypographyType } = {
+export const typographyTypes: Record<SearchSize, StaticTypographyType> = {
   small: 'bodySans01',
   medium: 'bodySans02',
   large: 'bodySans04',

--- a/packages/components/src/components/Search/SearchAutocompleteWrapper.tsx
+++ b/packages/components/src/components/Search/SearchAutocompleteWrapper.tsx
@@ -38,9 +38,11 @@ export interface SearchAutocompleteWrapperProps {
   onSuggestionSelection?: () => void;
   /** Custom filter for forslag. */
   filter?: (sugestion: string, query: string) => boolean;
-  /**Minst lengde på query når forslag skal vises. */
+  /**Minst lengde på query når forslag skal vises.
+   * @default 2
+   */
   queryLength?: number;
-  /** Barnet til komponenten (`<Search />`). */
+  /** Barnet til subkomponenten - `<Search>`. */
   children?: ReactNode;
   /**Initielle `value` i `<Search>`. */
   value?: string;

--- a/packages/components/src/components/Select/Select.styles.ts
+++ b/packages/components/src/components/Select/Select.styles.ts
@@ -10,9 +10,10 @@ import {
 } from '../helpers';
 import { scrollbarStyling } from '../helpers';
 
-type SelectTypography = {
-  [k in InputSize]: { font: string; letterSpacing: string; fontStyle?: string };
-};
+type SelectTypography = Record<
+  InputSize,
+  { font: string; letterSpacing: string; fontStyle?: string }
+>;
 
 const placeholderTypography: SelectTypography = {
   medium: {

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -64,7 +64,9 @@ type WrappedReactSelectProps<
 export type SelectProps<Option = unknown, IsMulti extends boolean = false> = {
   /**Ledetekst for nedtrekkslisten. */
   label?: string;
-  /**Størrelsen på komponenten. */
+  /**Størrelsen på komponenten.
+   * @default "medium"
+   */
   componentSize?: InputSize;
   /**Ikonet som vises i komponenten. */
   icon?: SvgIcon;

--- a/packages/components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
+++ b/packages/components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
@@ -13,6 +13,7 @@ export default {
     disabled: { control: { type: 'boolean' } },
     readOnly: { control: { type: 'boolean' } },
     indeterminate: { control: { type: 'boolean' } },
+    htmlProps: { control: false },
   },
   parameters: {
     docs: {

--- a/packages/components/src/components/SelectionControl/Checkbox/Checkbox.types.tsx
+++ b/packages/components/src/components/SelectionControl/Checkbox/Checkbox.types.tsx
@@ -1,6 +1,7 @@
 import { type InputHTMLAttributes } from 'react';
 
 import { type BaseComponentProps } from '../../../types';
+import { type SelectionControlCommonProps } from '../common/SelectionControl.types';
 
 export type CheckboxPickedHTMLAttributes = Pick<
   InputHTMLAttributes<HTMLInputElement>,
@@ -16,16 +17,9 @@ export type CheckboxPickedHTMLAttributes = Pick<
 
 export type CheckboxProps = BaseComponentProps<
   HTMLInputElement,
-  {
-    /** Ledetekst for inputelementet. */
-    label?: string;
-    /**Indikererr ugyldig input, endrer styling. */
-    error?: boolean;
-    /** Setter disabled-tilstand for inputelementet. */
-    disabled?: boolean;
-    /**Inputelementet blir readOnly - den kan ikke interageres med. Brukes til å hente input brukeren har fylt ut andre steder. */
-    readOnly?: boolean;
-    /**Brukes ved nøstet struktur der alle Checkbox som hører til en gruppe kan bli valgt ved å trykke på en forelder Checkbox. Hvis enkelte <Checkbox /> blir valgt men ikke alle skal forelder <Checkbox /> få tilstanden indeterminate - verken checked eller ikke. */
+  SelectionControlCommonProps & {
+    /**Brukes ved nøstet struktur der alle `<Checkbox>` som hører til en gruppe kan bli valgt ved å trykke på en forelder `<Checkbox>`.
+     * Hvis enkelte `<Checkbox>` blir valgt men ikke alle, skal forelder `<Checkbox>` få tilstanden `indeterminate` - verken valgt eller ikke. */
     indeterminate?: boolean;
   } & CheckboxPickedHTMLAttributes,
   Omit<

--- a/packages/components/src/components/SelectionControl/Checkbox/CheckboxGroup.tsx
+++ b/packages/components/src/components/SelectionControl/Checkbox/CheckboxGroup.tsx
@@ -6,7 +6,6 @@ import {
 } from './CheckboxGroupContext';
 import {
   type BaseComponentPropsWithChildren,
-  type Direction,
   getBaseHTMLProps,
 } from '../../../types';
 import { RequiredMarker, cn, derivativeIdGenerator } from '../../../utils';
@@ -15,27 +14,14 @@ import { LockIcon } from '../../Icon/icons';
 import { renderInputMessage } from '../../InputMessage';
 import { Typography } from '../../Typography';
 import labelStyles from '../../Typography/Label/Label.module.css';
+import { type SelectionControlGroupCommonProps } from '../common/SelectionControl.types';
 import styles from '../SelectionControl.module.css';
 
 export type CheckboxGroupProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
-  {
-    /**Ledetekst for gruppen. */
-    label?: string;
-    /**Retningen barna gjengis i. */
-    direction?: Direction;
-    /**Custom id for for gruppen, knytter ledetekst til gruppen via `aria-label`. */
-    groupId?: string;
-    /**Meldingen som vises ved valideringsfeil. Sender error-tilstand til barna når det finnes  og setter `aria-describedby` for barna. */
-    errorMessage?: string;
-    /**Hjelpetekst for gruppen. */
-    tip?: string;
-    /**Indikerer at det er påkrevd å velge minst ett alternativ. Innebærer visuell endring. **OBS!** `required` må i tillegg gis til `<Checkbox />` manuelt. */
+  SelectionControlGroupCommonProps & {
+    /**Indikerer at det er påkrevd å velge minst ett alternativ. Legger en markør bak ledeteksten. **OBS!** `required` må i tillegg gis til `<Checkbox>`-barna manuelt. */
     required?: boolean;
-    /**Gir alle barna `disabled` prop. */
-    disabled?: boolean;
-    /**Gir alle barna `readOnly` prop. */
-    readOnly?: boolean;
   }
 >;
 

--- a/packages/components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
+++ b/packages/components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
@@ -12,7 +12,7 @@ export default {
     error: { control: { type: 'boolean' } },
     disabled: { control: { type: 'boolean' } },
     readOnly: { control: { type: 'boolean' } },
-    className: { control: { type: 'text' } },
+    htmlProps: { control: false },
   },
   parameters: {
     docs: {

--- a/packages/components/src/components/SelectionControl/RadioButton/RadioButton.types.tsx
+++ b/packages/components/src/components/SelectionControl/RadioButton/RadioButton.types.tsx
@@ -1,6 +1,7 @@
 import { type InputHTMLAttributes } from 'react';
 
 import { type BaseComponentPropsWithChildren } from '../../../types';
+import { type SelectionControlCommonProps } from '../common/SelectionControl.types';
 
 type PickedInputHTMLAttributes = Pick<
   InputHTMLAttributes<HTMLInputElement>,
@@ -15,13 +16,6 @@ type PickedInputHTMLAttributes = Pick<
 
 export type RadioButtonProps = BaseComponentPropsWithChildren<
   HTMLInputElement,
-  {
-    /**Ledetekst for alternativet. */
-    label?: string;
-    /**Spesifiserer om input er disabled. */
-    disabled?: boolean;
-    /**Indikerer valideringsfeil. Påvirker styling. */
-    error?: boolean;
-  } & PickedInputHTMLAttributes,
+  SelectionControlCommonProps & PickedInputHTMLAttributes,
   Omit<InputHTMLAttributes<HTMLInputElement>, keyof PickedInputHTMLAttributes>
 >;

--- a/packages/components/src/components/SelectionControl/RadioButton/RadioButtonGroup.tsx
+++ b/packages/components/src/components/SelectionControl/RadioButton/RadioButtonGroup.tsx
@@ -14,7 +14,6 @@ import {
 } from './RadioButtonGroupContext';
 import {
   type BaseComponentPropsWithChildren,
-  type Direction,
   getBaseHTMLProps,
 } from '../../../types';
 import { RequiredMarker, cn, combineHandlers } from '../../../utils';
@@ -23,37 +22,24 @@ import { LockIcon } from '../../Icon/icons';
 import { renderInputMessage } from '../../InputMessage';
 import { Typography } from '../../Typography';
 import labelStyles from '../../Typography/Label/Label.module.css';
+import { type SelectionControlGroupCommonProps } from '../common/SelectionControl.types';
 import styles from '../SelectionControl.module.css';
 
 export type RadioButtonGroupProps<T extends string | number> =
   BaseComponentPropsWithChildren<
     HTMLDivElement,
-    {
+    SelectionControlGroupCommonProps & {
       /** Gir alle barna `name` prop.*/
       name?: string;
-      /**Ledetekst for hele gruppen. */
-      label?: string;
       /**Funksjonen for onChange-event for barna. */
       onChange?: (
         event: ChangeEvent<HTMLInputElement>,
         value: T | undefined,
       ) => void;
-      /**Legger en markør (*) bak label som indikerer at input er påkrevd. Gjør alle barna påkrevd ved å gi dem `required` prop. */
+      /** Gjør alle barna påkrevd ved å gi dem `required` prop. Legger en markør (*) bak ledeteksten. */
       required?: boolean;
-      /**Meldingen som vises ved valideringsfeil. Gir alle barna error prop. */
-      errorMessage?: string;
-      /**Hjelpetekst for gruppen. */
-      tip?: string;
-      /**Gir alle barna `disabled` prop. */
-      disabled?: boolean;
-      /**Gir alle barna `readOnly` prop */
-      readOnly?: boolean;
-      /**Retningen radioknappene skal gjengis i. */
-      direction?: Direction;
       /**Default verdi - en `<RadioButton />` blir forhåndsvalgt. **OBS!** brukes kun når brukeren ikke skal fylle ut selv. */
       value?: T | undefined;
-      /**custom id for for gruppen, knytter `label` til gruppen via `aria-label`. */
-      groupId?: string;
     },
     Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>
   >;

--- a/packages/components/src/components/SelectionControl/common/SelectionControl.types.tsx
+++ b/packages/components/src/components/SelectionControl/common/SelectionControl.types.tsx
@@ -1,0 +1,31 @@
+import { type Direction } from '../../../types';
+
+export interface SelectionControlCommonProps {
+  /**Ledetekst for alternativet. */
+  label?: string;
+  /**Spesifiserer om input er `disabled`. */
+  disabled?: boolean;
+  /**Indikerer valideringsfeil. Påvirker styling. */
+  error?: boolean;
+  /**Inputelementet blir `readonly` - den kan ikke interageres med. Brukes bl.a. til å presentere input brukeren har fylt ut andre steder. */
+  readOnly?: boolean;
+}
+
+export interface SelectionControlGroupCommonProps {
+  /**Ledetekst for gruppen. */
+  label?: string;
+  /**Retningen barna gjengis i.
+   * @default "row"
+   */
+  direction?: Direction;
+  /**Custom id for for gruppen, knytter ledetekst til gruppen via `aria-label`. */
+  groupId?: string;
+  /**Hjelpetekst for gruppen. */
+  tip?: string;
+  /**Gir alle barna `disabled` prop. */
+  disabled?: boolean;
+  /**Gir alle barna `readOnly` prop. */
+  readOnly?: boolean;
+  /**Meldingen som vises ved valideringsfeil. Gir error-tilstand til barna og setter `aria-describedby` for barna. */
+  errorMessage?: string;
+}

--- a/packages/components/src/components/SkipToContent/SkipToContent.tsx
+++ b/packages/components/src/components/SkipToContent/SkipToContent.tsx
@@ -9,11 +9,15 @@ import { Link, defaultTypographyType } from '../Typography';
 export type SkipToContentProps = BaseComponentProps<
   HTMLAnchorElement,
   {
-    /** Teksten som vises i lenka. */
+    /** Teksten som vises i lenka.
+     * @default "Til hovedinnhold"
+     */
     text?: string;
     /**Spesifiserer hvor det skal hoppes til via `id`-attributtet til innholdet. */
     href: string;
-    /**Avstand fra top i nærmeste posisjonert container. */
+    /**Avstand fra top i nærmeste posisjonert container.
+     * @default 0
+     */
     top?: Property.Top;
   }
 >;

--- a/packages/components/src/components/Spinner/Spinner.tsx
+++ b/packages/components/src/components/Spinner/Spinner.tsx
@@ -9,11 +9,17 @@ import { type TextColor, cn, getTextColor } from '../../utils';
 export type SpinnerProps = BaseComponentProps<
   SVGElement,
   {
-    /**Farge på spinneren. */
+    /**Farge på spinneren.
+     * @default "iconActionResting"
+     */
     color?: TextColor;
-    /**Størrelse; Setter høyde og bredde på spinneren. */
+    /**Størrelse; Setter høyde og bredde på spinneren.
+     * @default ddsTokens.ddsIconSizeMedium
+     */
     size?: Property.Width;
-    /**Tekst som vises ved hover. */
+    /**Tekst som vises ved hover.
+     * @default "Innlasting pågår"
+     */
     tooltip?: string;
   }
 >;

--- a/packages/components/src/components/SplitButton/SplitButton.tsx
+++ b/packages/components/src/components/SplitButton/SplitButton.tsx
@@ -3,12 +3,7 @@ import { type HTMLAttributes, forwardRef, useState } from 'react';
 import styles from './SplitButton.module.css';
 import { type ExtractStrict } from '../../types';
 import { cn } from '../../utils';
-import {
-  Button,
-  type ButtonProps,
-  type ButtonPurpose,
-  type ButtonSize,
-} from '../Button';
+import { Button, type ButtonProps, type ButtonPurpose } from '../Button';
 import { ChevronDownIcon, ChevronUpIcon } from '../Icon/icons';
 import {
   OverflowMenu,
@@ -29,14 +24,14 @@ export type SplitButtonPrimaryActionProps = Omit<
 >;
 export type SplitButtonSecondaryActionsProps = Array<OverflowMenuButtonProps>;
 
-export type SplitButtonProps = {
-  /**Størrelse på komponenten. */
-  size?: ButtonSize;
-  /**Props for primær handling. Samme props som for `<Button />` unntatt `size` og `purpose`. */
+export type SplitButtonProps = Pick<ButtonProps, 'size'> & {
+  /**Props for primær handling. Samme props som for `<Button>` unntatt `size` og `purpose`. */
   primaryAction: SplitButtonPrimaryActionProps;
   /**Props for sekunære handlinger. */
   secondaryActions: SplitButtonSecondaryActionsProps;
-  /**Formål med knappen */
+  /**Formål med knappen.
+   * @default "primary"
+   */
   purpose?: SplitButtonPurpose;
 } & HTMLAttributes<HTMLDivElement>;
 
@@ -53,7 +48,7 @@ export const SplitButton = forwardRef<HTMLDivElement, SplitButtonProps>(
 
     const [isOpen, setIsOpen] = useState(false);
     const buttonStyleProps: ButtonProps = {
-      purpose: purpose,
+      purpose,
       size,
     };
 

--- a/packages/components/src/components/Stack/Stack.tsx
+++ b/packages/components/src/components/Stack/Stack.tsx
@@ -28,12 +28,12 @@ export interface StackStyleProps {
   direction: 'horizontal' | 'vertical';
   /**
    * CSS `align-items`.
-   * @default 'center'
+   * @default "center"
    */
   align?: StandardProperties['alignItems'];
   /**
    * CSS `justify-content`.
-   * @default 'flex-start'
+   * @default "flex-start"
    */
   justify?: StandardProperties['justifyContent'];
   /**

--- a/packages/components/src/components/Table/normal/Cell.tsx
+++ b/packages/components/src/components/Table/normal/Cell.tsx
@@ -18,10 +18,12 @@ export interface CollapsibleProps {
 export type TableCellProps = {
   /**
    * Type celle. Returnerer enten `<td>` eller `<th>`.
-   * @default 'data' hvis den er brukt i `<Table.Body>` eller `<Table.Foot>`, 'head' hvis den er i `<Table.Head>`.
+   * @default "data" hvis den er brukt i `<Table.Body>` eller `<Table.Foot>`, 'head' hvis den er i `<Table.Head>`.
    */
   type?: TableCellType;
-  /**Layout av innholdet i cellen; legger en flex `<div>` i cellen, unntatt 'none' som ikke legger inn noe. 'tekst and icon' legger `gap` mellom barna og andre barnet i cellen.  */
+  /**Layout av innholdet i cellen; legger en flex `<div>` i cellen, unntatt 'none' som ikke legger inn noe. 'tekst and icon' legger `gap` mellom barna og andre barnet i cellen.
+   * @default "left"
+   */
   layout?: TableCellLayout;
   /** Props ved bruk av `<CollapsibleRow>`. **OBS!** settes automatisk av forelder. */
   collapsibleProps?: CollapsibleProps;

--- a/packages/components/src/components/Table/normal/Table.types.ts
+++ b/packages/components/src/components/Table/normal/Table.types.ts
@@ -3,7 +3,9 @@ import { type HTMLAttributes, type ReactNode } from 'react';
 export type TableDensity = 'normal' | 'compact' | 'extraCompact';
 
 export type TableProps = {
-  /**Spesifiserer hvor romslige cellene i tabellen skal være. */
+  /**Spesifiserer hvor romslige cellene i tabellen skal være.
+   * @default "normal"
+   */
   density?: TableDensity;
   /**Spesifiserer om cellene i `<Head>` skal bli sticky ved scrolling. */
   stickyHeader?: boolean;
@@ -19,10 +21,13 @@ export type RowMode = 'normal' | 'sum';
 export type TableRowProps = {
   /**
    * Spesifiserer om raden skal brukes i `<head>` eller `<body>`-seksjonen.
-   * @default 'body' hvis den er brukt i `<Table.Body>` eller `<Table.Foot>`, 'head' hvis den er i `<Table.Head>`.
+   * @default "body" hvis den er brukt i `<Table.Body>` eller `<Table.Foot>`, 'head' hvis den er i `<Table.Head>`.
    */
   type?: TableRowType;
-  /**Custom modus for rader som har ytterligere semantisk betydning (f.eks. summeringsrad), definerer kun styling. Ved bruk av sum må `<Cell>` med tall i høyrestilles vha layout prop.  */
+  /**Custom modus for rader som har ytterligere semantisk betydning (f.eks. summeringsrad), definerer kun styling.
+   * Ved bruk av sum må `<Cell>` med tall i høyrestilles vha layout prop.
+   * @default "normal"
+   **/
   mode?: RowMode;
   /**Spesifiserer om raden har blitt valgt/markert. */
   selected?: boolean;

--- a/packages/components/src/components/Tabs/Tab.tsx
+++ b/packages/components/src/components/Tabs/Tab.tsx
@@ -29,17 +29,21 @@ import typographyStyles from '../Typography/typographyStyles.module.css';
 export type TabProps = BaseComponentPropsWithChildren<
   HTMLButtonElement,
   {
-    /**Spesifiserer om fanen er aktiv. */
+    /**Spesifiserer om fanen er aktiv.
+     * @default false
+     */
     active?: boolean;
     /** Ikon. */
     icon?: SvgIcon;
-    /** Spesifiserer om `<Tab />` skal ha fokus. **OBS!** settes automatisk av forelder.*/
+    /** Spesifiserer om `<Tab>` skal ha fokus. **OBS!** settes automatisk av forelder.*/
     focus?: boolean;
     /**  Callback som setter fokus. **OBS!** settes automatisk av forelder.*/
     setFocus?: Dispatch<SetStateAction<number>>;
-    /** Indeksen til `<Tab />`. **OBS!** settes automatisk av forelder.*/
+    /** Indeksen til `<Tab>`. **OBS!** settes automatisk av forelder.*/
     index?: number;
-    /** Bredden til `<Tab />`. Her er det støtte for de samme enhetene som du kan bruke i `grid-template-columns`. */
+    /** Bredden til `<Tab>`. Her er det støtte for de samme enhetene som du kan bruke i `grid-template-columns`.
+     * @default "1fr"
+     */
     width?: CSS.Properties['width'];
   } & Pick<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'onKeyDown'>,
   Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'onKeyDown'>

--- a/packages/components/src/components/Tabs/Tabs.mdx
+++ b/packages/components/src/components/Tabs/Tabs.mdx
@@ -42,7 +42,7 @@ En fane. Tilhørende `<TabPanel>` vises ved museklikk.
 
 <ArgTypes of={Tab} />
 
-#### `width`
+#### Bredde
 
 For å endre på bredden til tabs kan du bruke `width`-attributtet. Her støttes alle de samme enhetene som i `grid-template-columns` i CSS.
 

--- a/packages/components/src/components/Tabs/Tabs.tsx
+++ b/packages/components/src/components/Tabs/Tabs.tsx
@@ -24,7 +24,9 @@ export type TabsProps = BaseComponentPropsWithChildren<
     activeTab?: number;
     /** Ekstra logikk ved endring av aktiv fane. */
     onChange?: (index: number) => void;
-    /** Retningen ikon og tekst vises i `<Tab />`-elementer. */
+    /** Retningen ikon og tekst vises i `<Tab>`-elementer.
+     * @default "row"
+     */
     tabContentDirection?: Direction;
     /**Bredde for hele komponenten. */
     width?: Property.Width;

--- a/packages/components/src/components/Tag/Tag.tsx
+++ b/packages/components/src/components/Tag/Tag.tsx
@@ -19,26 +19,12 @@ import {
 } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
-const purposeVariants: {
-  [k in TagPurpose]: {
-    icon: SvgIcon | undefined;
-  };
-} = {
-  info: {
-    icon: InfoIcon,
-  },
-  danger: {
-    icon: ErrorIcon,
-  },
-  warning: {
-    icon: WarningIcon,
-  },
-  success: {
-    icon: CheckCircledIcon,
-  },
-  default: {
-    icon: undefined,
-  },
+const icons: Record<TagPurpose, SvgIcon | undefined> = {
+  info: InfoIcon,
+  danger: ErrorIcon,
+  warning: WarningIcon,
+  success: CheckCircledIcon,
+  default: undefined,
 };
 
 export type TagPurpose = 'success' | 'info' | 'danger' | 'warning' | 'default';
@@ -57,10 +43,12 @@ export type TagProps = BaseComponentPropsWithChildren<
     text?: string;
     /**
      * Formål med status eller kategorisering. Påvirker styling.
-     * */
+     * @default "default"
+     */
     purpose?: TagPurpose;
     /**
      * Det visuelle uttrykket til komponenten.
+     * @default "default"
      */
     appearance?: TagAppearance;
     /**
@@ -84,7 +72,7 @@ export const Tag = forwardRef<HTMLSpanElement, TagProps>((props, ref) => {
     ...rest
   } = props;
 
-  const icon = purposeVariants[purpose].icon;
+  const icon = icons[purpose];
 
   return (
     <TextOverflowEllipsisWrapper

--- a/packages/components/src/components/TextArea/TextArea.tsx
+++ b/packages/components/src/components/TextArea/TextArea.tsx
@@ -23,7 +23,9 @@ import { Label, getTypographyCn } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 export type TextAreaProps = CommonInputProps & {
-  /** Spesifiserer om tegntelleren skal vises ved bruk av `maxLength` attributt. */
+  /** Spesifiserer om tegntelleren skal vises ved bruk av `maxLength` attributt.
+   * @default true
+   */
   withCharacterCounter?: boolean;
 } & TextareaHTMLAttributes<HTMLTextAreaElement>;
 

--- a/packages/components/src/components/ToggleBar/ToggleBar.types.tsx
+++ b/packages/components/src/components/ToggleBar/ToggleBar.types.tsx
@@ -10,7 +10,9 @@ export type ToggleBarProps<T extends string | number> =
   BaseComponentPropsWithChildren<
     HTMLDivElement,
     {
-      /**Størrelse på komponenten. */
+      /**Størrelse på komponenten.
+       * @default "medium"
+       */
       size?: ToggleBarSize;
       /**Ledetekst for hele gruppen. */
       label?: string;

--- a/packages/components/src/components/ToggleBar/ToggleRadio.tsx
+++ b/packages/components/src/components/ToggleBar/ToggleRadio.tsx
@@ -19,7 +19,7 @@ import { Icon } from '../Icon';
 import { type SvgIcon } from '../Icon/utils';
 import { type StaticTypographyType, Typography } from '../Typography';
 
-export const typographyTypes: { [k in ToggleBarSize]: StaticTypographyType } = {
+export const typographyTypes: Record<ToggleBarSize, StaticTypographyType> = {
   large: 'bodySans04',
   medium: 'bodySans02',
   small: 'bodySans01',

--- a/packages/components/src/components/ToggleButton/ToggleButtonGroup.tsx
+++ b/packages/components/src/components/ToggleButton/ToggleButtonGroup.tsx
@@ -15,7 +15,9 @@ export type ToggleButtonGroupProps = BaseComponentPropsWithChildren<
   {
     /** Ledetekst for gruppen. */
     label?: string;
-    /**Retningen barna legger seg i. */
+    /**Retningen barna legger seg i.
+     * @default "row"
+     */
     direction?: Direction;
     /** Custom `id` for ledetekst. Blir generert som default for å knytte ledetekst til gruppen.  */
     labelId?: string;

--- a/packages/components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/components/src/components/Tooltip/Tooltip.tsx
@@ -31,11 +31,15 @@ export type TooltipProps = BaseComponentProps<
   {
     /**Innhold i tooltip. */
     text: string;
-    /**Plassering i forhold til anchor-elementet. */
+    /**Plassering i forhold til anchor-elementet.
+     * @default "bottom"
+     */
     placement?: Placement;
     /**Anchor-elementet. */
     children: AnchorElement;
-    /**Forsinkelse for når tooltip skal dukke opp. Oppgis i millisekunder.  */
+    /**Forsinkelse for når tooltip skal dukke opp. Oppgis i millisekunder.
+     * @default 100
+     */
     delay?: number;
     /**`id` for tooltip. */
     tooltipId?: string;

--- a/packages/components/src/components/date-inputs/DatePicker/DateField/DateSegment.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/DateField/DateSegment.tsx
@@ -15,15 +15,16 @@ import typographyStyles from '../../../Typography/typographyStyles.module.css';
 import styles from '../../common/DateInput.module.css';
 import { type DatePickerProps } from '../DatePicker';
 
-export const typographyTypes: { [k in InputSize]: StaticTypographyType } = {
+export const typographyTypes: Record<InputSize, StaticTypographyType> = {
   medium: 'bodySans02',
   small: 'bodySans01',
   tiny: 'supportingStyleTiny01',
 };
 
-export const placeholderTypographyTypes: {
-  [k in InputSize]: StaticTypographyType;
-} = {
+export const placeholderTypographyTypes: Record<
+  InputSize,
+  StaticTypographyType
+> = {
   medium: 'supportingStylePlaceholderText01',
   small: 'supportingStylePlaceholderText02',
   tiny: 'supportingStylePlaceholderText03',

--- a/packages/components/src/components/helpers/Input/Input.types.tsx
+++ b/packages/components/src/components/helpers/Input/Input.types.tsx
@@ -17,7 +17,9 @@ export interface CommonInputProps {
 export type InputSize = 'medium' | 'small' | 'tiny';
 
 export type InputProps = CommonInputProps & {
-  /**Størrelse på inputfeltet. */
+  /**Størrelse på inputfeltet.
+   * @default "medium"
+   */
   componentSize?: InputSize;
 } & InputHTMLAttributes<HTMLInputElement>;
 
@@ -26,4 +28,4 @@ export type StatefulInputProps = {
 } & Pick<InputProps, 'componentSize'> &
   InputHTMLAttributes<HTMLInputElement>;
 
-export type InputTypographyTypes = { [k in InputSize]: StaticTypographyType };
+export type InputTypographyTypes = Record<InputSize, StaticTypographyType>;


### PR DESCRIPTION
Storybook viser ikke default-verdien for props i arg-tabeller for komponenter. Må dermed legge til `@default` for alle props som har en default i JSDoc.

Rydder litt oppi types i samme slengen.