### PR TITLE
ELSA1-512 Gruppe for typescript i dependabot YAML

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
         versions:
           - '3.1.3'
     groups:
+      typescript:
+        patterns:
+          - 'typescript'
       non-major:
         update-types:
           - 'minor'


### PR DESCRIPTION
Legge til egen gruppe i YAML, da Typescript ikke følger semver og update blir lettere å håndtere i enestående PR.