### PR TITLE
fix(splitbutton): Sett unik key på SecondaryActions i SplitButton

### DIFF
--- a/.changeset/eleven-emus-study.md
+++ b/.changeset/eleven-emus-study.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Sett unik key på SecondaryActions i SplitButton

--- a/packages/components/src/components/SplitButton/SplitButton.tsx
+++ b/packages/components/src/components/SplitButton/SplitButton.tsx
@@ -73,8 +73,8 @@ export const SplitButton = forwardRef<HTMLDivElement, SplitButtonProps>(
           />
           <OverflowMenu placement="bottom-end">
             <OverflowMenuList>
-              {secondaryActions.map(item => (
-                <OverflowMenuButton {...item}>
+              {secondaryActions.map((item, index) => (
+                <OverflowMenuButton key={index} {...item}>
                   {item.children}
                 </OverflowMenuButton>
               ))}


### PR DESCRIPTION
Manglende key ga feil i konsollet i nettleseren.