### PR TITLE
ELSA1-461 Fikser fokusring i `<Footer>` stories

### DIFF
--- a/packages/components/src/components/Footer/Footer.stories.tsx
+++ b/packages/components/src/components/Footer/Footer.stories.tsx
@@ -29,6 +29,56 @@ export default {
 
 type Story = StoryObj<typeof Footer>;
 
+const socials = (
+  <FooterSocialsGroup>
+    <FooterListHeader>Følg oss</FooterListHeader>
+    <FooterSocialsList>
+      <li>
+        <Link
+          href="/"
+          htmlProps={{
+            style: { display: 'block' },
+          }}
+        >
+          <Icon
+            icon={FacebookIcon}
+            htmlProps={{ style: { display: 'block' } }}
+          />
+        </Link>
+        <VisuallyHidden as="span">Facebook</VisuallyHidden>
+      </li>
+      <li>
+        <Link
+          href="/"
+          htmlProps={{
+            style: { display: 'block' },
+          }}
+        >
+          <Icon
+            icon={InstagramIcon}
+            htmlProps={{ style: { display: 'block' } }}
+          />
+          <VisuallyHidden as="span">Instagram</VisuallyHidden>
+        </Link>
+      </li>
+      <li>
+        <Link
+          href="/"
+          htmlProps={{
+            style: { display: 'block' },
+          }}
+        >
+          <Icon
+            icon={LinkedInIcon}
+            htmlProps={{ style: { display: 'block' } }}
+          />
+          <VisuallyHidden as="span">LinkedIn</VisuallyHidden>
+        </Link>
+      </li>
+    </FooterSocialsList>
+  </FooterSocialsGroup>
+);
+
 export const Default: Story = {
   render: args => (
     <Footer {...args}>
@@ -50,26 +100,7 @@ export const Default: Story = {
         >
           <FooterLeft>
             <FooterLogo hideBreakpoint="xs" />
-            <FooterSocialsGroup>
-              <FooterListHeader>Følg oss</FooterListHeader>
-              <FooterSocialsList>
-                <li>
-                  <Link href="/" htmlProps={{ title: 'Facebook' }}>
-                    <Icon icon={FacebookIcon} />
-                  </Link>
-                </li>
-                <li>
-                  <Link href="/" htmlProps={{ title: 'Instagram' }}>
-                    <Icon icon={InstagramIcon} />
-                  </Link>
-                </li>
-                <li>
-                  <Link href="/" htmlProps={{ title: 'LinkedIn' }}>
-                    <Icon icon={LinkedInIcon} />
-                  </Link>
-                </li>
-              </FooterSocialsList>
-            </FooterSocialsGroup>
+            {socials}
           </FooterLeft>
         </GridChild>
         <GridChild
@@ -311,26 +342,7 @@ export const Left: Story = {
     <Footer {...args} className="story-padding">
       <FooterLeft>
         <FooterLogo />
-        <FooterSocialsGroup>
-          <FooterListHeader>Følg oss</FooterListHeader>
-          <FooterSocialsList>
-            <li>
-              <Link href="/" htmlProps={{ title: 'Facebook' }}>
-                <Icon icon={FacebookIcon} />
-              </Link>
-            </li>
-            <li>
-              <Link href="/" htmlProps={{ title: 'Instagram' }}>
-                <Icon icon={InstagramIcon} />
-              </Link>
-            </li>
-            <li>
-              <Link href="/" htmlProps={{ title: 'LinkedIn' }}>
-                <Icon icon={LinkedInIcon} />
-              </Link>
-            </li>
-          </FooterSocialsList>
-        </FooterSocialsGroup>
+        {socials}
       </FooterLeft>
     </Footer>
   ),
@@ -376,29 +388,7 @@ export const Socials: Story = {
   ],
   render: args => (
     <Footer {...args} className="story-padding">
-      <FooterSocialsGroup>
-        <FooterListHeader>Følg oss</FooterListHeader>
-        <FooterSocialsList>
-          <li>
-            <Link href="/">
-              <Icon icon={FacebookIcon} />
-              <VisuallyHidden as="span">Facebook</VisuallyHidden>
-            </Link>
-          </li>
-          <li>
-            <Link href="/">
-              <Icon icon={InstagramIcon} />
-              <VisuallyHidden as="span">Instagram</VisuallyHidden>
-            </Link>
-          </li>
-          <li>
-            <Link href="/">
-              <Icon icon={LinkedInIcon} />
-              <VisuallyHidden as="span">LinkedIn</VisuallyHidden>
-            </Link>
-          </li>
-        </FooterSocialsList>
-      </FooterSocialsGroup>
+      {socials}
     </Footer>
   ),
 };


### PR DESCRIPTION
Fokusringen gikk ikke rundt ikonlenkene i socials-seksjonen, men over ikonet. Dette er typisk oppførsel. Kan fikses med å sette CSS `display: block;` på begge, men vi ønsker ikke slik visning i disse komponentene ellers. Setter dermed `display: block;` kun i eksemplene/stories, slik at folk ser at ekstra styling trengs for riktig visning.

Før:
![Navnløs](https://github.com/user-attachments/assets/57827a16-c315-4ea0-8c42-8ccbfeccaca0)
Etter:
![image](https://github.com/user-attachments/assets/65489311-cbb3-467e-8998-0448a1fb413f)
