### PR TITLE
ELSA1-489 Flytter chevron i `<AccordionHeader>`

### DIFF
--- a/.changeset/thirty-adults-watch.md
+++ b/.changeset/thirty-adults-watch.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Flytter chevron i `<AccordionHeader>` til venstre for teksten. Dette sørger for at brukeren forstår at hele headeren er klikkbar, samt vet hva tilstanden på komponenten er ved zoom og o.l.

--- a/packages/components/src/components/Accordion/Accordion.module.css
+++ b/packages/components/src/components/Accordion/Accordion.module.css
@@ -24,6 +24,10 @@
     var(--dds-spacing-x1);
 }
 
+.header-container__chevron {
+  margin-right: var(--dds-spacing-x0-5);
+}
+
 .body {
   height: var(--dds-card-accordion-body-height);
 }

--- a/packages/components/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/components/src/components/Accordion/AccordionHeader.tsx
@@ -67,6 +67,18 @@ export const AccordionHeader = forwardRef<
       {...restHeaderProps}
       type="button"
     >
+      <span
+        className={cn(
+          baseStyles.header__chevron,
+          styles['header-container__chevron'],
+        )}
+      >
+        <AnimatedChevronUpDown
+          width={ddsTokens.ddsIconSizeMedium}
+          height={ddsTokens.ddsSpacingX05}
+          isUp={isExpanded}
+        />
+      </span>
       <div
         className={cn(
           baseStyles.header__content,
@@ -76,13 +88,6 @@ export const AccordionHeader = forwardRef<
       >
         {children}
       </div>
-      <span className={baseStyles.header__chevron}>
-        <AnimatedChevronUpDown
-          width={ddsTokens.ddsIconSizeMedium}
-          height={ddsTokens.ddsSpacingX05}
-          isUp={isExpanded}
-        />
-      </span>
     </button>
   );
 });

--- a/packages/components/src/components/Card/CardAccordion/CardAccordion.module.css
+++ b/packages/components/src/components/Card/CardAccordion/CardAccordion.module.css
@@ -16,10 +16,15 @@
 
 .header-container {
   padding: var(--dds-card-accordion-header-container-padding);
+  justify-content: space-between;
 
   @media (prefers-reduced-motion: no-preference) {
     transition: box-shadow 0.2s;
   }
+}
+
+.header-container__chevron {
+  margin-left: var(--dds-spacing-x0-5);
 }
 
 .body {

--- a/packages/components/src/components/Card/CardAccordion/CardAccordionHeader.tsx
+++ b/packages/components/src/components/Card/CardAccordion/CardAccordionHeader.tsx
@@ -86,7 +86,12 @@ export const CardAccordionHeader = forwardRef<
         )}
       >
         <div className={baseStyles.header__content}>{children}</div>
-        <span className={baseStyles.header__chevron}>
+        <span
+          className={cn(
+            baseStyles.header__chevron,
+            styles['header-container__chevron'],
+          )}
+        >
           <AnimatedChevronUpDown
             width={ddsTokens.ddsIconSizeMedium}
             height={ddsTokens.ddsSpacingX05}

--- a/packages/components/src/components/helpers/AccordionBase/AccordionBase.module.css
+++ b/packages/components/src/components/helpers/AccordionBase/AccordionBase.module.css
@@ -9,7 +9,6 @@
 
 .header-container {
   display: flex;
-  justify-content: space-between;
   align-items: center;
 }
 
@@ -23,7 +22,6 @@
   justify-content: center;
   height: var(--dds-icon-size-medium);
   width: var(--dds-icon-size-medium);
-  margin-left: var(--dds-spacing-x0-5);
 }
 
 .body {


### PR DESCRIPTION
Flytter chevron i `<AccordionHeader>` til venstre for teksten. Dette sørger for at brukeren forstår at hele headeren er klikkbar, samt vet hva tilstanden på komponenten er ved zoom og o.l.

Før:
![bilde](https://github.com/user-attachments/assets/d084710e-b34d-4a7f-883c-509063df2bce)

Etter: 
![bilde](https://github.com/user-attachments/assets/70b181b8-4aaa-48a9-bc80-84ab61084278)
