### PR TITLE
ELSA1-442 Fikser `<Popover>` `className` bug

### DIFF
--- a/.changeset/proud-buses-swim.md
+++ b/.changeset/proud-buses-swim.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug som gjorde at `<Popover>` ikke fikk klassenavn satt via `className` prop.

--- a/packages/components/src/components/Popover/Popover.tsx
+++ b/packages/components/src/components/Popover/Popover.tsx
@@ -116,21 +116,26 @@ export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
 
     return isOpen || hasTransitionedIn ? (
       <Paper
-        {...getBaseHTMLProps(id, className, htmlProps, rest)}
+        {...getBaseHTMLProps(
+          id,
+          cn(
+            className,
+            styles.container,
+            utilStyles['visibility-transition'],
+            hasTransitionedIn && isOpen
+              ? utilStyles['visibility-transition--open']
+              : utilStyles['visibility-transition--closed'],
+            focusStyles.focusable,
+          ),
+          htmlProps,
+          rest,
+        )}
         ref={multiRef}
         tabIndex={-1}
         style={{ ...htmlProps.style, ...floatingStyles.floating, ...sizeProps }}
         role="dialog"
         elevation={3}
         border="subtle"
-        className={cn(
-          styles.container,
-          utilStyles['visibility-transition'],
-          hasTransitionedIn && isOpen
-            ? utilStyles['visibility-transition--open']
-            : utilStyles['visibility-transition--closed'],
-          focusStyles.focusable,
-        )}
       >
         {title && (
           <div className={styles.title}>


### PR DESCRIPTION
Fikser bug som gjorde at `<Popover>` ikke fikk klassenavn satt via `className` prop. `className` ble duplisert og satt kun CSS klasser fra Elsa, slår de sammen.