### PR TITLE
ELSA1-399 Fikser underline bug i Safari

### DIFF
--- a/.changeset/weak-pianos-yawn.md
+++ b/.changeset/weak-pianos-yawn.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<BackLink>` ikke fikk `text-decoration-color: transparent;` på hover i Safari.

--- a/packages/components/src/components/BackLink/BackLink.module.css
+++ b/packages/components/src/components/BackLink/BackLink.module.css
@@ -1,5 +1,6 @@
-.link {
-  align-items: center;
-  display: flex;
-  gap: var(--dds-spacing-x0-25);
+.icon {
+  display: inline;
+  margin: 0.1em 0.25em -0.1em 0.1em;
+  transform: translateY(0.05em);
+  vertical-align: baseline;
 }

--- a/packages/components/src/components/BackLink/BackLink.tsx
+++ b/packages/components/src/components/BackLink/BackLink.tsx
@@ -19,8 +19,12 @@ export interface BackLinkProps {
 export const BackLink = forwardRef<HTMLElement, BackLinkProps>((props, ref) => {
   return (
     <nav ref={ref} aria-label="gå tilbake">
-      <Link href={props.href} className={styles.link}>
-        <Icon icon={icons.ArrowLeftIcon} iconSize="small" />
+      <Link href={props.href}>
+        <Icon
+          icon={icons.ArrowLeftIcon}
+          iconSize="small"
+          className={styles.icon}
+        />
         {props.label}
       </Link>
     </nav>


### PR DESCRIPTION
`text-decoration-color: transparent;` funker ikke i `<BackLink>` eller `<InlineButton>` ved `:hover` i Safari.

Endrer litt styling i `<BackLink>` for å få det til å funke, samt standardisere styling i lenker.

`<InlineButton>` er vanskelig å fikse uten "hacking" eller ofring av animasjon på tvers av nettlesere. I tilleg kom støtte for regelen i Safari ganske nylig. Siden feilen er så liten venter vi og ser om det det blir fikset.