### PR TITLE
ELSA1-409 Ny komponent: `<DetailList>`

### DIFF
--- a/.changeset/silly-doors-retire.md
+++ b/.changeset/silly-doors-retire.md
@@ -2,4 +2,4 @@
 '@norges-domstoler/dds-components': minor
 ---
 
-Ny komponent: `<DetailList>` med tilhørende subkomponenter. Den returnerer `<dl>`, `<dt>` og `<dl>`. Komponenten brukes til å vise informasjon på en ryddig måte, der den første cellen i raden er et uttrykk eller ledetekst (term). Resterende celler i raden innheholder detaljer om dette utrykket, eller erelevante lenker og knapper.
+Ny komponent: `<DetailList>` med tilhørende subkomponenter. Den returnerer `<dl>`, `<dt>` og `<dd>`. Komponenten brukes til å vise informasjon på en ryddig måte, der den første cellen i raden er et uttrykk eller ledetekst (term). Resterende celler i raden innheholder detaljer om dette utrykket, eller relevante lenker og knapper.

--- a/.changeset/silly-doors-retire.md
+++ b/.changeset/silly-doors-retire.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Ny komponent: `<DetailList>` med tilhørende subkomponenter. Den returnerer `<dl>`, `<dt>` og `<dl>`. Komponenten brukes til å vise informasjon på en ryddig måte, der den første cellen i raden er et uttrykk eller ledetekst (term). Resterende celler i raden innheholder detaljer om dette utrykket, eller erelevante lenker og knapper.

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -54,6 +54,7 @@ Tilgjengelige komponenter:
 - Chip
 - DatePicker
 - DescriptionList
+- DetailList
 - Divider
 - Drawer
 - EmptyContent
@@ -76,6 +77,7 @@ Tilgjengelige komponenter:
 - RadioButton
 - Search
 - Select
+- Skeleton
 - SkipToContent
 - Spinner
 - Stack

--- a/packages/components/src/components/DetailList/DetailList.mdx
+++ b/packages/components/src/components/DetailList/DetailList.mdx
@@ -1,0 +1,56 @@
+import { Meta, ArgTypes, Canvas, Controls } from '@storybook/blocks';
+import { DetailListDesc, DetailListRow } from '.';
+import {
+  Source,
+  ComponentLinkRow,
+} from '@norges-domstoler/storybook-components';
+import * as DetailListStories from './DetailList.stories';
+
+<Meta of={DetailListStories} />
+
+# DetailList
+
+<ComponentLinkRow
+  docsHref="https://design.domstol.no/987b33f71/p/90ac92-detaillist"
+  figmaHref="https://www.figma.com/design/ewqSDmkgqDQ5PyOsRp4V5b/DDS-Komponenter?node-id=18211-10410"
+  githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/DetailList"
+  storybookHref="https://domstolene.github.io/designsystem/?path=/story/dds-components-detaillist--default"
+  withBottomSpacing
+/>
+
+Detaljert liste er en beskrivelsesliste formatert som en tabell. Den bygges med følgende subkomponenter:
+
+- **`<DetailList>`**: tilsvarer `<dl>`, hele listen.
+- **`<DetailListRow>`**: en rad. Oppfører seg som en tabellrad.
+- **`<DetailListTerm>`**: tilsvarer `<dt>`, uttrykk eller ledetekst. Oppfører seg som en tabellcelle.
+- **`<DetailListDesc>`**: tilsvarer `<dd>`, verdi, beskrivelse, knapp eller lenke relatert til `<DetailListTerm>`. Oppfører seg som en tabellcelle.
+
+## Props
+
+### DetailList
+
+Tilsvarer `<dl>`.
+
+<Canvas of={DetailListStories.Default} sourceState="shown" />
+<Controls of={DetailListStories.Default} />
+
+### DetailListTerm
+
+Tilsvarer `<dt>`. Oppfører seg som en tabellcelle. Støtter native props.
+
+### DetailListDesc
+
+Tilsvarer `<dd>`. Oppfører seg som en tabellcelle. Støtter native props.
+
+### DetailListRow
+
+Subkomponent som grupperer `<DetailListTerm>` og `<DetailListDesc>` i en rad. Oppfører seg som en tabellrad. Støtter native props.
+
+## Retningslinjer
+
+### Layout
+
+Bruk gjerne egen CSS for layout etter behov:
+
+- `table-layout` på `<DetailList>`
+- `width`, `text-align` på individuelle celler (`<DetailListTerm>` og `<DetailListDesc>`)

--- a/packages/components/src/components/DetailList/DetailList.module.css
+++ b/packages/components/src/components/DetailList/DetailList.module.css
@@ -1,0 +1,55 @@
+.list {
+  display: table;
+  width: 100%;
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+
+.list--with-dividers {
+  .row {
+    border-bottom: 1px solid var(--dds-color-border-default);
+  }
+}
+
+.list--striped {
+  .row {
+    &:nth-of-type(even) {
+      background-color: var(--dds-color-surface-default);
+    }
+
+    &:nth-of-type(odd) {
+      background-color: var(--dds-color-surface-subtle);
+    }
+  }
+}
+
+.list--normal {
+  .cell {
+    padding-block: var(--dds-spacing-x1-5);
+    padding-inline: var(--dds-spacing-x0-75);
+  }
+}
+
+.list--compact {
+  .cell {
+    padding: var(--dds-spacing-x0-75);
+  }
+}
+
+.list--extra-compact {
+  .cell {
+    padding: var(--dds-spacing-x0-5);
+  }
+}
+
+.row {
+  display: table-row;
+}
+
+.cell {
+  display: table-cell;
+}
+
+.term {
+  font-weight: var(--dds-font-weight-bold);
+}

--- a/packages/components/src/components/DetailList/DetailList.stories.tsx
+++ b/packages/components/src/components/DetailList/DetailList.stories.tsx
@@ -1,0 +1,81 @@
+import { type Meta, type StoryObj } from '@storybook/react';
+
+import { InlineButton } from '../InlineButton';
+
+import { DetailList, DetailListDesc, DetailListRow, DetailListTerm } from '.';
+
+export default {
+  title: 'dds-components/DetailList',
+  component: DetailList,
+  parameters: {
+    docs: {
+      story: { inline: true },
+    },
+  },
+  argTypes: {
+    htmlProps: { control: false },
+    withDividers: { control: 'boolean' },
+    striped: { control: 'boolean' },
+  },
+} satisfies Meta<typeof DetailList>;
+
+type Story = StoryObj<typeof DetailList>;
+
+export const Default: Story = {
+  render: args => (
+    <DetailList {...args}>
+      <DetailListRow>
+        <DetailListTerm>Term</DetailListTerm>
+        <DetailListDesc>Beskrivelse</DetailListDesc>
+        <DetailListDesc style={{ textAlign: 'right' }}>
+          <InlineButton
+            onClick={() => {
+              null;
+            }}
+          >
+            Knapp
+          </InlineButton>
+        </DetailListDesc>
+      </DetailListRow>
+      <DetailListRow>
+        <DetailListTerm>Term</DetailListTerm>
+        <DetailListDesc>Beskrivelse</DetailListDesc>
+        <DetailListDesc style={{ textAlign: 'right' }}>
+          <InlineButton
+            onClick={() => {
+              null;
+            }}
+          >
+            Knapp
+          </InlineButton>
+        </DetailListDesc>
+      </DetailListRow>
+      <DetailListRow>
+        <DetailListTerm>Term</DetailListTerm>
+        <DetailListDesc>Beskrivelse</DetailListDesc>
+        <DetailListDesc style={{ textAlign: 'right' }}>
+          <InlineButton
+            onClick={() => {
+              null;
+            }}
+          >
+            Knapp
+          </InlineButton>
+        </DetailListDesc>
+      </DetailListRow>
+      <DetailListRow>
+        <DetailListTerm>Term</DetailListTerm>
+        <DetailListDesc>Beskrivelse</DetailListDesc>
+        <DetailListDesc style={{ textAlign: 'right' }}>
+          <InlineButton
+            onClick={() => {
+              null;
+            }}
+          >
+            Knapp
+          </InlineButton>
+        </DetailListDesc>
+      </DetailListRow>
+    </DetailList>
+  ),
+};

--- a/packages/components/src/components/DetailList/DetailList.tsx
+++ b/packages/components/src/components/DetailList/DetailList.tsx
@@ -1,0 +1,64 @@
+import { forwardRef } from 'react';
+
+import styles from './DetailList.module.css';
+import {
+  type BaseComponentPropsWithChildren,
+  getBaseHTMLProps,
+} from '../../types';
+import { type Density, getDensityCn } from '../../types/Density';
+import { cn } from '../../utils';
+
+export type DetailListProps = BaseComponentPropsWithChildren<
+  HTMLDListElement,
+  {
+    /**
+     * Spesifiserer hvor romslige celler skal være.
+     * @default "normal"
+     */
+    density?: Density;
+    /**
+     * Om rader skal ha skillelinje.
+     * @default true
+     */
+    withDividers?: boolean;
+    /**
+     * Om rader skal ha sebrastriper.
+     * @default true
+     */
+    striped?: boolean;
+  }
+>;
+
+export const DetailList = forwardRef<HTMLDListElement, DetailListProps>(
+  (props, ref) => {
+    const {
+      id,
+      className,
+      htmlProps,
+      withDividers = true,
+      striped = true,
+      density = 'normal',
+      ...rest
+    } = props;
+
+    return (
+      <dl
+        ref={ref}
+        {...getBaseHTMLProps(
+          id,
+          cn(
+            className,
+            styles.list,
+            styles[`list--${getDensityCn(density)}`],
+            withDividers && styles['list--with-dividers'],
+            striped && styles['list--striped'],
+          ),
+          htmlProps,
+          rest,
+        )}
+      />
+    );
+  },
+);
+
+DetailList.displayName = 'DetailList';

--- a/packages/components/src/components/DetailList/DetailListDesc.tsx
+++ b/packages/components/src/components/DetailList/DetailListDesc.tsx
@@ -1,0 +1,14 @@
+import { type ComponentPropsWithRef, forwardRef } from 'react';
+
+import styles from './DetailList.module.css';
+import { cn } from '../../utils';
+
+export type DetailListDescProps = ComponentPropsWithRef<'dd'>;
+
+export const DetailListDesc = forwardRef<HTMLElement, DetailListDescProps>(
+  ({ className, ...rest }, ref) => {
+    return <dd ref={ref} className={cn(className, styles.cell)} {...rest} />;
+  },
+);
+
+DetailListDesc.displayName = 'DetailListDesc';

--- a/packages/components/src/components/DetailList/DetailListRow.tsx
+++ b/packages/components/src/components/DetailList/DetailListRow.tsx
@@ -1,0 +1,14 @@
+import { type ComponentPropsWithRef, forwardRef } from 'react';
+
+import styles from './DetailList.module.css';
+import { cn } from '../../utils';
+
+export type DetailListRowProps = ComponentPropsWithRef<'div'>;
+
+export const DetailListRow = forwardRef<HTMLDivElement, DetailListRowProps>(
+  ({ className, ...rest }, ref) => {
+    return <div ref={ref} className={cn(className, styles.row)} {...rest} />;
+  },
+);
+
+DetailListRow.displayName = 'DetailListRow';

--- a/packages/components/src/components/DetailList/DetailListTerm.tsx
+++ b/packages/components/src/components/DetailList/DetailListTerm.tsx
@@ -1,0 +1,20 @@
+import { type ComponentPropsWithRef, forwardRef } from 'react';
+
+import styles from './DetailList.module.css';
+import { cn } from '../../utils';
+
+export type DetailListTermProps = ComponentPropsWithRef<'dt'>;
+
+export const DetailListTerm = forwardRef<HTMLElement, DetailListTermProps>(
+  ({ className, ...rest }, ref) => {
+    return (
+      <dt
+        ref={ref}
+        className={cn(className, styles.cell, styles.term)}
+        {...rest}
+      />
+    );
+  },
+);
+
+DetailListTerm.displayName = 'DetailListTerm';

--- a/packages/components/src/components/DetailList/index.ts
+++ b/packages/components/src/components/DetailList/index.ts
@@ -1,0 +1,4 @@
+export * from './DetailList';
+export * from './DetailListDesc';
+export * from './DetailListRow';
+export * from './DetailListTerm';

--- a/packages/components/src/components/Table/normal/Table.types.ts
+++ b/packages/components/src/components/Table/normal/Table.types.ts
@@ -1,6 +1,8 @@
 import { type HTMLAttributes, type ReactNode } from 'react';
 
-export type TableDensity = 'normal' | 'compact' | 'extraCompact';
+import { type Density } from '../../../types';
+
+export type TableDensity = Density;
 
 export type TableProps = {
   /**Spesifiserer hvor romslige cellene i tabellen skal være.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -15,6 +15,7 @@ export * from './components/Card';
 export * from './components/Chip';
 export * from './components/date-inputs';
 export * from './components/DescriptionList';
+export * from './components/DetailList';
 export * from './components/Divider';
 export * from './components/Drawer';
 export * from './components/EmptyContent';

--- a/packages/components/src/types/Density.tsx
+++ b/packages/components/src/types/Density.tsx
@@ -1,0 +1,11 @@
+export type Density = 'normal' | 'compact' | 'extraCompact';
+
+export function getDensityCn(value: Density) {
+  switch (value) {
+    case 'normal':
+    case 'compact':
+      return value;
+    case 'extraCompact':
+      return 'extra-compact';
+  }
+}

--- a/packages/components/src/types/index.ts
+++ b/packages/components/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './Density';
 export * from './Direction';
 export * from './BaseComponentProps';
 export * from './polymorphic';


### PR DESCRIPTION
`<DetailList>` er en beskrivelsesliste formatert som en tabell. Den har tilhørende subkomponenter, od til sammen returnerer de beskrivelsesliste (`<dl>`, `<dt>` og `<dl>`) og en `<div>` for å formatere en rad. Komponenten brukes til å vise informasjon på en ryddig måte:
- bygges med div-rader i en beskrivelsesliste
- den første cellen i raden er et uttrykk eller ledetekst (term)
- resterende celler i raden innheholder detaljer om dette utrykket, eller erelevante lenker og knapper.

![image](https://github.com/user-attachments/assets/a966a5fe-5171-47ae-89fa-2dacbc7b478d)
