### PR TITLE
ELSA1-473 `border-radius` bug i `<Card>`

### DIFF
--- a/.changeset/gentle-zoos-chew.md
+++ b/.changeset/gentle-zoos-chew.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser `border-radius` i `<Card cardType="expandable">` ved hover.

--- a/packages/components/src/components/Card/CardAccordion/CardAccordion.module.css
+++ b/packages/components/src/components/Card/CardAccordion/CardAccordion.module.css
@@ -1,3 +1,7 @@
+.container {
+  border-radius: inherit;
+}
+
 .header-button {
   @media (prefers-reduced-motion: no-preference) {
     transition:

--- a/packages/components/src/components/Card/CardAccordion/CardAccordion.tsx
+++ b/packages/components/src/components/Card/CardAccordion/CardAccordion.tsx
@@ -1,9 +1,11 @@
 import { forwardRef } from 'react';
 
+import styles from './CardAccordion.module.css';
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../../types';
+import { cn } from '../../../utils';
 import {
   AccordionContextProvider,
   useAccordion,
@@ -42,7 +44,12 @@ export const CardAccordion = forwardRef<HTMLDivElement, CardAccordionProps>(
 
     return (
       <div
-        {...getBaseHTMLProps(accordionId, className, htmlProps, rest)}
+        {...getBaseHTMLProps(
+          accordionId,
+          cn(className, styles['container']),
+          htmlProps,
+          rest,
+        )}
         ref={ref}
       >
         <AccordionContextProvider

--- a/packages/components/src/components/helpers/AccordionBase/AccordionBase.module.css
+++ b/packages/components/src/components/helpers/AccordionBase/AccordionBase.module.css
@@ -4,6 +4,7 @@
   cursor: pointer;
   display: block;
   width: 100%;
+  border-radius: inherit;
 }
 
 .header-container {


### PR DESCRIPTION
Fikser `border-radius` i `<Card cardType="expandable">` ved hover.

Før:
<img width="512" alt="Navnløs" src="https://github.com/user-attachments/assets/6a370699-da71-461c-a7c5-49c5a36ba47d">
Etter:
![bilde](https://github.com/user-attachments/assets/cb0fa18e-1575-4629-8b90-1add71607e35)

![bilde](https://github.com/user-attachments/assets/11740081-0765-41ba-ab6a-8c8bc864111e)
Uten hover:
![bilde](https://github.com/user-attachments/assets/ab002bb9-77fb-413c-8526-13c138596931)
