### PR TITLE
ELSA1-452 Fikser border farge i ButtonGroup

### DIFF
--- a/.changeset/rude-parrots-complain.md
+++ b/.changeset/rude-parrots-complain.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der border i trykt inn knapp i `<ButtonGroup>` hadde feil farge.

--- a/packages/components/src/components/ButtonGroup/ButtonGroup.module.css
+++ b/packages/components/src/components/ButtonGroup/ButtonGroup.module.css
@@ -15,56 +15,31 @@
 .group--column > *:first-child {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
+  margin-block-end: -1px;
 }
 
 .group--column > *:last-child {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
-  &:not(:active) {
-    border-top-color: transparent;
-  }
 }
 
 .group--column > *:not(:first-child):not(:last-child) {
   border-radius: 0;
-  &:not(:active) {
-    border-top-color: transparent;
-  }
-
-  &:active + * {
-    border-top-color: initial;
-  }
+  margin-block-end: -1px;
 }
 
-.group--column > *:first-child:not(:last-child) {
-  &:active + * {
-    border-top-color: initial;
-  }
+.group--row > *:first-child {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  margin-inline-end: -1px;
+}
+
+.group--row > *:last-child {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
 }
 
 .group--row > *:not(:first-child):not(:last-child) {
   border-radius: 0;
-  &:not(:active) {
-    border-left-color: transparent;
-  }
-  &:active + * {
-    border-left-color: initial;
-  }
-}
-.group--row > *:first-child {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
-}
-
-.group--row > *:first-child:not(:last-child) {
-  &:active + * {
-    border-left-color: initial;
-  }
-}
-.group--row > *:last-child {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  &:not(:active) {
-    border-left-color: transparent;
-  }
+  margin-inline-end: -1px;
 }


### PR DESCRIPTION
I `<ButtonGroup>` vil barn ha dobbel border, det er ønsket med enkel border. Slik det er løst idag: `<ButtonGroup>` setter fargen på den ene i doble border til `transparent`; når knappen er trykt inn og border skal vises igjen settes fargen til `initial`. Denne fargen er default fra nettleseren og er feil, noe som ikke synes veldig godt når border er mørkegrå. Dette vil synes veldig godt med andre farger hvis det blir endringer.

Dette løses med negativ margin.

Før (border med feil farge markert):
![Navnløs](https://github.com/user-attachments/assets/60e7ebb2-6e65-418b-a20e-723d69ab2229)

Etter:
![bilde](https://github.com/user-attachments/assets/c62b1dd6-3ec4-4d8c-a79c-da9e37dcb72a)
