### PR TITLE
ELSA1-373 Fikser `ref` og return-verdi i `<Select>`

### DIFF
--- a/.changeset/lemon-jars-push.md
+++ b/.changeset/lemon-jars-push.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Fikser bug der `<Select>` ikke eksporterte `JSX.element`, samt bug der `ref` ikke var støttet. Eksponerer `type SelectForwardRefType<Option, IsMulti extends boolean>` for å sette type ved bruk av `useRef()` (valgfritt).

--- a/packages/dds-components/src/components/Select/Select.mdx
+++ b/packages/dds-components/src/components/Select/Select.mdx
@@ -2,7 +2,6 @@ import { Story, Canvas, Meta, Controls } from '@storybook/blocks';
 import {
   Source,
   ComponentLinkRow,
-
 } from '@norges-domstoler/storybook-components';
 import { Link } from '../Typography';
 import { Table } from '../Table';
@@ -180,6 +179,24 @@ Du kan bruke `options` i custom format, og sette label og value basert på optio
 Du kan customisere visuelle elementer for både det valgte elemetet og alternativer i lista.
 
 <Canvas of={SelectStories.CustomElement} />
+
+### Bruk av `ref`
+
+`useRef()` støttes uten definert type. Du kan ha strongly typed `ref` ved å sette return-type til vår `SelectForwardRefType<Option, isMulti>` på den.
+
+<Source
+  code={`
+  const ref: SelectForwardRefType<
+    {
+      label: string;
+      value: string;
+    },
+    false
+  > = useRef(null);
+
+return <Select options={[{ label: 'alt', value: 'alt' }]} ref={ref} />;
+`}
+/>
 
 ### Multiselect
 

--- a/packages/dds-components/src/components/Select/Select.tsx
+++ b/packages/dds-components/src/components/Select/Select.tsx
@@ -1,5 +1,11 @@
 import { type Properties, type Property } from 'csstype';
-import { type HTMLAttributes, forwardRef, useContext, useId } from 'react';
+import {
+  type HTMLAttributes,
+  type ReactElement,
+  forwardRef,
+  useContext,
+  useId,
+} from 'react';
 import {
   type GroupBase,
   type OptionProps,
@@ -86,13 +92,14 @@ export type SelectProps<Option = unknown, IsMulti extends boolean = false> = {
 } & Pick<HTMLAttributes<HTMLInputElement>, 'aria-required'> &
   WrappedReactSelectProps<Option, IsMulti, GroupBase<Option>>;
 
-type ForwardRefType<Option, IsMulti extends boolean> = React.ForwardedRef<
-  SelectInstance<Option, IsMulti, GroupBase<Option>>
->;
+export type SelectForwardRefType<
+  Option,
+  IsMulti extends boolean,
+> = React.ForwardedRef<SelectInstance<Option, IsMulti, GroupBase<Option>>>;
 
 function SelectInner<Option = unknown, IsMulti extends boolean = false>(
   props: SelectProps<Option, IsMulti>,
-  ref: ForwardRefType<Option, IsMulti>,
+  ref: SelectForwardRefType<Option, IsMulti>,
 ) {
   const {
     id,
@@ -246,7 +253,14 @@ function SelectInner<Option = unknown, IsMulti extends boolean = false>(
   );
 }
 
-export const Select = forwardRef(SelectInner) as typeof SelectInner;
+export const Select = forwardRef(SelectInner) as <
+  Option = unknown,
+  IsMulti extends boolean = false,
+>(
+  props: SelectProps<Option, IsMulti> & {
+    ref?: SelectForwardRefType<Option, IsMulti>;
+  },
+) => ReactElement;
 
 // @ts-expect-error TODO fix Select type
 Select.displayName = 'Select';


### PR DESCRIPTION
`<Select>` returnerte ikke riktig type, mest sannsynligvis pga bruk av `typeof SelectInner`. Dette påvirket også `ref`, da den ikke var støttet på komponenten.

Hva ble gjort:
- Fikser typen som returneres i `Select`.
- Eksponerer `type SelectForwardRefType<Option, IsMulti extends boolean>` til bruk med `useRef()` ved behov.
- Docs om bruk av `ref`.