### PR TITLE
ELSA1-438 Utvider type for `buttonProps` i `<Search>`

### DIFF
--- a/.changeset/two-mayflies-perform.md
+++ b/.changeset/two-mayflies-perform.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Utvider type for `buttonProps`-prop i `<Search>`. Nå kan den også ta inn `icon` og `loadingTooltip`.

--- a/packages/components/src/components/Search/Search.mdx
+++ b/packages/components/src/components/Search/Search.mdx
@@ -40,10 +40,10 @@ Ikke-compound komponenter er også støttet: `<SearchAutocompleteWrapper>`, `<Se
 
 <Source
   code={`type ButtonProps = {
-  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
   label?: string;
-  loading?: boolean;
-  } & ButtonHTMLAttributes<HTMLButtonElement>;`}
+  purpose?: ExtractStrict<ButtonPurpose, 'primary' | 'secondary'>;
+} & Pick<ButtonProps, 'loading' | 'loadingTooltip'> &
+  ComponentProps<'button'>;`}
 />
 
 ### Search.AutocompleteWrapper

--- a/packages/components/src/components/Search/Search.types.tsx
+++ b/packages/components/src/components/Search/Search.types.tsx
@@ -1,9 +1,12 @@
-import { type ButtonHTMLAttributes, type MouseEvent } from 'react';
+import { type ComponentProps } from 'react';
+
+import { type ExtractStrict } from '../../types';
+import { type ButtonProps, type ButtonPurpose } from '../Button';
 
 export type SearchSize = 'small' | 'medium' | 'large';
+
 export type SearchButtonProps = {
-  onClick: (event: MouseEvent<HTMLButtonElement>) => void;
   label?: string;
-  loading?: boolean;
-  purpose?: 'primary' | 'secondary';
-} & ButtonHTMLAttributes<HTMLButtonElement>;
+  purpose?: ExtractStrict<ButtonPurpose, 'primary' | 'secondary'>;
+} & Pick<ButtonProps, 'loading' | 'loadingTooltip'> &
+  ComponentProps<'button'>;


### PR DESCRIPTION
Nå kan `buttonProps`-prop også ta inn `icon` og `loadingTooltip`.