### PR TITLE
Fix: bump kun versjoner med workspace-protokoll

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,7 @@
   "ignore": [],
   "access": "public",
   "baseBranch": "main",
+  "bumpVersionsWithWorkspaceProtocolOnly": true,
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }


### PR DESCRIPTION
Interne pakker avhengige av spesifikk versjon av andre interne pakker bør ikke få bump på den; kun pakker som bruker workspace-protokoll skal få bump.