### PR TITLE
ELSA1-453 Fikser hopping av kalender i `<DatePicker>`

### DIFF
--- a/.changeset/clever-actors-clap.md
+++ b/.changeset/clever-actors-clap.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Setter fast høyde på kalender-popover i `<DatePicker>`. På denne måten har den forutsigbar størrelse, og innholdet hopper ikke når antall uker i måneden forandrer seg.

--- a/packages/components/src/components/date-inputs/common/DateInput.module.css
+++ b/packages/components/src/components/date-inputs/common/DateInput.module.css
@@ -119,6 +119,7 @@
   border: 1px solid var(--dds-color-border-default);
   padding: var(--dds-spacing-x0-5);
   box-shadow: var(--dds-shadow-2);
+  height: 347px;
 }
 
 .calendar {


### PR DESCRIPTION
I Lovisa kan kalender-popover legge seg over input-feltet og ikke under. Når brukerer blar i måneder og kommer til en med forskjellig antall uker, vil popover "hoppe". Da må brukeren flytte på musa for å fortsette å bla. 

https://github.com/user-attachments/assets/eac67bb4-da82-45b9-935a-dcf9c5d138a8

Setter fast høyde på kalender-popover i `<DatePicker>`. På denne måten har den forutsigbar størrelse, og ingenting hopper ikke når antall uker i måneden forandrer seg.