### PR TITLE
ELSA1-475 `border-radius` bug i `<Skeleton>`

### DIFF
--- a/.changeset/hip-pigs-design.md
+++ b/.changeset/hip-pigs-design.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `border-radius` prop var påkrevd i `<Skeleton>`.

--- a/packages/components/src/components/Skeleton/Skeleton.tsx
+++ b/packages/components/src/components/Skeleton/Skeleton.tsx
@@ -14,7 +14,7 @@ export type SkeletonProps = {
   /**CSS border radius.
    * @default "var(--dds-border-radius-surface)"
    */
-  borderRadius: Property.BorderRadius;
+  borderRadius?: Property.BorderRadius;
 } & ComponentPropsWithRef<'div'>;
 
 export const Skeleton = forwardRef<HTMLDivElement, SkeletonProps>(


### PR DESCRIPTION
Fikser bug der `border-radius` prop var påkrevd i `<Skeleton>`.