### PR TITLE
ELSA1-514 Legger ProgressTracker stories i ThemeProvider

### DIFF
--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
@@ -17,6 +17,7 @@ import { Select } from '../Select';
 import { Checkbox } from '../SelectionControl/Checkbox';
 import { HStack, VStack } from '../Stack';
 import { TextInput } from '../TextInput';
+import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
 import { Heading, Legend, Paragraph } from '../Typography';
 
 export default {
@@ -209,6 +210,13 @@ export const FutureStepsDisabled: Story = {
 };
 
 export const SmallScreen: Story = {
+  decorators: [
+    Story => (
+      <StoryThemeProvider>
+        <Story />
+      </StoryThemeProvider>
+    ),
+  ],
   render: args => {
     const numSteps = 3;
 
@@ -270,7 +278,7 @@ export const SmallScreen: Story = {
 export const RealWorldRosponsiveExample: Story = {
   decorators: [
     Story => (
-      <>
+      <StoryThemeProvider>
         <Story />
         <style>
           {`
@@ -305,7 +313,7 @@ export const RealWorldRosponsiveExample: Story = {
           }
           `}
         </style>
-      </>
+      </StoryThemeProvider>
     ),
   ],
   render: args => {


### PR DESCRIPTION
Eksempler som bruker `<Drawer>` resulterte i Error da de må wrappes inn `<StoryThemeProvider>` for å få ref til `<div>` `<Drawer>` rendres i. Wrapper relevante stories.

Før:
![image](https://github.com/user-attachments/assets/352deb75-2ef6-4ad9-a554-af2d9783fe73)


Etter:
![image](https://github.com/user-attachments/assets/eee50387-f13c-4033-919c-eac8b8ac1afb)
