### PR TITLE
ELSA1-504 Fikser border i `<SplitButton>`

### DIFF
--- a/.changeset/shiny-cars-brush.md
+++ b/.changeset/shiny-cars-brush.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser border i `<SplitButton>`slik at den ikke blir gjennomsiktig på en side ved `:active` state.

--- a/packages/dds-components/src/components/Button/Button.module.css
+++ b/packages/dds-components/src/components/Button/Button.module.css
@@ -1,4 +1,4 @@
-.button {
+:where(.button) {
   user-select: text;
   display: inline-flex;
   align-items: center;
@@ -15,7 +15,7 @@
     transition: all 0.2s;
   }
 
-  &:active:not(.button--is-loading) {
+  &:active:not([aria-disabled='true']) {
     scale: 0.95;
   }
 }

--- a/packages/dds-components/src/components/SplitButton/SplitButton.module.css
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.module.css
@@ -5,7 +5,7 @@
 .main {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
-  border-right: none;
+  margin-inline-end: -1px;
 }
 
 .main:focus {


### PR DESCRIPTION
Ved `:active` state blir border på den ene siden gjennomsiktig. For å unngå det fikses komponenten som `<ButtonGroup>`, med negativ `margin`.

Før:
![bilde](https://github.com/user-attachments/assets/8ec4a7fa-7b9f-4546-ab92-d3dd95365f89)


Etter:
![bilde](https://github.com/user-attachments/assets/4c2bb10f-7ca4-4384-bc19-72279cd01838)
