### PR TITLE
ELSA1-465 Setter linjehøyde til token i `<ListItem>`

### DIFF
--- a/.changeset/sixty-scissors-jump.md
+++ b/.changeset/sixty-scissors-jump.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Setter linjehøyde for `<ListItem>` til `--dds-font-lineheight-list` (istedenfor hardkodet verdi).

--- a/packages/components/src/components/List/List.module.css
+++ b/packages/components/src/components/List/List.module.css
@@ -56,5 +56,5 @@
 }
 
 .li {
-  line-height: 2.5em;
+  line-height: var(--dds-font-lineheight-list);
 }


### PR DESCRIPTION
`<ListItem>` hadde hardkodet verdi for linjehøyde. Setter den til `--dds-font-lineheight-list`.