### PR TITLE
ELSA1-437 Standardisering i `<InternalHeader>`

### DIFF
--- a/.changeset/five-garlics-taste.md
+++ b/.changeset/five-garlics-taste.md
@@ -1,0 +1,38 @@
+---
+'@norges-domstoler/dds-components': major
+---
+
+Endrer navn på props i `<InternalHeader>`: `userProps` til `user`, `navigationElements` til `navItems` og `contextMenuElements` til `contextMenuItems`. Dette standardiserer navngiginv på tvers av komponenter.
+
+I tillegg endrer vi de samme props; de tar inn `children` istedenfor `title` eller `name` for å vise tekst i elementer i menyen og lenker. På denne måten følger props samme standard som andre komponenter.
+
+```jsx
+//Før
+const items = [
+  {
+    title: 'Sekundær handling',
+    onClick: () => null,
+  },
+];
+
+const user = [
+  {
+    name: 'Navn Navnesen',
+    href: '/',
+  },
+];
+
+//Etter
+const items = [
+  {
+    children: 'Sekundær handling',
+    onClick: () => null,
+  },
+];
+const user = [
+  {
+    children: 'Navn Navnesen',
+    href: '/',
+  },
+];
+```

--- a/packages/app-shell/src/AppShell/AppShell.tsx
+++ b/packages/app-shell/src/AppShell/AppShell.tsx
@@ -9,6 +9,7 @@ import {
   type ButtonHTMLAttributes,
   type PropsWithChildren,
   type ReactElement,
+  type ReactNode,
 } from 'react';
 import styled from 'styled-components';
 
@@ -18,7 +19,7 @@ import { Navigation } from './Navigation/Navigation';
 import { type User } from './Navigation/TopBar';
 
 export type UserMenuItem = {
-  children: string;
+  children: ReactNode;
   href?: string;
   icon?: SvgIcon;
   onClick?: () => void;

--- a/packages/components/src/components/Grid/Grid.stories.tsx
+++ b/packages/components/src/components/Grid/Grid.stories.tsx
@@ -86,9 +86,9 @@ export const PageExample: Story = {
         <InternalHeader
           applicationName="Applikasjon"
           applicationDesc="Beskrivelse"
-          navigationElements={[
-            { title: 'Advokater', href: '/' },
-            { title: 'Saker', href: '/' },
+          navItems={[
+            { children: 'Advokater', href: '/' },
+            { children: 'Saker', href: '/' },
           ]}
           smallScreenBreakpoint="xs"
         />

--- a/packages/components/src/components/InternalHeader/InternalHeader.mdx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.mdx
@@ -42,8 +42,8 @@ applikasjoner vil være tilgjengelige ved å trykke på det som i dag er navn p�
 <Source
   code={`
   type NavigationLinkProps = {
+  children: ReactNode;
   href: string;
-  title: string;
   } & AnchorHTMLAttributes<HTMLAnchorElement>;
   `}
 />
@@ -51,8 +51,9 @@ applikasjoner vil være tilgjengelige ved å trykke på det som i dag er navn p�
 <Source
   code={`
   type ContextMenuElementProps = {
-  title: string;
+  children: ReactNode;
   href?: string;
+  /* OBS! ikon settes i tillegg til children for riktig layout. */
   icon?: SvgIcon;
   onClick?: () => void;
   } & (
@@ -66,7 +67,7 @@ applikasjoner vil være tilgjengelige ved å trykke på det som i dag er navn p�
 <Source
   code={`
   type InternaHeaderUserProps = {
-  name: string;
+  children: ReactNode;
   href?: string;
   };
 

--- a/packages/components/src/components/InternalHeader/InternalHeader.spec.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.spec.tsx
@@ -4,6 +4,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { InternalHeader } from '.';
 
+const href = '#';
+const children = 'link';
+const link = {
+  children,
+  href,
+};
+
 describe('<InternalHeader>', () => {
   it('should display application name', () => {
     const appName = 'appName';
@@ -15,10 +22,10 @@ describe('<InternalHeader>', () => {
   it('should run onclick event from context menu', async () => {
     const event = vi.fn();
     const element = {
-      title: 'action',
+      children: 'action',
       onClick: event,
     };
-    render(<InternalHeader contextMenuElements={[element]} />);
+    render(<InternalHeader contextMenuItems={[element]} />);
     const contextMenuButton = screen.getByRole('button');
     await userEvent.click(contextMenuButton!);
     const contextMenuLink = screen.getByRole('menuitem');
@@ -27,37 +34,24 @@ describe('<InternalHeader>', () => {
   });
 
   it('should have a link in navigation', () => {
-    const href = '#';
-    const element = {
-      title: 'link',
-      href: href,
-    };
-    render(<InternalHeader navigationElements={[element]} />);
+    render(<InternalHeader navItems={[link]} />);
     const navigationLink = screen.getByRole('link');
     expect(navigationLink).toHaveAttribute('href', href);
   });
 
   it('should have a link in navigation with target attribute', () => {
-    const href = '#';
     const target = '_blank';
     const element = {
-      title: 'link',
-      href: href,
+      ...link,
       target: target,
     };
-    render(<InternalHeader navigationElements={[element]} />);
+    render(<InternalHeader navItems={[element]} />);
     const navigationLink = screen.getByRole('link');
     expect(navigationLink).toHaveAttribute('target', target);
   });
 
   it('should have a link in context menu', async () => {
-    const href = '#';
-    const title = 'title';
-    const element = {
-      title: title,
-      href: href,
-    };
-    render(<InternalHeader contextMenuElements={[element]} />);
+    render(<InternalHeader contextMenuItems={[link]} />);
 
     const contextMenuButton = screen.getByRole('button');
     await userEvent.click(contextMenuButton);
@@ -67,22 +61,11 @@ describe('<InternalHeader>', () => {
   });
 
   it('should have a nav link in context menu', async () => {
-    const href = '#';
-    const title = 'title';
-    const element = {
-      title: title,
-      href: href,
-    };
-    render(
-      <InternalHeader
-        navigationElements={[element]}
-        smallScreenBreakpoint="xl"
-      />,
-    );
+    render(<InternalHeader navItems={[link]} smallScreenBreakpoint="xl" />);
     const burgerButton = screen.getByRole('button');
     await userEvent.click(burgerButton);
     const navigationLink = screen.getByRole('menuitem', {
-      name: element.title,
+      name: children,
     });
     expect(navigationLink).toHaveAttribute('href', href);
   });
@@ -90,10 +73,10 @@ describe('<InternalHeader>', () => {
   it('should have a static username in context menu', () => {
     const name = 'name';
     const user = {
-      name: name,
+      children: name,
     };
 
-    render(<InternalHeader userProps={user} />);
+    render(<InternalHeader user={user} />);
     const element = screen.getByText(name);
     expect(element).toBeInTheDocument();
   });
@@ -102,11 +85,11 @@ describe('<InternalHeader>', () => {
     const name = 'name';
     const href = '#';
     const user = {
-      name: name,
+      children: name,
       href: href,
     };
 
-    render(<InternalHeader userProps={user} />);
+    render(<InternalHeader user={user} />);
     const element = screen.getByText(name);
     expect(element).toHaveAttribute('href', href);
   });

--- a/packages/components/src/components/InternalHeader/InternalHeader.stories.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.stories.tsx
@@ -13,9 +13,9 @@ export default {
     applicationDesc: { control: 'text' },
     currentPageHref: { control: 'text' },
     applicationHref: { control: 'text' },
-    navigationElements: { control: false },
-    contextMenuElements: { control: false },
-    userProps: { control: false },
+    navItems: { control: false },
+    contextMenuItems: { control: false },
+    user: { control: false },
     htmlProps: { control: false },
   },
   parameters: {
@@ -28,24 +28,24 @@ export default {
 
 const navigationLink = {
   href: '#',
-  title: 'navlenke',
+  children: 'navlenke',
 };
 
 const uniqueNavigationLink = {
   href: '#/',
-  title: 'unik navlenke',
+  children: 'unik navlenke',
 };
 
 const longNavigationLink = {
   href: '#',
-  title: 'Veldig veldig veldig velidg lang lenke her',
+  children: 'Veldig veldig veldig velidg lang lenke her',
 };
 
 const navigationLinks = [navigationLink, navigationLink];
 const navigationLinksWithLong = [...navigationLinks, longNavigationLink];
 
 const user = {
-  name: 'Navn Navnesen',
+  children: 'Navn Navnesen',
 };
 
 const userWithHref = {
@@ -54,12 +54,12 @@ const userWithHref = {
 };
 
 const menuElementWithIcon = {
-  title: 'handling',
+  children: 'handling',
   icon: EditIcon,
   onClick: () => null,
 };
 const menuElement = {
-  title: 'kontekstmenypunkt',
+  children: 'kontekstmenypunkt',
   href: '#',
 };
 
@@ -72,9 +72,9 @@ export const WithNavigationAndContextMenu: Story = {
   args: {
     applicationName: 'Lovisa',
     applicationDesc: 'Produktnavn',
-    navigationElements: navigationLinks,
-    contextMenuElements: menuElements,
-    userProps: user,
+    navItems: navigationLinks,
+    contextMenuItems: menuElements,
+    user,
   },
 };
 
@@ -83,9 +83,10 @@ export const Responsive: Story = {
   args: {
     applicationName: 'Lovisa',
     applicationDesc: 'Produktnavn',
-    navigationElements: navigationLinks,
-    contextMenuElements: menuElements,
-    userProps: user,
+    navItems: navigationLinks,
+    contextMenuItems: menuElements,
+    user,
+    smallScreenBreakpoint: 'xs',
   },
 };
 
@@ -93,9 +94,9 @@ export const WithCurrentPage: Story = {
   args: {
     applicationName: 'Lovisa',
     applicationDesc: 'Produktnavn',
-    navigationElements: [navigationLink, uniqueNavigationLink],
-    contextMenuElements: menuElements,
-    userProps: user,
+    navItems: [navigationLink, uniqueNavigationLink],
+    contextMenuItems: menuElements,
+    user,
     currentPageHref: '#',
   },
 };
@@ -110,44 +111,40 @@ export const Overview: Story = {
       <InternalHeader {...args} />
       <InternalHeader
         {...args}
-        navigationElements={navigationLinks}
-        contextMenuElements={menuElements}
-        userProps={user}
+        navItems={navigationLinks}
+        contextMenuItems={menuElements}
+        user={user}
       />
       <InternalHeader
         {...args}
-        navigationElements={[navigationLink, uniqueNavigationLink]}
-        contextMenuElements={menuElements}
-        userProps={user}
+        navItems={[navigationLink, uniqueNavigationLink]}
+        contextMenuItems={menuElements}
+        user={user}
         currentPageHref="#"
       />
       <InternalHeader
         {...args}
-        navigationElements={navigationLinks}
-        userProps={userWithHref}
+        navItems={navigationLinks}
+        user={userWithHref}
       />
       <InternalHeader
         {...args}
-        navigationElements={navigationLinks}
-        contextMenuElements={menuElements}
-        userProps={userWithHref}
+        navItems={navigationLinks}
+        contextMenuItems={menuElements}
+        user={userWithHref}
       />
+      <InternalHeader {...args} contextMenuItems={menuElements} user={user} />
       <InternalHeader
         {...args}
-        contextMenuElements={menuElements}
-        userProps={user}
-      />
-      <InternalHeader
-        {...args}
-        navigationElements={navigationLinks}
-        contextMenuElements={menuElements}
-        userProps={user}
+        navItems={navigationLinks}
+        contextMenuItems={menuElements}
+        user={user}
         smallScreenBreakpoint="xs"
       />
       <InternalHeader
         {...args}
-        navigationElements={navigationLinks}
-        userProps={user}
+        navItems={navigationLinks}
+        user={user}
         smallScreenBreakpoint="xs"
       />
     </StoryVStack>
@@ -158,7 +155,7 @@ export const ResponsiveWithNavigation: Story = {
   args: {
     applicationName: 'Lovisa',
     applicationDesc: 'Produktnavn',
-    navigationElements: navigationLinks,
+    navItems: navigationLinks,
     smallScreenBreakpoint: 'sm',
   },
 };
@@ -167,7 +164,7 @@ export const ResponsiveWithContextMenu: Story = {
   args: {
     applicationName: 'Lovisa',
     applicationDesc: 'Produktnavn',
-    contextMenuElements: menuElements,
+    contextMenuItems: menuElements,
     smallScreenBreakpoint: 'sm',
   },
 };
@@ -177,9 +174,9 @@ export const ResponsiveWithNavigationAndContextMenu: Story = {
   args: {
     applicationName: 'Lovisa',
     applicationDesc: 'Produktnavn',
-    contextMenuElements: menuElements,
-    navigationElements: navigationLinks,
-    userProps: user,
+    contextMenuItems: menuElements,
+    navItems: navigationLinks,
+    user: user,
     smallScreenBreakpoint: 'sm',
   },
 };
@@ -188,7 +185,7 @@ export const WithNavigationLongLink: Story = {
   args: {
     applicationName: 'Lovisa',
     applicationDesc: 'Produktnavn',
-    navigationElements: navigationLinksWithLong,
+    navItems: navigationLinksWithLong,
   },
 };
 
@@ -196,7 +193,7 @@ export const NonInteractiveUserOnly: Story = {
   args: {
     applicationName: 'Lovisa',
     applicationDesc: 'Produktnavn',
-    userProps: user,
+    user: user,
   },
 };
 

--- a/packages/components/src/components/InternalHeader/InternalHeader.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.tsx
@@ -27,10 +27,10 @@ export const InternalHeader = (props: InternalHeaderProps) => {
     applicationName,
     applicationHref,
     smallScreenBreakpoint,
-    navigationElements,
-    contextMenuElements,
+    navItems,
+    contextMenuItems,
     currentPageHref,
-    userProps,
+    user,
     onCurrentPageChange,
     id,
     className,
@@ -56,10 +56,9 @@ export const InternalHeader = (props: InternalHeaderProps) => {
 
   const onOveflowMenuClose = () => setContextMenuIsClosed(true);
 
-  const hasNavigationElements =
-    !!navigationElements && navigationElements.length > 0;
+  const hasNavigationElements = !!navItems && navItems.length > 0;
   const hasContextMenuElements =
-    !!contextMenuElements && contextMenuElements.length > 0;
+    !!contextMenuItems && contextMenuItems.length > 0;
   const hasSmallScreenBreakpoint = !!smallScreenBreakpoint;
   const hasNavInContextMenu = hasSmallScreenBreakpoint && hasNavigationElements;
 
@@ -73,7 +72,7 @@ export const InternalHeader = (props: InternalHeaderProps) => {
           utilStyles['remove-list-styling'],
         )}
       >
-        {navigationElements.map((item, index) => {
+        {navItems.map((item, index) => {
           const { href, ...rest } = item;
           const isCurrent = href === currentPage;
           return (
@@ -92,8 +91,8 @@ export const InternalHeader = (props: InternalHeaderProps) => {
   ) : null;
 
   const hasContextMenu =
-    hasContextMenuElements || !!userProps || hasNavInContextMenu;
-  const hasContextMenuLargeScreen = hasContextMenuElements || !!userProps;
+    hasContextMenuElements || !!user || hasNavInContextMenu;
+  const hasContextMenuLargeScreen = hasContextMenuElements || !!user;
 
   return (
     <div
@@ -158,16 +157,12 @@ export const InternalHeader = (props: InternalHeaderProps) => {
             anchorRef={buttonRef}
             className={styles['context-menu']}
           >
-            {userProps && (
+            {user && (
               <OverflowMenuList>
-                {userProps.href ? (
-                  <OverflowMenuLink icon={PersonIcon} href={userProps.href}>
-                    {userProps.name}
-                  </OverflowMenuLink>
+                {user.href ? (
+                  <OverflowMenuLink icon={PersonIcon} {...user} />
                 ) : (
-                  <OverflowMenuSpan icon={PersonIcon}>
-                    {userProps.name}
-                  </OverflowMenuSpan>
+                  <OverflowMenuSpan icon={PersonIcon} {...user} />
                 )}
               </OverflowMenuList>
             )}
@@ -180,8 +175,8 @@ export const InternalHeader = (props: InternalHeaderProps) => {
                 )}
               >
                 <OverflowMenuList>
-                  {navigationElements.map(item => (
-                    <OverflowMenuLink {...item}>{item.title}</OverflowMenuLink>
+                  {navItems.map(item => (
+                    <OverflowMenuLink {...item} />
                   ))}
                 </OverflowMenuList>
               </nav>
@@ -196,17 +191,13 @@ export const InternalHeader = (props: InternalHeaderProps) => {
             )}
             {hasContextMenuElements && (
               <OverflowMenuList>
-                {contextMenuElements.map(item => {
-                  const { title } = item;
-
+                {contextMenuItems.map(item => {
                   return item.href ? (
-                    <OverflowMenuLink {...(item as OverflowMenuLinkProps)}>
-                      {title}
-                    </OverflowMenuLink>
+                    <OverflowMenuLink {...(item as OverflowMenuLinkProps)} />
                   ) : (
-                    <OverflowMenuButton {...(item as OverflowMenuButtonProps)}>
-                      {title}
-                    </OverflowMenuButton>
+                    <OverflowMenuButton
+                      {...(item as OverflowMenuButtonProps)}
+                    />
                   );
                 })}
               </OverflowMenuList>

--- a/packages/components/src/components/InternalHeader/InternalHeader.types.tsx
+++ b/packages/components/src/components/InternalHeader/InternalHeader.types.tsx
@@ -1,16 +1,20 @@
-import { type AnchorHTMLAttributes, type ButtonHTMLAttributes } from 'react';
+import {
+  type AnchorHTMLAttributes,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+} from 'react';
 
 import { type BaseComponentProps } from '../../types';
 import { type ScreenSizeLiteral } from '../helpers';
 import { type SvgIcon } from '../Icon/utils';
 
 type NavigationLinkProps = {
+  children: ReactNode;
   href: string;
-  title: string;
 } & AnchorHTMLAttributes<HTMLAnchorElement>;
 
 type ContextMenuElementProps = {
-  title: string;
+  children: ReactNode;
   href?: string;
   icon?: SvgIcon;
   onClick?: () => void;
@@ -20,7 +24,7 @@ type ContextMenuElementProps = {
 );
 
 interface InternaHeaderUserProps {
-  name: string;
+  children: ReactNode;
   href?: string;
 }
 
@@ -36,12 +40,12 @@ export type InternalHeaderProps = BaseComponentProps<
     /**Spesifiserer ved hvilket brekkpunkt og nedover versjonen for små skjermer skal vises; den justerer på spacing og legger navigasjonen i kontekstmenyen. */
     smallScreenBreakpoint?: ScreenSizeLiteral;
     /**Info om brukeren. Dukker opp som punkt på toppen av kontekstmenyen med tekst oppgitt i name. Blir en lenke hvis href er oppgitt. */
-    userProps?: InternaHeaderUserProps;
+    user?: InternaHeaderUserProps;
     /**Lenker som skal vises i navigasjonsmenyen. */
-    navigationElements?: Array<NavigationLinkProps>;
+    navItems?: Array<NavigationLinkProps>;
     /**Lenker eller knapper som skal vises i kontekstmenyen. Støtter ikon i tillegg til tekst. */
-    contextMenuElements?: Array<ContextMenuElementProps>;
-    /**URL til siden i navigasjonen brukeren er på. Gir highlight til navigasjonselementet i navigationElements med samme URL. */
+    contextMenuItems?: Array<ContextMenuElementProps>;
+    /**URL til siden i navigasjonen brukeren er på. Gir highlight til navigasjonselementet i navItems med samme URL. */
     currentPageHref?: string;
     /**Ekstra logikk som kjøres når currentPage endres. */
     onCurrentPageChange?: () => void;

--- a/packages/components/src/components/InternalHeader/NavigationItem.tsx
+++ b/packages/components/src/components/InternalHeader/NavigationItem.tsx
@@ -6,14 +6,13 @@ import { focusable } from '../helpers/styling/focus.module.css';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 export type NavigationItemProps = {
-  title: string;
   isCurrent?: boolean;
 } & AnchorHTMLAttributes<HTMLAnchorElement>;
 
 export const NavigationItem = forwardRef<
   HTMLAnchorElement,
   NavigationItemProps
->(({ title, isCurrent, ...rest }, ref) => {
+>(({ isCurrent, ...rest }, ref) => {
   return (
     <a
       {...rest}
@@ -25,8 +24,6 @@ export const NavigationItem = forwardRef<
         typographyStyles['body-sans-02'],
         focusable,
       )}
-    >
-      {title}
-    </a>
+    />
   );
 });

--- a/packages/components/src/components/OverflowMenu/OverflowMenu.spec.tsx
+++ b/packages/components/src/components/OverflowMenu/OverflowMenu.spec.tsx
@@ -7,10 +7,13 @@ import { Button } from '../Button';
 import {
   OverflowMenu,
   OverflowMenuButton,
+  type OverflowMenuButtonProps,
   OverflowMenuGroup,
   OverflowMenuLink,
+  type OverflowMenuLinkProps,
   OverflowMenuList,
   OverflowMenuSpan,
+  type OverflowMenuSpanProps,
 } from '.';
 
 const text = 'text';
@@ -18,9 +21,9 @@ const href = '#';
 const item = { children: text, onClick: () => null };
 const link = { children: text, href: href };
 interface props {
-  link?: { children: string; href: string };
-  item?: { children: string; onClick?: () => void };
-  span?: { children: string };
+  link?: OverflowMenuLinkProps;
+  item?: OverflowMenuButtonProps;
+  span?: OverflowMenuSpanProps;
 }
 
 function TestComponent({ link, item, span }: props) {

--- a/packages/components/src/components/OverflowMenu/OverflowMenu.types.tsx
+++ b/packages/components/src/components/OverflowMenu/OverflowMenu.types.tsx
@@ -10,7 +10,7 @@ import { type BaseComponentPropsWithChildren } from '../../types';
 import { type SvgIcon } from '../Icon/utils';
 
 export interface OverflowMenuListItemBaseProps {
-  /**Ikon som vises ved teksten. */
+  /**Ikon som vises ved teksten. **OBS!** Settes i tillegg til `children` for riktig layout. */
   icon?: SvgIcon;
 }
 


### PR DESCRIPTION
Endrer navn på props i `<InternalHeader>`: `userProps` til `user`, `navigationElements` til `navItems` og `contextMenuElements` til `contextMenuItems`. Dette standardiserer navngiginv på tvers av komponenter.

I tillegg endrer vi de samme props; de tar inn `children` istedenfor `title` eller `name` for å vise tekst i elementer i menyen og lenker.

På denne måten følger props samme standard som andre komponenter.