### PR TITLE
ELSA1-449 Fikser Caption layout bug

### DIFF
--- a/.changeset/brave-turkeys-raise.md
+++ b/.changeset/brave-turkeys-raise.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<Caption withMargins="true">` la seg inni tabellen istedenfor over.

--- a/packages/components/src/components/Typography/Typography/Typography.tsx
+++ b/packages/components/src/components/Typography/Typography/Typography.tsx
@@ -11,7 +11,12 @@ import {
   type OtherTypographyType,
   type TypographyComponentProps,
 } from './Typography.types';
-import { getElementType, getTypographyCn, isLegend } from './Typography.utils';
+import {
+  getElementType,
+  getTypographyCn,
+  isCaption,
+  isLegend,
+} from './Typography.utils';
 import { type BaseComponentProps, getBaseHTMLProps } from '../../../types';
 import { cn } from '../../../utils';
 import { getTextColor } from '../../../utils/color';
@@ -117,6 +122,9 @@ export const Typography = forwardRef<HTMLElement, TypographyProps>(
             withMargins && typographyStyles[`${typographyCn}--margins`],
             isLegend(as) && typographyStyles.legend,
             isLegend(as) && withMargins && typographyStyles['legend--margins'],
+            isCaption(as) &&
+              withMargins &&
+              typographyStyles['caption--withMargins'],
             bold && typographyStyles.bold,
             underline && typographyStyles.underline,
             italic && typographyStyles.italic,

--- a/packages/components/src/components/Typography/Typography/Typography.utils.ts
+++ b/packages/components/src/components/Typography/Typography/Typography.utils.ts
@@ -62,6 +62,10 @@ export const isLegend = (as: ElementType): boolean => {
   return as === 'legend';
 };
 
+export const isCaption = (as: ElementType): boolean => {
+  return as === 'caption';
+};
+
 export const inlineElements: Array<ElementType> = [
   'a',
   'abbr',

--- a/packages/components/src/components/Typography/typographyStyles.module.css
+++ b/packages/components/src/components/Typography/typographyStyles.module.css
@@ -408,6 +408,10 @@
   margin-bottom: var(--dds-spacing-x1-5);
 }
 
+:where(.caption--withMargins) {
+  display: table-caption;
+}
+
 :where(.bold) {
   font-weight: 600;
 }


### PR DESCRIPTION
Fikser bug der `<Caption withMargins="true">` la seg inni tabellen istedenfor over.

Før: 
![image](https://github.com/user-attachments/assets/64141171-2d79-4ddf-947a-7a8e9eb0eaea)

Etter:
![image](https://github.com/user-attachments/assets/47364231-9a86-4280-bf7b-e3725e256cfe)
