### PR TITLE
ELSA1-440 Fikser høyde i `<Select componentSize="small">`

### DIFF
--- a/.changeset/mean-fans-boil.md
+++ b/.changeset/mean-fans-boil.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Standardiserer ikonplassering på tvers av input-komponenter via absolutt posisjonering, slik at den ikke påvirker høyden på komponenten.

--- a/.changeset/orange-poems-hunt.md
+++ b/.changeset/orange-poems-hunt.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser feil høyde i `<Select componentSize="small">` og gjør indikator-ikonene mindre.

--- a/packages/components/src/components/Search/Search.module.css
+++ b/packages/components/src/components/Search/Search.module.css
@@ -55,12 +55,7 @@
 }
 
 .search-icon {
-  position: absolute;
   left: var(--dds-spacing-x0-75);
-  top: 50%;
-  transform: translate(0, -50%);
-  z-index: 1;
-  color: var(--dds-color-icon-default);
 }
 
 .clear-button {

--- a/packages/components/src/components/Search/Search.tsx
+++ b/packages/components/src/components/Search/Search.tsx
@@ -117,7 +117,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
               <Icon
                 icon={SearchIcon}
                 iconSize={getIconSize(componentSize)}
-                className={cn(styles['search-icon'])}
+                className={cn(inputStyles.icon, styles['search-icon'])}
               />
               <Input
                 {...rest}
@@ -138,7 +138,6 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
                 aria-expanded={context.showSuggestions}
                 role={hasSuggestions ? 'combobox' : undefined}
                 className={cn(
-                  inputStyles.input,
                   styles.input,
                   styles[`input--${componentSize}`],
                   typographyStyles[

--- a/packages/components/src/components/Select/Select.module.css
+++ b/packages/components/src/components/Select/Select.module.css
@@ -20,10 +20,16 @@
   max-width: 100%;
 }
 
-.icon {
-  margin-right: var(--dds-spacing-x0-5);
-  /* Ikon har samme plassering som i TextInput */
-  margin-left: -1px;
+.icon--medium {
+  left: var(--dds-spacing-x0-75);
+}
+
+.icon--small {
+  left: var(--dds-spacing-x0-75);
+}
+
+.icon--tiny {
+  left: var(--dds-spacing-x0-5);
 }
 
 .control {

--- a/packages/components/src/components/Select/Select.styles.ts
+++ b/packages/components/src/components/Select/Select.styles.ts
@@ -84,25 +84,44 @@ export const prefix = 'dds-select';
 
 const control = {
   medium: {
-    paddingBlock: 'var(--dds-spacing-x0-75)',
-    paddingInline: 'var(--dds-spacing-x0-5) var(--dds-spacing-x0-75)',
-    ...optionTypography.medium,
+    base: {
+      paddingBlock: 'var(--dds-spacing-x0-75)',
+      paddingLeft: 'var(--dds-spacing-x0-75)',
+      ...optionTypography.medium,
+    },
+    hasIcon: {
+      paddingLeft:
+        'calc(var(--dds-spacing-x0-75) + var(--dds-icon-size-medium) + var(--dds-spacing-x0-5))',
+    },
   },
   small: {
-    paddingBlock: 'var(--dds-spacing-x0-5)',
-    paddingInline: 'var(--dds-spacing-x0-5) var(--dds-spacing-x0-75)',
-    ...optionTypography.small,
+    base: {
+      paddingBlock: 'var(--dds-spacing-x0-5)',
+      paddingLeft: 'var(--dds-spacing-x0-75)',
+      ...optionTypography.small,
+    },
+    hasIcon: {
+      paddingLeft:
+        'calc(var(--dds-spacing-x0-75) + var(--dds-icon-size-medium) + var(--dds-spacing-x0-5))',
+    },
   },
   tiny: {
-    paddingBlock: 'var(--dds-spacing-x0-25)',
-    paddingInline: 'var(--dds-spacing-x0-5) ',
-    ...optionTypography.tiny,
+    base: {
+      paddingBlock: 'var(--dds-spacing-x0-25)',
+      paddingLeft: 'var(--dds-spacing-x0-5)',
+      ...optionTypography.tiny,
+    },
+    hasIcon: {
+      paddingLeft:
+        'calc(var(--dds-spacing-x0-5) + var(--dds-icon-size-small) + var(--dds-spacing-x0-5))',
+    },
   },
 };
 
 export const getCustomStyles = <TOption>(
   size: InputSize,
   hasError: boolean,
+  hasIcon: boolean,
   isReadOnly?: boolean,
 ): Partial<StylesConfig<TOption, boolean, GroupBase<TOption>>> => ({
   control: (provided, state) => ({
@@ -116,7 +135,9 @@ export const getCustomStyles = <TOption>(
     borderColor: 'var(--dds-color-border-default)',
     backgroundColor: 'var(--dds-color-surface-default)',
     transition: 'box-shadow 0.2s, border-color 0.2s',
-    ...control[size],
+    paddingRight: 'var(--dds-spacing-x0-5)',
+    ...control[size].base,
+    ...(hasIcon && control[size].hasIcon),
     '&:hover': {
       ...(!isReadOnly && hoverInputfield),
     },

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -136,6 +136,7 @@ function SelectInner<Option = unknown, IsMulti extends boolean = false>(
   const singleValueId = !isMulti ? `${uniqueId}-singleValue` : undefined;
   const hasLabel = !!label;
   const hasErrorMessage = !!errorMessage;
+  const hasIcon = !!icon;
   const showRequiredStyling = !!(required || ariaRequired);
 
   const tipId = derivativeIdGenerator(uniqueId, 'tip');
@@ -161,7 +162,12 @@ function SelectInner<Option = unknown, IsMulti extends boolean = false>(
     inputId: uniqueId,
     name: uniqueId,
     classNamePrefix: prefix,
-    styles: getCustomStyles<Option>(componentSize, hasErrorMessage, readOnly),
+    styles: getCustomStyles<Option>(
+      componentSize,
+      hasErrorMessage,
+      hasIcon,
+      readOnly,
+    ),
     filterOption: (option, inputValue) => {
       const { label } = option;
       return searchFilter(label, inputValue) || inputValue === '';

--- a/packages/components/src/components/Select/SelectComponents.tsx
+++ b/packages/components/src/components/Select/SelectComponents.tsx
@@ -14,7 +14,8 @@ import {
 import styles from './Select.module.css';
 import { cn, getFormInputIconSize } from '../../utils';
 import { type InputSize } from '../helpers';
-import { Icon, type SvgIcon } from '../Icon';
+import inputStyles from '../helpers/Input/Input.module.css';
+import { Icon, type IconSize, type SvgIcon } from '../Icon';
 import { CheckIcon, ChevronDownIcon, CloseSmallIcon } from '../Icon/icons';
 
 const {
@@ -27,6 +28,17 @@ const {
   MultiValueRemove,
   Control,
 } = components;
+
+export const getIndicatorIconSize = (componentSize: InputSize): IconSize => {
+  switch (componentSize) {
+    case 'medium':
+      return 'medium';
+    case 'small':
+      return 'small';
+    case 'tiny':
+      return 'small';
+  }
+};
 
 export const DDSOption = <TValue, IsMulti extends boolean>(
   props: OptionProps<TValue, IsMulti>,
@@ -72,7 +84,7 @@ export const DDSClearIndicator = <TValue, IsMulti extends boolean>(
   size: InputSize,
 ) => (
   <ClearIndicator {...props}>
-    <Icon icon={CloseSmallIcon} iconSize={getFormInputIconSize(size)} />
+    <Icon icon={CloseSmallIcon} iconSize={getIndicatorIconSize(size)} />
   </ClearIndicator>
 );
 
@@ -94,7 +106,7 @@ export const DDSDropdownIndicator = <TValue, IsMulti extends boolean>(
       {...rest}
       className={cn(className, styles['dropdown-indicator'])}
     >
-      <Icon icon={ChevronDownIcon} iconSize={getFormInputIconSize(size)} />
+      <Icon icon={ChevronDownIcon} iconSize={getIndicatorIconSize(size)} />
     </DropdownIndicator>
   );
 };
@@ -139,7 +151,7 @@ export const DDSControl = <TValue, IsMulti extends boolean>(
           <Icon
             icon={icon}
             iconSize={getFormInputIconSize(componentSize)}
-            className={styles.icon}
+            className={cn(inputStyles.icon, styles[`icon--${componentSize}`])}
           />
         )}
         {props.children}

--- a/packages/components/src/components/TextInput/TextInput.module.css
+++ b/packages/components/src/components/TextInput/TextInput.module.css
@@ -49,24 +49,16 @@
   width: 100%;
 }
 
-.icon {
-  position: absolute;
-  z-index: 1;
-}
-
 .icon--medium {
   left: var(--dds-spacing-x0-75);
-  top: calc(50% - (var(--dds-icon-size-medium) / 2));
 }
 
 .icon--small {
   left: var(--dds-spacing-x0-75);
-  top: calc(50% - (var(--dds-icon-size-medium) / 2));
 }
 
 .icon--tiny {
   left: var(--dds-spacing-x0-5);
-  top: calc(50% - (var(--dds-icon-size-small) / 2));
 }
 
 .label {

--- a/packages/components/src/components/TextInput/TextInput.tsx
+++ b/packages/components/src/components/TextInput/TextInput.tsx
@@ -153,7 +153,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
             <Icon
               icon={icon}
               iconSize={getFormInputIconSize(componentSize)}
-              className={cn(styles.icon, styles[`icon--${componentSize}`])}
+              className={cn(inputStyles.icon, styles[`icon--${componentSize}`])}
             />
           }
           <StatefulInput

--- a/packages/components/src/components/helpers/Input/Input.module.css
+++ b/packages/components/src/components/helpers/Input/Input.module.css
@@ -116,3 +116,11 @@
 :where(.char-counter) {
   margin-left: auto;
 }
+
+:where(.icon) {
+  position: absolute;
+  top: 50%;
+  transform: translate(0, -50%);
+  z-index: 1;
+  color: var(--dds-color-icon-default);
+}


### PR DESCRIPTION
Høyden var feil pga store ikoner og bruk av kun padding/margin for å posisjonere custom ikon.

- Gjør indikator-ikonene mindre per Figma-skisser
- Standardiserer ikonplassering på tvers av input-komponenter via absolutt posisjonering, slik at den ikke påvirker høyden på komponenten.