### PR TITLE
ELSA1-535 Fikser problem med `<TableWrapper>` og SSR

### DIFF
--- a/.changeset/empty-kangaroos-hang.md
+++ b/.changeset/empty-kangaroos-hang.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fjerner referanse til `window` i `<TableWrapper>` slik at den fungerer med SSR.

--- a/packages/dds-components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
+++ b/packages/dds-components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
@@ -11,6 +11,7 @@ import {
   PersonIcon,
   TrashIcon,
 } from '../../Icon/icons';
+import { StoryThemeProvider } from '../../ThemeProvider/utils/StoryThemeProvider';
 import { Link } from '../../Typography';
 import { VisuallyHidden } from '../../VisuallyHidden';
 import { Table } from '../normal';
@@ -18,7 +19,7 @@ import { data, headerCells, mapCellContents } from '../normal/tableData';
 
 import { CollapsibleTable } from '.';
 
-export default {
+const meta: Meta<typeof CollapsibleTable> = {
   title: 'dds-components/Table/CollapsibleTable',
   component: CollapsibleTable,
   argTypes: {
@@ -39,7 +40,16 @@ export default {
       exclude: ['headerValues', 'definingColumnIndex'],
     },
   },
-} satisfies Meta<typeof CollapsibleTable>;
+  decorators: [
+    Story => (
+      <StoryThemeProvider>
+        <Story />
+      </StoryThemeProvider>
+    ),
+  ],
+};
+
+export default meta;
 
 type Story = StoryObj<typeof CollapsibleTable>;
 

--- a/packages/dds-components/src/components/Table/normal/Table.stories.tsx
+++ b/packages/dds-components/src/components/Table/normal/Table.stories.tsx
@@ -12,6 +12,7 @@ import { Button } from '../../Button';
 import { Icon } from '../../Icon';
 import { PersonIcon, TrashIcon } from '../../Icon/icons';
 import { Checkbox } from '../../SelectionControl/Checkbox';
+import { StoryThemeProvider } from '../../ThemeProvider/utils/StoryThemeProvider';
 import { Link, Paragraph } from '../../Typography';
 
 import { type SortOrder, Table } from '.';
@@ -37,6 +38,13 @@ const meta: Meta<typeof Table> = {
       canvas: { sourceState: 'hidden' },
     },
   },
+  decorators: [
+    Story => (
+      <StoryThemeProvider>
+        <Story />
+      </StoryThemeProvider>
+    ),
+  ],
 };
 
 export default meta;

--- a/packages/dds-components/src/components/Table/normal/TableWrapper.tsx
+++ b/packages/dds-components/src/components/Table/normal/TableWrapper.tsx
@@ -1,14 +1,26 @@
-import { type HTMLAttributes, useEffect, useRef, useState } from 'react';
+import {
+  type HTMLAttributes,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import styles from './Table.module.css';
 import { cn } from '../../../utils';
 import { scrollbar } from '../../helpers/styling/utilStyles.module.css';
+import { ThemeContext } from '../../ThemeProvider';
 
 export type TableWrapperProps = HTMLAttributes<HTMLDivElement>;
 
 export const TableWrapper = ({ className, ...rest }: TableWrapperProps) => {
+  const themeContext = useContext(ThemeContext);
+  const container = themeContext?.el;
+  const containerWidth = container ? container.clientWidth : 0;
+
   const [overflowX, setOverflowX] = useState(false);
-  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+  const [themeContainerWidth, setThemeContainerWidth] =
+    useState(containerWidth);
 
   function isOverflowingX(event: HTMLDivElement): boolean {
     return event.offsetWidth < event.scrollWidth;
@@ -22,11 +34,11 @@ export const TableWrapper = ({ className, ...rest }: TableWrapperProps) => {
       return;
     }
     setOverflowX(false);
-  }, [windowWidth]);
+  }, [themeContainerWidth]);
 
   useEffect(() => {
     function handleResize() {
-      setWindowWidth(window.innerWidth);
+      setThemeContainerWidth(containerWidth);
     }
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);


### PR DESCRIPTION
Fjerner referanser til `window.innerWidth` i `useState` og `handleResize`. Erstatter de med ref til `<div>` returnert av `<ThemeProvider>` og `clientWidth`.

Ser ikke ut til å fungere noe særlig i vanlig Storybook story, men fungerer fint i stories i docs og story åpnet i egen side; vil tro at problemet er `<iframe>`s og sånt, og vil dermed fungere i ekte applikasjoner.