### PR TITLE
Legger til støtte for åpning av modal fra drawer med backdrop

### DIFF
--- a/.changeset/thirty-rules-attack.md
+++ b/.changeset/thirty-rules-attack.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Legger til støtte for åpning av modal fra drawer med backdrop.

--- a/packages/components/src/components/Drawer/Drawer.tsx
+++ b/packages/components/src/components/Drawer/Drawer.tsx
@@ -1,10 +1,12 @@
 import { type Property } from 'csstype';
 import {
+  type MouseEvent,
   type ReactNode,
   type RefObject,
   forwardRef,
   useEffect,
   useId,
+  useRef,
 } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -124,10 +126,17 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
   if (triggerRef) elements.push(triggerRef.current);
 
   useOnClickOutside(elements, () => {
-    if (isOpen) {
+    if (isOpen && !withBackdrop) {
       onClose?.();
     }
   });
+
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const onBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target === backdropRef.current && isOpen && withBackdrop) {
+      onClose?.();
+    }
+  };
 
   const hasTransitionedIn = useMountTransition(isOpen, 500);
   const isMounted = hasTransitionedIn && isOpen;
@@ -190,7 +199,9 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
   );
 
   const component = withBackdrop ? (
-    <Backdrop isMounted={isMounted}>{drawer}</Backdrop>
+    <Backdrop isMounted={isMounted} ref={backdropRef} onClick={onBackdropClick}>
+      {drawer}
+    </Backdrop>
   ) : (
     drawer
   );

--- a/packages/components/src/components/Modal/Modal.tsx
+++ b/packages/components/src/components/Modal/Modal.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   useEffect,
   useId,
+  useRef,
 } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -12,7 +13,6 @@ import {
   useCombinedRef,
   useFocusTrap,
   useMountTransition,
-  useOnClickOutside,
   useOnKeyDown,
 } from '../../hooks';
 import {
@@ -88,7 +88,12 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>((props, ref) => {
     return () => handleElementWithBackdropUnmount(document.body);
   }, [isOpen]);
 
-  useOnClickOutside(modalRef.current, () => handleClose());
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const onBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === backdropRef.current && isOpen) {
+      handleClose();
+    }
+  };
 
   useOnKeyDown(['Escape', 'Esc'], () => handleClose());
 
@@ -96,7 +101,11 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>((props, ref) => {
 
   return isOpen || hasTransitionedIn
     ? createPortal(
-        <Backdrop isMounted={isOpen && hasTransitionedIn}>
+        <Backdrop
+          isMounted={isOpen && hasTransitionedIn}
+          ref={backdropRef}
+          onClick={onBackdropClick}
+        >
           <Paper
             {...getBaseHTMLProps(
               id,

--- a/packages/components/src/components/helpers/Backdrop/Backdrop.tsx
+++ b/packages/components/src/components/helpers/Backdrop/Backdrop.tsx
@@ -1,20 +1,23 @@
-import { type ComponentProps } from 'react';
+import { type ComponentProps, forwardRef } from 'react';
 
 import styles from './Backdrop.module.css';
 import { cn } from '../../../utils';
 
 type BackdropProps = {
   isMounted?: boolean;
-} & Pick<ComponentProps<'div'>, 'children'>;
+} & Pick<ComponentProps<'div'>, 'children' | 'onClick'>;
 
-export const Backdrop = ({ isMounted, ...props }: BackdropProps) => {
-  const isMountedCn = isMounted ? 'visible' : 'hidden';
-  return (
-    <div
-      className={cn(styles.backdrop, styles[`backdrop--${isMountedCn}`])}
-      {...props}
-    />
-  );
-};
+export const Backdrop = forwardRef<HTMLDivElement, BackdropProps>(
+  ({ isMounted, ...props }, ref) => {
+    const isMountedCn = isMounted ? 'visible' : 'hidden';
+    return (
+      <div
+        ref={ref}
+        className={cn(styles.backdrop, styles[`backdrop--${isMountedCn}`])}
+        {...props}
+      />
+    );
+  },
+);
 
 Backdrop.displayName = 'Backdrop';


### PR DESCRIPTION
Unngår at Drawer *med backdrop* lukkes om man åpner en modal fra Drawer'en og interagerer med noe som helst på siden