### PR TITLE
ELSA1-460 Fikser bakgrunn for kode i Icons docs

### DIFF
--- a/packages/components/src/components/Icon/IconStory.module.css
+++ b/packages/components/src/components/Icon/IconStory.module.css
@@ -82,6 +82,8 @@
   margin: var(--dds-spacing-x1) 0;
   border-radius: var(--dds-border-radius-surface);
   code.icon-code {
+    background-color: var(--dds-color-surface-inverse-default) !important;
+    border-color: transparent !important;
     color: var(--dds-color-text-on-inverse);
   }
 }


### PR DESCRIPTION
Bakgrunn har feil farge i docs for Icons pga styling for inline `<code>`. Fikser til å bli samme farge som i kodeblokka.

![Navnløs](https://github.com/user-attachments/assets/6d52b553-0865-46d9-8db0-0344bb2d1d8c)
