### PR TITLE
ELSA1-518 Fikser ThemeProvider-errors i stories

### DIFF
--- a/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
@@ -1,10 +1,11 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { StoryVStack } from '../Stack/utils';
+import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
 
 import { Pagination } from '.';
 
-export default {
+const meta: Meta<typeof Pagination> = {
   title: 'dds-components/Pagination',
   component: Pagination,
   argTypes: {
@@ -22,7 +23,15 @@ export default {
       canvas: { sourceState: 'hidden' },
     },
   },
-} satisfies Meta<typeof Pagination>;
+  decorators: [
+    Story => (
+      <StoryThemeProvider>
+        <Story />
+      </StoryThemeProvider>
+    ),
+  ],
+};
+export default meta;
 
 const customOptionsItemsAmount = 100;
 const customOptions = [17, 32, customOptionsItemsAmount].map(o => ({

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
@@ -12,6 +12,7 @@ import { useRef, useState } from 'react';
 import { Button } from '../../Button';
 import { Modal } from '../../Modal';
 import { StoryHStack, StoryVStack } from '../../Stack/utils';
+import { StoryThemeProvider } from '../../ThemeProvider/utils/StoryThemeProvider';
 import { Paragraph } from '../../Typography';
 import { TimePicker } from '../TimePicker';
 import {
@@ -168,6 +169,13 @@ export const ControlFocus: Story = {
 
 export const InsideModal: Story = {
   args: { label: 'Dato' },
+  decorators: [
+    Story => (
+      <StoryThemeProvider>
+        <Story />
+      </StoryThemeProvider>
+    ),
+  ],
   render: args => {
     const [isOpen, setOpen] = useState(true);
     return (


### PR DESCRIPTION
Eksempler som bruker `<Modal>` og `<Select>` resulterte i Error da de må wrappes inni `<StoryThemeProvider>` for å få ref til `<div>` disse komponentene rendres i. Wrapper relevante stories.

Før:
![image](https://github.com/user-attachments/assets/fcb5e865-d4e4-4244-94bd-ba6a04bed9fe)

Etter:
![image](https://github.com/user-attachments/assets/518f0217-1a19-4791-81c5-eb75076f7b15)
