### PR TITLE
ELSA1-433 Styling i `<Table density="extraCompact">`

### DIFF
--- a/.changeset/khaki-mails-visit.md
+++ b/.changeset/khaki-mails-visit.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bakgrunnsfarge i rader i `<Table density="extraCompact">`.

--- a/packages/components/src/components/Table/normal/Table.module.css
+++ b/packages/components/src/components/Table/normal/Table.module.css
@@ -54,6 +54,16 @@
     font: var(--dds-font-body-sans-01);
     font-weight: var(--dds-font-weight-bold);
   }
+
+  .row--body {
+    &:nth-of-type(odd) {
+      background-color: var(--dds-color-surface-subtle);
+    }
+
+    &:nth-of-type(even) {
+      background-color: var(--dds-color-surface-default);
+    }
+  }
 }
 
 .row {
@@ -86,10 +96,10 @@
   &.row--selected:nth-of-type(odd) {
     background-color: var(--dds-color-surface-selected-default);
   }
-}
 
-.row--hoverable:hover {
-  background-color: var(--dds-color-surface-hover-default);
+  &.row--hoverable:hover {
+    background-color: var(--dds-color-surface-hover-default);
+  }
 }
 
 .cell--head {


### PR DESCRIPTION
Fikser bakgrunnsfarge i rader i `<Table density="extraCompact">`, slik at oddetall rader har farge.

Før:
![image](https://github.com/user-attachments/assets/b69ae8d1-5cc1-40cc-ad8f-42d80a7873c3)


Etter:
![image](https://github.com/user-attachments/assets/6a23282b-38c0-40ae-8750-a95cae1177fd)
