### PR TITLE
ELSA1-527 Gjør AppShell deprecated

### DIFF
--- a/.changeset/smart-news-sparkle.md
+++ b/.changeset/smart-news-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/app-shell': patch
+---
+
+Gjør `@norges-domstoler/app-shell` deprecated. Kopier koden til `<AppShell>`-komponenten inni kodebasen din hvis du ønsker å fortsette å bruke den.

--- a/packages/app-shell/package.json
+++ b/packages/app-shell/package.json
@@ -30,8 +30,8 @@
     "elsa"
   ],
   "devDependencies": {
-    "@norges-domstoler/dds-components": "workspace:*",
-    "@norges-domstoler/development-utils": "workspace:*",
+    "@norges-domstoler/dds-components": "^18",
+    "@norges-domstoler/development-utils": "^1",
     "@norges-domstoler/storybook-components": "workspace:*",
     "@storybook/blocks": "8.4.7",
     "@testing-library/dom": "^10.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,11 +109,11 @@ importers:
   packages/app-shell:
     devDependencies:
       '@norges-domstoler/dds-components':
-        specifier: workspace:*
-        version: link:../dds-components
+        specifier: ^18
+        version: 18.1.0(@internationalized/date@3.6.0)(@norges-domstoler/dds-design-tokens@7.0.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@norges-domstoler/development-utils':
-        specifier: workspace:*
-        version: link:../development-utils
+        specifier: ^1
+        version: 1.3.1(react@18.3.1)(styled-components@6.1.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@norges-domstoler/storybook-components':
         specifier: workspace:*
         version: link:../storybook-components
@@ -1027,6 +1027,23 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@norges-domstoler/dds-components@18.1.0':
+    resolution: {integrity: sha512-xqsRksuwtLewg7VujgjZKN6HtA2KdfV2Ftl2daTyDAH9NBQ5DPplgr5+Wqx/rG3JLyNFuBLr3+njlwmJSFwqxA==}
+    peerDependencies:
+      '@internationalized/date': ^3
+      '@norges-domstoler/dds-design-tokens': '>=5.0.0'
+      react: 18.3.1
+      react-dom: 18.3.1
+
+  '@norges-domstoler/dds-design-tokens@7.0.0':
+    resolution: {integrity: sha512-4BmkGIfa6shLPSB7pI8uq3oQEX8eLw2zt4l6YxQlQ7qIjnXyETTc3WnfHNRQjw2OsqkLSB1h2PZobz2p2anBrQ==}
+
+  '@norges-domstoler/development-utils@1.3.1':
+    resolution: {integrity: sha512-ev22C/cB8W2+t5KnoWtFfcLr4qmJQEPFw7I7YvTDntrF483Q4YukstbEUx5G0vjKaULWD/VT48UxImX544HiDw==}
+    peerDependencies:
+      react: 18.3.1
+      styled-components: ^5 || ^6
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5458,6 +5475,35 @@ snapshots:
       fastq: 1.18.0
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@norges-domstoler/dds-components@18.1.0(@internationalized/date@3.6.0)(@norges-domstoler/dds-design-tokens@7.0.0)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.1.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@internationalized/date': 3.6.0
+      '@norges-domstoler/dds-design-tokens': 7.0.0
+      '@norges-domstoler/development-utils': 1.3.1(react@18.3.1)(styled-components@6.1.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@react-aria/button': 3.11.0(react@18.3.1)
+      '@react-aria/calendar': 3.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/datepicker': 3.12.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/focus': 3.19.0(react@18.3.1)
+      '@react-aria/i18n': 3.12.4(react@18.3.1)
+      '@react-stately/calendar': 3.6.0(react@18.3.1)
+      '@react-stately/datepicker': 3.11.0(react@18.3.1)
+      file-selector: 2.1.2
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-select: 5.9.0(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - styled-components
+      - supports-color
+
+  '@norges-domstoler/dds-design-tokens@7.0.0': {}
+
+  '@norges-domstoler/development-utils@1.3.1(react@18.3.1)(styled-components@6.1.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      react: 18.3.1
+      styled-components: 6.1.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
   '@pkgjs/parseargs@0.11.0':
     optional: true


### PR DESCRIPTION
Endrer devPependencies til Elsa slik at de peker til nåværende major, slik at pakken ikke må oppdateres med endringer framover.