### PR TITLE
legge til støtte for react 19

### DIFF
--- a/.changeset/brave-humans-run.md
+++ b/.changeset/brave-humans-run.md
@@ -1,0 +1,8 @@
+---
+'@norges-domstoler/storybook-components': patch
+'@norges-domstoler/development-utils': patch
+'@norges-domstoler/dds-components': patch
+'@norges-domstoler/app-shell': patch
+---
+
+Tillat react v19 i peer dependency range.

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -38,9 +38,7 @@
     "@testing-library/jest-dom": "^6.6.2",
     "@testing-library/react": "^16.0.1",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
     "styled-components": "^6.1.13",
     "tsup": "^8.3.0",
     "typescript": "^5.6.3",
@@ -50,8 +48,7 @@
   "peerDependencies": {
     "@norges-domstoler/dds-components": ">=16",
     "@norges-domstoler/development-utils": ">=1",
-    "react": "^16 || ^17 || ^18",
-    "react-dom": "^16 || ^17 || ^18",
+    "react": "^16 || ^17 || ^18 || ^19",
     "styled-components": "^5 || ^6"
   },
   "publishConfig": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -69,8 +69,8 @@
   "peerDependencies": {
     "@internationalized/date": "^3",
     "@norges-domstoler/dds-design-tokens": ">=5.0.0",
-    "react": "^16 || ^17 || ^18",
-    "react-dom": "^16 || ^17 || ^18"
+    "react": "^16 || ^17 || ^18 || ^19",
+    "react-dom": "^16 || ^17 || ^18 || ^19"
   },
   "dependencies": {
     "@floating-ui/react-dom": "^2.1.2",

--- a/packages/development-utils/package.json
+++ b/packages/development-utils/package.json
@@ -36,9 +36,7 @@
     "@storybook/blocks": "8.3.6",
     "@testing-library/react": "^16.0.1",
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
     "styled-components": "^6.1.13",
     "tsup": "^8.3.0",
     "typescript": "^5.6.3",
@@ -46,8 +44,7 @@
     "vitest": "^2.1.3"
   },
   "peerDependencies": {
-    "react": "^16 || ^17 || ^18",
-    "react-dom": "^16 || ^17 || ^18",
+    "react": "^16 || ^17 || ^18 || ^19",
     "styled-components": "^5 || ^6"
   },
   "publishConfig": {

--- a/packages/storybook-components/package.json
+++ b/packages/storybook-components/package.json
@@ -16,15 +16,12 @@
   },
   "devDependencies": {
     "@types/react": "^18.3.11",
-    "@types/react-dom": "^18.3.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
     "tsup": "^8.3.0",
     "typescript": "^5.6.3"
   },
   "peerDependencies": {
-    "react": "^16 || ^17 || ^18",
-    "react-dom": "^16 || ^17 || ^18"
+    "react": "^16 || ^17 || ^18 || ^19"
   },
   "dependencies": {
     "@norges-domstoler/dds-design-tokens": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,15 +130,9 @@ importers:
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.11
-      '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.1
       react:
         specifier: 18.3.1
         version: 18.3.1
-      react-dom:
-        specifier: 18.3.1
-        version: 18.3.1(react@18.3.1)
       styled-components:
         specifier: ^6.1.13
         version: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -275,15 +269,9 @@ importers:
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.11
-      '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.1
       react:
         specifier: 18.3.1
         version: 18.3.1
-      react-dom:
-        specifier: 18.3.1
-        version: 18.3.1(react@18.3.1)
       styled-components:
         specifier: ^6.1.13
         version: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -327,15 +315,9 @@ importers:
       '@types/react':
         specifier: ^18.3.11
         version: 18.3.11
-      '@types/react-dom':
-        specifier: ^18.3.1
-        version: 18.3.1
       react:
         specifier: 18.3.1
         version: 18.3.1
-      react-dom:
-        specifier: 18.3.1
-        version: 18.3.1(react@18.3.1)
       tsup:
         specifier: ^8.3.0
         version: 8.3.0(postcss@8.4.47)(typescript@5.6.3)(yaml@2.5.0)


### PR DESCRIPTION
fjerner samtidig ubrukte deps/peerDeps på react-dom i diverse pakker.

Ser ikke ut til at noen av de brekkende endringene som ligger i RC treffer oss, så da er det greit å bare tillate bruk av React 19 sammen med designsystemet. Kjørte også React 19 RC sin codemod, og den endret heller ingenting.

Vi ønsker å oppgradere til Next.js 15, og de bruker React 19 RC, og fikk under oppgradering da litt kjeft av npm for å overskride denne dependency rangen 😅 