### PR TITLE
ELSA1-454 Fikser visuell bug i SplitButton story

### DIFF
--- a/packages/components/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/components/src/components/SplitButton/SplitButton.stories.tsx
@@ -59,7 +59,7 @@ export const Overview: Story = {
         />
       </StoryVStack>
       <StoryVStack>
-        <SplitButtonVariants args={args} loading />
+        <SplitButtonVariants args={args} children="Tekst" loading />
       </StoryVStack>
     </StoryHStack>
   ),


### PR DESCRIPTION
Fikser bug der `loading`-variant gjorde knappen større. Størrelsen følger original innhold før `loading` slår inn. La til `children` for å ha størrelse å følge.
Så slik ut: 
![Navnløs](https://github.com/user-attachments/assets/bd832bec-8cf0-49cd-b15d-ee349f15f159)
