### PR TITLE
ELSA1-448 Gjør `onClick` valgrfri i `ProgressTrackerItem`

### DIFF
--- a/.changeset/slow-eggs-wonder.md
+++ b/.changeset/slow-eggs-wonder.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `onClick` i `ProgressTrackerItem` ikke var valgfri.

--- a/packages/components/src/components/ProgressTracker/ProgressTrackerItem.tsx
+++ b/packages/components/src/components/ProgressTracker/ProgressTrackerItem.tsx
@@ -74,7 +74,7 @@ export type ProgressTrackerItemProps =
       HTMLButtonElement,
       BaseItemProps & {
         /** Click-handler som gjør det mulig for bruker å klikke på steget for å navigere. Valgfri. */
-        onClick: (index: number) => void;
+        onClick?: (index: number) => void;
       }
     >
   | BaseComponentPropsWithChildren<


### PR DESCRIPTION
Fikser bug der `onClick` i `ProgressTrackerItem` ikke var valgfri.