### PR TITLE
ELSA1-516 Endrer `type DdsTheme` til `keyof typeof`

### DIFF
--- a/packages/dds-components/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/dds-components/src/components/ThemeProvider/ThemeProvider.tsx
@@ -11,7 +11,7 @@ import {
 import styles from './ThemeProvider.module.css';
 import { cn } from '../../utils';
 
-export type DdsTheme = 'core' | 'public';
+export type DdsTheme = keyof typeof ddsTokens;
 const defaultTheme = 'core';
 
 interface ThemeContextProps {


### PR DESCRIPTION
Endre DdsTheme  fra `'core' | 'public'` til `keyof typeof ddsTokens` da `ddsTokens` er delt opp i tema basert på nanv. Det blir mer gjenbrukbart, samt lettere å verifisere om type-feil kommer fra dds-design-tokens eller dds-components.