### PR TITLE
ELSA1-508 Fjerner `<label>` i noen komponenter

### DIFF
--- a/.changeset/serious-years-drive.md
+++ b/.changeset/serious-years-drive.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<ToggleBar>` og `<Feedback>` rendret `<label>` for tekster som ikke er semantiske ledetekster.

--- a/packages/dds-components/src/components/Feedback/RatingComponent.tsx
+++ b/packages/dds-components/src/components/Feedback/RatingComponent.tsx
@@ -1,13 +1,13 @@
 import styles from './Feedback.module.css';
 import { type Layout, type Rating } from './Feedback.types';
+import { ThumbIcon } from './utils';
 import { cn } from '../../utils';
 import { focusable } from '../helpers/styling/focus.module.css';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { Spinner } from '../Spinner';
 import { HStack } from '../Stack';
 import { Tooltip } from '../Tooltip';
-import { Label } from '../Typography';
-import { ThumbIcon } from './utils';
+import typographyStyles from '../Typography/typographyStyles.module.css';
 
 interface RatingComponentType {
   layout: Layout;
@@ -48,7 +48,7 @@ export const RatingComponent = ({
         styles[`rating-container--${layout}`],
       )}
     >
-      <Label>{ratingLabel}</Label>
+      <h2 className={typographyStyles['label-medium']}>{ratingLabel}</h2>
       {loading ? (
         <Spinner tooltip="Laster opp tilbakemelding ..." />
       ) : (

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.tsx
@@ -5,7 +5,7 @@ import styles from './ToggleBar.module.css';
 import { type ToggleBarProps, type ToggleBarValue } from './ToggleBar.types';
 import { getBaseHTMLProps } from '../../types';
 import { cn, combineHandlers } from '../../utils';
-import { Label } from '../Typography';
+import { Typography } from '../Typography';
 
 export const ToggleBar = <T extends string | number = string>(
   props: ToggleBarProps<T>,
@@ -56,7 +56,11 @@ export const ToggleBar = <T extends string | number = string>(
         role="radiogroup"
         aria-labelledby={labelId ?? htmlProps?.['aria-labelledby']}
       >
-        {label && <Label id={labelId}>{label}</Label>}
+        {label && (
+          <Typography id={labelId} as="span" typographyType="labelMedium">
+            {label}
+          </Typography>
+        )}
         <div className={styles.bar}>{children}</div>
       </div>
     </ToggleBarContext.Provider>


### PR DESCRIPTION
Fikset bug der `<ToggleBar>` og `<Feedback>` rendret `<label>` for tekster som ikke er semantiske ledetekster. `<ToggleBar>` returnerer nå `<span>`, slik det at følger mønsteret fra andra selection control-komponenter. `<Feedback>` returnerer `<h2>` med label styling, da den relevante teksten blir overskriften for  feedback-seksjonen hos konsumenten.