### PR TITLE
ELSA1-496 Fikser høyde i `<NativeSelect>`

### DIFF
--- a/.changeset/fast-needles-exist.md
+++ b/.changeset/fast-needles-exist.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser høyde i `<NativeSelect>`.

--- a/packages/components/src/components/Select/NativeSelect/NativeSelect.module.css
+++ b/packages/components/src/components/Select/NativeSelect/NativeSelect.module.css
@@ -54,21 +54,14 @@
 }
 
 .select--medium {
-  height: calc(
-    1.5em + var(--dds-spacing-x0-75) + var(--dds-spacing-x0-75) + 2px
-  );
   padding-right: var(--dds-spacing-x2);
 }
 
 .select--small {
-  height: calc(1.5em + var(--dds-spacing-x0-5) + var(--dds-spacing-x0-5) + 2px);
   padding-right: var(--dds-spacing-x2);
 }
 
 .select--tiny {
-  height: calc(
-    1.5em + var(--dds-spacing-x0-25) + var(--dds-spacing-x0-25) + 2px
-  );
   padding-right: var(--dds-spacing-x1-5);
 }
 


### PR DESCRIPTION
Det ble originalt satt custom styling på høyde pga noen små forskjeller mellom komponenter, men den ser ut til å fungere dårligere. Fjerner den stylinga.