### PR TITLE
ELSA1-470 Støtte for `showWeekNumbers` prop i `<DatePicker>`

### DIFF
--- a/.changeset/angry-kiwis-hear.md
+++ b/.changeset/angry-kiwis-hear.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for `showWeekNumbers` prop i `<DatePicker>` som styrer visning av ukenumre. `true` som default.

--- a/packages/components/src/components/date-inputs/DatePicker/Calendar/CalendarGrid.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/Calendar/CalendarGrid.tsx
@@ -8,12 +8,15 @@ import {
   type CalendarState,
   type RangeCalendarState,
 } from '@react-stately/calendar';
+import { useContext } from 'react';
 
 import { CalendarCell } from './CalendarCell';
 import { cn } from '../../../../utils';
 import typographyStyles from '../../../Typography/typographyStyles.module.css';
+import { VisuallyHidden } from '../../../VisuallyHidden';
 import styles from '../../common/DateInput.module.css';
 import { getWeekNumber } from '../../utils/getWeekNumber';
+import { CalendarPopoverContext } from '../CalendarPopover';
 
 interface CalendarGridProps extends AriaCalendarGridProps {
   state: CalendarState | RangeCalendarState;
@@ -29,6 +32,8 @@ export function CalendarGrid({ state, ...props }: CalendarGridProps) {
   // Get the number of weeks in the month so we can render the proper number of rows.
   const weeksInMonth = getWeeksInMonth(state.visibleRange.start, locale);
   const weekDays = ['Ma', 'Ti', 'On', 'To', 'Fr', 'Lø', 'Sø'];
+
+  const { showWeekNumbers } = useContext(CalendarPopoverContext);
 
   const typographyCn = [
     typographyStyles['supporting-style-tiny-02'],
@@ -51,7 +56,11 @@ export function CalendarGrid({ state, ...props }: CalendarGridProps) {
     >
       <thead {...headerProps}>
         <tr>
-          <th className={cn(...typographyCn)}>#</th>
+          {showWeekNumbers && (
+            <th className={cn(...typographyCn)}>
+              # <VisuallyHidden as="span">Ukenummer</VisuallyHidden>
+            </th>
+          )}
           {weekDays.map((day, index) => (
             <th key={index} className={cn(...typographyCn)}>
               {day}
@@ -68,11 +77,16 @@ export function CalendarGrid({ state, ...props }: CalendarGridProps) {
             : '';
           return (
             <tr key={weekIndex}>
-              <td
-                className={cn(styles['calendar__week-number'], ...typographyCn)}
-              >
-                {weekNumber}
-              </td>
+              {showWeekNumbers && (
+                <td
+                  className={cn(
+                    styles['calendar__week-number'],
+                    ...typographyCn,
+                  )}
+                >
+                  {weekNumber}
+                </td>
+              )}
               {datesInWeek.map((date, i) =>
                 date ? (
                   <CalendarCell key={i} state={state} date={date} />

--- a/packages/components/src/components/date-inputs/DatePicker/CalendarPopover.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/CalendarPopover.tsx
@@ -24,6 +24,7 @@ interface CalendarPopoverContextValue {
   anchorRef: RefObject<HTMLDivElement> | null;
   isOpen: boolean;
   onClose: () => void;
+  showWeekNumbers: boolean;
 }
 
 export const CalendarPopoverContext =
@@ -31,23 +32,25 @@ export const CalendarPopoverContext =
     anchorRef: null,
     isOpen: false,
     onClose: () => null,
+    showWeekNumbers: true,
   });
 
 interface CalendarPopoverProps {
   children: ReactNode;
   isOpen: boolean;
   onClose: () => void;
+  showWeekNumbers: boolean;
 }
 
 export const CalendarPopover = ({
   children,
-  isOpen,
   onClose,
+  ...props
 }: CalendarPopoverProps) => {
   const anchorRef = useRef<HTMLDivElement>(null);
   useOnKeyDown('Escape', onClose);
   return (
-    <CalendarPopoverContext.Provider value={{ anchorRef, isOpen, onClose }}>
+    <CalendarPopoverContext.Provider value={{ anchorRef, onClose, ...props }}>
       {children}
     </CalendarPopoverContext.Provider>
   );

--- a/packages/components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
@@ -43,6 +43,9 @@ const meta: Meta<typeof DatePicker> = {
     width: {
       control: 'text',
     },
+    showWeekNumbers: {
+      control: 'boolean',
+    },
     isDisabled: {
       control: 'boolean',
     },

--- a/packages/components/src/components/date-inputs/DatePicker/DatePicker.tsx
+++ b/packages/components/src/components/date-inputs/DatePicker/DatePicker.tsx
@@ -31,6 +31,10 @@ export interface DatePickerProps
    * Feilmelding.
    */
   errorMessage?: string;
+  /**Om ukenummer skal vises.
+   * @default true
+   */
+  showWeekNumbers?: boolean;
   /**
    * Egendefinert bredde på komponenten.
    */
@@ -42,7 +46,15 @@ const refIsFocusable = (ref: Ref<unknown>): ref is FocusableRef => {
 };
 
 export function _DatePicker(
-  { errorMessage, componentSize, tip, style, width, ...props }: DatePickerProps,
+  {
+    errorMessage,
+    componentSize,
+    tip,
+    style,
+    width,
+    showWeekNumbers = true,
+    ...props
+  }: DatePickerProps,
   forwardedRef: Ref<HTMLElement>,
 ) {
   const state = useDatePickerState(props);
@@ -59,7 +71,11 @@ export function _DatePicker(
 
   return (
     <I18nProvider locale={locale}>
-      <CalendarPopover isOpen={state.isOpen} onClose={state.close}>
+      <CalendarPopover
+        isOpen={state.isOpen}
+        onClose={state.close}
+        showWeekNumbers={showWeekNumbers}
+      >
         <CalendarPopoverAnchor>
           <DateField
             {...fieldProps}


### PR DESCRIPTION
Den styrer visning av ukenumre. `true` som default.

Med:
![bilde](https://github.com/user-attachments/assets/60e6aad9-36f4-40d4-ba0d-433db08f6ee1)

Uten:
![bilde](https://github.com/user-attachments/assets/b37cdf09-c47b-486a-bf19-c8e6b51aa205)
