### PR TITLE
ELSA1-497 Fikser default bredde i `<Select>`

### DIFF
--- a/.changeset/fresh-windows-join.md
+++ b/.changeset/fresh-windows-join.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Setter default bredde på minste varianten av `<Select>` til å følge `<TextInput>`.

--- a/packages/components/src/components/Select/Select.module.css
+++ b/packages/components/src/components/Select/Select.module.css
@@ -1,7 +1,7 @@
 .container {
   margin: 0;
   position: relative;
-  width: var(--dds-input-default-width);
+  width: var(--dds-select-width);
 }
 
 .container--disabled {

--- a/packages/components/src/components/Select/Select.tsx
+++ b/packages/components/src/components/Select/Select.tsx
@@ -1,4 +1,4 @@
-import { type Property } from 'csstype';
+import { type Properties, type Property } from 'csstype';
 import { type HTMLAttributes, type ReactNode, forwardRef, useId } from 'react';
 import {
   type GroupBase,
@@ -142,6 +142,15 @@ function SelectInner<Option = unknown, IsMulti extends boolean = false>(
   const tipId = derivativeIdGenerator(uniqueId, 'tip');
   const errorMessageId = derivativeIdGenerator(uniqueId, 'errorMessage');
 
+  const styleVariables: Properties = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ['--dds-select-width' as any]: width
+      ? width
+      : componentSize === 'tiny'
+        ? '210px'
+        : 'var(--dds-input-default-width)',
+  };
+
   const reactSelectProps: ReactSelectProps<
     Option,
     IsMulti,
@@ -219,7 +228,7 @@ function SelectInner<Option = unknown, IsMulti extends boolean = false>(
         isDisabled && styles['container--disabled'],
         readOnly && styles['container--readonly'],
       )}
-      style={{ ...style, width }}
+      style={{ ...style, ...styleVariables }}
     >
       {hasLabel && (
         <Label

--- a/packages/components/src/components/TextInput/TextInput.module.css
+++ b/packages/components/src/components/TextInput/TextInput.module.css
@@ -10,10 +10,6 @@
   color: var(--dds-color-text-subtle);
 }
 
-.container--tiny {
-  width: 210px;
-}
-
 .affix-container {
   position: relative;
   display: flex;


### PR DESCRIPTION
Setter default bredde på minste varianten av `<Select>` til å følge `<TextInput>`.

Fjenrner ubrukt styling i samme slengen.