### PR TITLE
ELSA1-492 Fikser `border-radius` i `<Drawer>`

### DIFF
--- a/.changeset/polite-yaks-return.md
+++ b/.changeset/polite-yaks-return.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Setter `border-radius` i `<Drawer>` til 0, da flata tar hele viewport-høyden.

--- a/packages/components/src/components/Drawer/Drawer.module.css
+++ b/packages/components/src/components/Drawer/Drawer.module.css
@@ -16,6 +16,7 @@
   justify-content: flex-end;
   min-width: 300px;
   z-index: 100;
+  border-radius: 0;
   padding: var(--dds-drawer-container-padding);
 
   @media (prefers-reduced-motion: no-preference) {

--- a/packages/components/src/components/helpers/Paper/Paper.module.css
+++ b/packages/components/src/components/helpers/Paper/Paper.module.css
@@ -1,31 +1,31 @@
-.container {
+:where(.container) {
   box-sizing: border-box;
   background-color: var(--dds-color-surface-default);
   border-radius: var(--dds-border-radius-surface);
   margin: 0;
 }
 
-.shadow--1 {
+:where(.shadow--1) {
   box-shadow: var(--dds-shadow-1);
 }
-.shadow--2 {
+:where(.shadow--2) {
   box-shadow: var(--dds-shadow-2);
 }
-.shadow--3 {
+:where(.shadow--3) {
   box-shadow: var(--dds-shadow-3);
 }
-.shadow--4 {
+:where(.shadow--4) {
   box-shadow: var(--dds-shadow-4);
 }
 
-.border--default {
+:where(.border--default) {
   border: 1px solid var(--dds-color-border-default);
 }
 
-.border--subtle {
+:where(.border--subtle) {
   border: 1px solid var(--dds-color-border-subtle);
 }
 
-.border--on-inverse {
+:where(.border--on-inverse) {
   border: 1px solid var(--dds-color-border-inverse);
 }


### PR DESCRIPTION
Setter `border-radius` i `<Drawer>` til 0, da flata tar hele viewport-høyden.

Bruker `:where()` i styling i `<Paper>` for enkel override.