### PR TITLE
ELSA1-462 Flytter `types` lengre opp i exports

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -17,9 +17,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./index.css": "./dist/index.css"
   },


### PR DESCRIPTION
Får warning at `types` condition i `packages/components/package.json` ikke blir brukt da den kommer etter `import` og `require`:

![image](https://github.com/user-attachments/assets/bb867947-16d4-4e03-a940-0e4216c39855)


Flytter types til toppen.