### PR TITLE
Fikser Storybook sidemeny for Table

### DIFF
--- a/packages/dds-components/src/components/Table/normal/Table.mdx
+++ b/packages/dds-components/src/components/Table/normal/Table.mdx
@@ -9,7 +9,7 @@ import {
 import * as TableStories from './Table.stories';
 import * as CollapsibleTableStories from '../collapsible/CollapsibleTable.stories';
 
-<Meta title="dds-components/Table/Docs" />
+<Meta of={TableStories} />
 
 # Table
 

--- a/packages/dds-components/src/components/Table/normal/Table.stories.tsx
+++ b/packages/dds-components/src/components/Table/normal/Table.stories.tsx
@@ -17,7 +17,7 @@ import { Link, Paragraph } from '../../Typography';
 import { type SortOrder, Table } from '.';
 
 const meta: Meta<typeof Table> = {
-  title: 'dds-components/Table/Table',
+  title: 'dds-components/Table',
   component: Table,
   argTypes: {
     stickyHeader: {


### PR DESCRIPTION
Sidemenyen for Table er rotete, endrer litt på strukturen.

Før:
![image](https://github.com/user-attachments/assets/620702c0-bdd0-4090-86ec-d27653619302)

Etter:
![image](https://github.com/user-attachments/assets/b4fa57dc-4888-4b69-8daa-6c1a07a5253b)

