### PR TITLE
ELSA1-537 Legger til `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,470 @@
+# Bidra
+
+Vi setter pris på at du vil gjøre Elsa bedre! Ta gjerne kontakt med team Elsa i [#designsystemet-elsa](https://domstoladm.slack.com/archives/C01HNLSPTT9) på Slack for å diskutere bidraget.
+
+## Innhold
+
+- [Kom i gang](#kom-i-gang)
+- [Konvensjoner](#konvensjoner)
+- [Komponentutvikling](#komponentutvikling)
+- [Ikoner](#ikoner)
+- [Design tokens](#design-tokens)
+- [Release notes](#release-notes)
+- [Publisering](#publisering)
+
+## Kom i gang
+
+### Jira
+
+Arbeidet logges i [Elsa Utvikling tavle](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357) i Jira. Du kan be team Elsa om å lage oppgave og få den tildelt.
+
+### Nødvendige installasjoner
+
+- **[Volta](https://volta.sh/)**: Vi anbefaler å installere Volta for versjonshåndtering av Node.js og pnpm. Volta vil automatisk installere riktig versjon av Node.js og pnpm når du jobber med designsystemet. Siden Volta kun har eksperimentell støtte for pnpm må du legge til `VOLTA_FEATURE_PNPM=1` i miljøvariabler (Windows), eller `.bashrc`, `.zshrc` eller tilsvarende (Linux/Mac). Se [Volta pnpm support](https://docs.volta.sh/advanced/pnpm) for mer informasjon.
+- **[pnpm](https://pnpm.io/)**: vi bruker pnpm som pakke-manager. Kjør `volta install pnpm` for riktig versjon.
+- **[node](https://nodejs.org/en)**: kjør `volta install node` for riktig versjon.
+
+### Kjør miljøet
+
+Installer dependencies:
+
+```shell
+pnpm install
+```
+
+Kjør utviklingsmiljøet:
+
+```shell
+pnpm dev
+```
+
+Kjør Storybook (demoside og playground):
+
+```shell
+pnpm storybook
+```
+
+Storybook kjører på port `6006`.
+
+### Linking
+
+Hvis du vil teste endringer i Elsa live i applikasjonen din kan du bruke `npm link`.
+
+```Shell
+cd ~/designsystem/packages/pakke # velg pakke
+npm link
+cd ~/din-app
+npm link pakke
+```
+
+### Finner ikke pakken
+
+Skal ikke egentlig være nødvendig, men hvis du får en feilmeldinger om at den ikke finner en av pakkene kan du prøve:
+
+```Shell
+pnpm build
+```
+
+### Testing
+
+Du kan teste hele applikasjonen:
+
+```Shell
+pnpm test
+```
+
+## Konvensjoner
+
+### Språk
+
+- **Norsk:** dokumentasjon i design.domstol.no, `.mdx`-filer, `.md`-filer, [JSDoc](https://jsdoc.app/) som dokumenterer komponenter og hooks, pull requests.
+
+- **Engelsk:** kode, utviklingsrelaterte uttrykk i dokumentasjon som gir mest mening på engelsk, f.eks. "property"
+
+### Pull request
+
+- ID som tilsvarer Jira-saken i tittelen. Eksempel: `ELSA1-23 Ny komponent: Button`.
+- Commits bør også ha ID fra Jira i tittelen.
+- Beskriv kort men tydelig hva bidraget er.
+- Bruk [Markdown](https://www.markdownguide.org/basic-syntax/) slik at det er tydelig hva du refererer til. F.eks. et HTML element, en funksjon og en CSS-klasse bør bruke kode-markdown.
+- Ta med skjermdumper eller videoer av resultatet hvis relevant.
+- Squash gjerne dine commits.
+
+### Linting
+
+Vi bruker ESLint.
+
+#### VS Code
+
+Installer gjerne [VS Code ESLint extension](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).
+
+### Kodeformatering
+
+Vi bruker Prettier. Du kan sjekke hvilke filer er feilformatert:
+
+```shell
+pnpm prettier --check
+```
+
+Du kan rette filer med:
+
+```shell
+pnpm prettier --write
+```
+
+#### VS Code
+
+Installer plugin [Prettier - code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode).
+
+I instillinger:
+
+- Sett **Text Editor > Default formatter** til "Prettier - code formatter".
+- Sett **Text Editor > Formatting > Format on save mode** til "true".
+
+## Komponentutvikling
+
+Hver komponent skal ligge i egen mappe, der navnet er <KomponentNavn>. Mappen skal inneholde:
+
+- **Komponentfil:** `<KomponentNavn>.tsx`
+- **Css-fil:** inneholder relevant styling vha CSS modules: `<komponentNavn>.module.css`
+- **Testfil:** med tilhørende tester: `<KomponentNavn>.spec.tsx`
+- **Stories-fil:** med tilhørende stories: `<KomponentNavn>.stories.tsx`
+- **Docs-fil:** tilhørende teknisk dokumentasjon: `<KomponentNavn>.mdx`
+- **Index-fil:** `index.ts` for eksportering
+- **_(Ved behov) Types-fil:_** hvis komponenten har mange types eller flere delkomponenter deler types, kan det være relevant å flytte det ut til egen fil: `<KomponentNavn>.types.tsx`
+
+Det kan også være relevant med flere filer, f. eks. RadioButton inneholder komponentfilene `RadioButton.tsx` og `RadioButtonGroup.tsx`, samt tilhørende css-, testing- og stories-filer for begge.
+
+```
+├── <KomponentNavn>
+│ ├── <KomponentNavn>.mdx
+| ├── <komponentNavn>.modules.css
+│ ├── <KomponentNavn>.spec.tsx
+│ ├── <KomponentNavn>.stories.tsx
+│ ├── <KomponentNavn>.tsx
+| ├── <komponentNavn>.types.tsx (ved behov)
+│ └── index.ts
+```
+
+### Komponent-fil
+
+Her bygges selve komponenten. Du kan følge en enkel mal:
+
+```JSX
+import styles from './Component.module.css';
+import { BaseComponentProps, getBaseHTMLProps } from '../../types';
+
+export type ComponentSize = 'small' | 'medium';
+
+//BaseComponentProps eller BaseComponentPropsWithChildren for props
+// Bruk JSDoc og beskriv hver prop
+export type ComponentProps = BaseComponentPropsChildren<
+HTMLDivElement,
+{
+    /**
+     * Størrelse.
+     * @default "medium"
+    */
+    size: ComponentSize;
+}>;
+
+// Komponenten, helst med forwardRef
+export const Component = forwardRef<HTMLAnchorElement, ComponentProps>((props, ref)=>{
+    const { children, id, className, htmlProps, size, ...rest } = props;
+
+    return (
+        <div
+        // Bruk getBaseHTMLProps, slik at konsumenter ikke får alle native HTML-attributter i tooltip.
+            {...getBaseHTMLProps(
+                id,
+                className,
+                restHTMLprops,
+                rest
+            )}
+            // CSS styling, bruk cn() for å kombinere klasser
+            className={cn(styles.container, styles[size])}
+            ref={ref} >
+            {children}
+        </div>
+    )
+});
+```
+
+### Css-fil
+
+Vi bruker [CSS modules](https://github.com/css-modules/css-modules) til å scope styling per komponent. Bruk gjerne [BEM](https://getbem.com/introduction/)-systemet for lesbarhet. Her bruker du våre design tokens på CSS-format.
+
+Eksempel:
+
+```CSS
+/* Chip.module.css */
+.container {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    gap: var(--dds-spacing-x0-25);
+    padding: var(--dds-spacing-x0-125) var(--dds-spacing-x0-25)
+    var(--dds-spacing-x0-125) var(--dds-spacing-x0-5);
+    border: 1px solid var(--dds-color-border-subtle);
+    border-radius: var(--dds-border-radius-chip);
+    background-color: var(--dds-color-surface-subtle);
+}
+
+.group {
+    display: flex;
+    gap: var(--dds-spacing-x0-75);
+}
+```
+
+### Stories-fil
+
+Vi bruker Storybook som demoside og playground. Hver komponent skal ha minst en av grunnleggende stories (begge hvis relevant):
+
+- **Preview**, for bare-bones eksempel
+- **Overview**, der visuelle varianter og bruken av relevante props presenteres
+
+Spørs på komponenten kan det være relevant med flere stories: eksempel med kontrollert input, bruk av delkomponenter, gruppering osv. Ta gjerne kontakt med team Elsa hvis du er i tvil.
+
+Du kan følge en enkel mal for stories-fila:
+
+```JSX
+import { type Meta, type StoryObj } from '@storybook/react';
+import { Button } from '.';
+
+// config
+export default {
+  title: 'dds-components/Button',
+  component: Button,
+  // kontrollere  for demo
+  argTypes: {
+    label: { control: 'text' },
+    loading: { control: 'boolean' },
+    fullWidth: { control: 'boolean' },
+    href: { control: 'text' },
+    // ekskluderte kontrollere;
+    // bruk på props som ikke trenger å styres med i demo
+    htmlProps: { control: false },
+    target: { control: false },
+    icon: { control: false },
+  }
+} satisfies Meta<typeof Button>;
+
+type Story = StoryObj<typeof Button>;
+
+// demo; kan ha default args for bedre showcase
+export const Preview: Story = {
+  args: { children: 'Tekst' }
+};
+
+```
+
+#### StoryVStack og StoryHStack
+
+Hvis du viser flere varianter i en enkel story kan du bruke `<StoryVStack>` og `<StoryHStack>`-helpers til å oppnå riktig layout. De bruker fornuftige defaults for typiske avstander. Ved behov kan de overskrives, se [Stack-komponenten](https://design.domstol.no/987b33f71/p/8539cc-stack) for hva som støttes.
+
+```JSX
+import { Button } from '.';
+import { StoryVStack } from '../Stack/utils';
+
+/**config...**/
+
+// Demo med stack
+export const Sizes: Story = {
+    args: { children: 'Tekst' },
+    render: args => (
+        <StoryVStack>
+        <Button {...args} size="small" />
+        <Button {...args} size="medium" />
+        <Button {...args} size="large" />
+        </StoryVStack>
+    )
+};
+
+```
+
+### Docs-fil
+
+Docs-fila er en `.mdx` fil som inneholder teknisk dokumentasjon og viser Storybook demoer. Den bruker en blanding av markdown og JSX, og vises som en docs-story i Elsa Storybook.
+
+Enkel mal for docs-fila:
+
+```JSX
+import { Canvas, Controls, Meta } from '@storybook/addon-docs';
+import { Source, ComponentLinkRow } from '@norges-domstoler/storybook-components';
+import * as komponentStories from './KomponentNavn.stories'
+import * as delkomponentStories from './DelkomponentNavn.stories'
+
+<Meta of={komponentStories} />
+
+# KomponentNavn
+
+// Lenker til andre ressurser
+// Hopp over de som ikek er relevante
+<ComponentLinkRow
+  docsHref="link"
+  storybookHref="link"
+  figmaHref="link"
+  githubHref="link"
+/>
+
+## Props
+
+// Referanse til primære storien, ofte komponentStories.Default.
+// Bruk Canvas for demo og Controls for kotrollere.
+<Canvas of={komponentStories.Default} />
+<Controls of={komponentStories.Default} />
+
+// Hvis det er delkomponenter, vis demoer for de også.
+### Delkomponent
+
+<Canvas of={delkomponentStories.Default} />
+
+// Eksempler ved behov
+## Eksempler
+
+<Canvas of={komponentStories.Example} />
+
+<Source code={`
+import { KomponentNavn } from '@norges-domstoler/pakkenavn';
+    // eksempel på bruk
+`} />
+
+// Retningslinjer for utviklere
+## Retningslinjer
+
+/*...*/
+```
+
+### Testfil
+
+Det brukes Vitest og React Testing Library for testing. Skriv tester som sørger for riktig oppførsel.
+
+Ha med også UU-relaterte tester, som å sjekke om interaktive elementer får tilgjengelig navn og instrukser.
+
+Du kan kjøre testene i spesifikk fil:
+
+```shell
+pnpm --filter '@norges-domstoler/dds-components' test KomponentNavn.spec.tsx
+```
+
+### Index-fil
+
+Eksportering av komponenten:
+
+```JSX
+
+// src/components/Button/index.ts
+export * from './RadioButton';
+
+// ../../../index.ts
+export * from './components/Button';
+```
+
+### Helpers og utils
+
+Gjenbrukbare ressurser som løser typiske problemstillinger.
+
+- `helpers/`: delkomponenter (`<Paper>`, `<Input>` osv.)
+- `styling/`: styling på tvers av komponenter, som fokusring (`focus.module.css`), fjerning av default styling og normalisering.
+- `hooks/`: React hooks, dokumentert under [Hooks](https://zeroheight.com/987b33f71/p/389796).
+- `test/`: mocks til testing av komponenter.
+- `types/`: typings, bl.a. `type BaseComponentProps`
+- `utils/`: assorterte utilities.
+
+### Kvalitetskontroll
+
+- Test i alle evergreen nettlesere: Chrome, Firefox, Safari, Edge.
+- Følg relevante [WCAG krav](https://www.uutilsynet.no/wcag-standarden/wcag-standarden/86).
+- Test med skjermleser.
+- Sjekk nettleserstøtte for teknologi du bruker, for eksempel med [Can I use](https://caniuse.com/) eller [MDN Web Docs](https://developer.mozilla.org/en-US/).
+- Sjekk om navngiving og andre konvensjoner er like på tvers av komponentene.
+- Komponenter skal være gjenbrukbare, gjerne diskuter med designere og utviklere på ditt team samt team Elsa hvilke bruksområder og eventuelle edge cases som er relevante.
+
+## Ikoner
+
+Ikoner er JSX-elementer som returnerer `<svg>`. Under `dds-components/src/components/Icon` ligger:
+
+- Komponenten `<Icon>`
+- `icons/`: selve ikonene som `.tsx` filer.
+- `utils/`: utilities for ikon
+- `icons.stories.tsx`: katalog med ikoner
+
+### Legge til ikon
+
+#### Eksporter fra Figma
+
+Få taket i svg-koden til ikonet i Figma DDS Foundations; hvis det ikke finnes skal det legges inn der først.
+
+Det finnes flere måter å få taket i koden på. Du kan for eksempel bruke [SVG to JSX Figma plugin](https://www.figma.com/community/plugin/749818562498396194/SVG-to-JSX), eller bruke dev mode.
+
+Du kan også lagre ikonet midlertidig. Eksporter ikonet ved å velge det, sette Export-typen til SVG under Design og trykke på "Export"-knappen.
+
+#### I kode
+
+Når du har svg-koden tilgjengelig, kopier **kun barna til `<svg>`** (`<path>`, `<rect>`, `<cicrle>` osv. **OBS!** Ikke ta med fill-attributtet, fargen skal ikke være hardkodet). For eksempel:
+
+```HTML
+<svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <!-- kopier kun <path>! -->
+    <!-- Ikke ta med fill! -->
+    <path d="M6.70817 9.33333C8.80225 9.33333 10.4998 7.50516 10.4998 5.25H2.9165C2.9165 7.50516 4.61409 9.33333 6.70817 9.33333Z" />
+</svg>
+```
+
+Legg til nytt ikon under `icons/` på følgende form:
+
+```JSX
+import { type SvgProps, SvgWrapper } from '../utils';
+
+export function NameIcon(props: SvgProps) {
+    return (
+    <SvgWrapper {...props}>
+        /*barna til svg*/
+    </SvgWrapper>
+);
+}
+```
+
+Eksporter ikonet i `index.tsx`.
+
+## Design-tokens
+
+Tokens ligger på GitHub som `.json`-filer i `packages/dds-tokens/dds/tokens`.
+
+### Installasjon
+
+Installer [Style-dictionary](https://amzn.github.io/style-dictionary):
+
+```
+pnpm --filter "@norges-domstoler/dds-design-tokens" add -D style-dictionary
+```
+
+### Generere variabler
+
+Designansvarlig i team Elsa oppdaterer tokens i Figma; dette vil generere en PR via integrasjon med GitHub. Videre skal man dra branchen lokalt og bygge styling-variabler i CSS, SCSS og TS.
+
+Bygg tokens fra `packages/dds-tokens/dds`:
+
+```Shell
+node build.js
+```
+
+Genererte variabler ligger i `dds/build` organisert etter plattform.
+
+## Release notes
+
+Når du er ferdig med PR, legg til [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md):
+
+```Shell
+pnpm changeset
+```
+
+Velg pakke(r) som ble endret, velg riktig [semver](https://semver.org/) bump, og skriv changelog entry for neste release. Skriv gjerne flere entries ved behov, og bruk Markdown slik at det er tydelig hva du refererer til.
+
+Til slutt setter du team Elsa som reviewer.
+
+## Publisering
+
+> **OBS!** Publisering blir gjort av team Elsa.
+
+Alle pakker i repoet publiseres samtidig ved å merge "Version Packages" PR.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elsa - Domstolenes designsystem
 
-![GitHub License](https://img.shields.io/github/license/domstolene/designsystem) ![GitHub branch check runs](https://img.shields.io/github/check-runs/domstolene/designsystem/main) ![Checks](https://github.com/domstolene/designsystem/actions/workflows/release.yml/badge.svg) ![Static Badge](https://img.shields.io/badge/Slack-%23designsystemet-elsa?logo=slack&link=https%3A%2F%2Fdomstoladm.slack.com%2Farchives%2FC01HNLSPTT9)
+![GitHub License](https://img.shields.io/github/license/domstolene/designsystem) ![GitHub branch check runs](https://img.shields.io/github/check-runs/domstolene/designsystem/main) ![Checks](https://github.com/domstolene/designsystem/actions/workflows/release.yml/badge.svg) [![Static Badge](https://img.shields.io/badge/Slack-%23designsystemet--elsa-611F69?logo=slack)](https://domstoladm.slack.com/archives/C01HNLSPTT9)
 
 Elsa er Domstolenes offisielle designsystem. Det består av design i Figma, [dokumentasjon](https://design.domstol.no/) og dette monorepoet.
 

--- a/README.md
+++ b/README.md
@@ -1,85 +1,24 @@
 # Elsa - Domstolenes designsystem
 
+![GitHub License](https://img.shields.io/github/license/domstolene/designsystem) ![GitHub branch check runs](https://img.shields.io/github/check-runs/domstolene/designsystem/main) ![Checks](https://github.com/domstolene/designsystem/actions/workflows/release.yml/badge.svg) ![Static Badge](https://img.shields.io/badge/Slack-%23designsystemet-elsa?logo=slack&link=https%3A%2F%2Fdomstoladm.slack.com%2Farchives%2FC01HNLSPTT9)
+
 Elsa er Domstolenes offisielle designsystem. Det består av design i Figma, [dokumentasjon](https://design.domstol.no/) og dette monorepoet.
 
 I koden brukes prefikset `dds` for å spesifisere assosiasjon med designsystemet.
 
-## 📚 Innhold i monorepo
+## 📚 Pakker i monorepo
 
-🪑 [Komponenter](packages/components/README.md)
-
-🎨 [Design tokens](packages/tokens/README.md)
-
-📕 [Formatering](packages/formatting/README.md)
-
-🔧 [Dev utils](packages/development-utils/README.md)
-
-🐚 [App shell](packages/app-shell/README.md) (deprecated)
+- 🪑 [dds-components](packages/dds-components/README.md)
+- 🎨 [dds-design-tokens](packages/dds-tokens/README.md)
+- 📕 [dds-formatting](packages/dds-formatting/README.md)
+- 🔧 [development-utils](packages/development-utils/README.md)
+- 🐚 [app-shell](packages/app-shell/README.md) (deprecated, kopier `<AppShell>` inn i kodebasen din hvis du bruker denne)
 
 ## 🏬 Storefront
 
-📖 [Elsa - dokumentasjon](https://design.domstol.no/)
+- 📖 [Elsa - dokumentasjon](https://design.domstol.no/)
+- 🖼️ [Elsa Storybook](https://domstolene.github.io/designsystem/)
 
 ## 🤝 Bidra
 
-Team Elsa setter pris på all bidrag. Les hvordan bidra i [guiden for bidragsytere](https://design.domstol.no/987b33f71/p/34c962-hvordan-bidra/b/603442).
-
-### 🧑‍💻 Utvikling
-
-> Vi anbefaler å installere [Volta](https://volta.sh/) for versjonshåndtering av Node.js og pnpm.
-> Volta vil automatisk installere riktig versjon av Node.js og pnpm når du jobber med designsystemet.
-> Siden Volta kun har eksperimentell støtte for pnpm må du legge til `VOLTA_FEATURE_PNPM=1` i miljøvariabler (Windows), eller `.bashrc`, `.zshrc` eller tilsvarende (Linux/Mac).
-> Se [https://docs.volta.sh/advanced/pnpm](https://docs.volta.sh/advanced/pnpm) for mer informasjon.
-
-Installer avhengigheter
-
-```bash
-pnpm install
-```
-
-Start opp utviklingsmiljøet
-
-```bash
-pnpm dev
-```
-
-Start opp storybook
-
-```bash
-pnpm storybook
-```
-
-#### Linking
-
-Hvis du vil teste endringer i Elsa live i applikasjonen din kan du bruke `npm link`.
-
-```bash
-cd ~/designsystem/packages/pakke # velg pakke
-npm link
-cd ~/din-app
-npm link pakke
-```
-
-#### Finner ikke `@norges-domstoler\dds-design-tokens`
-
-Skal ikke egentlig være nødvendig, men hvis du får en feilmeldinger om at den ikke finner `@norges-domstoler\dds-design-tokens` kan du prøve:
-
-```bash
-pnpm build
-```
-
-#### Legge til change notes
-
-Når du er ferdig med PR, legg til [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md):
-
-```bash
-pnpm changeset
-```
-
-Velg pakke(r) som ble endret, velg riktig semver bump type, og skriv changelog entry for neste release. Skriv gjerne flere entries ved behov.
-
-#### Publisering
-
-Ny versjon av alle pakker i repoet publiseres samtidig ved å merge "Version Packages" PR.
-
-**OBS!** Publisering blir gjort av Elsa-teamet.
+Team Elsa setter pris på alle bidrag! Se [CONTRIBUTING.md](CONTRIBUTING.md) for å komme i gang.

--- a/packages/app-shell/README.md
+++ b/packages/app-shell/README.md
@@ -1,6 +1,6 @@
 # @norges-domstoler/app-shell
 
-![Version](https://img.shields.io/npm/v/@norges-domstoler/app-shell) [![License](https://img.shields.io/npm/l/@norges-domstoler/app-shell)](https://www.npmjs.com/package/@norges-domstoler/app-shell) ![Checks](https://github.com/domstolene/designsystem/actions/workflows/release.yml/badge.svg)
+![Static badge](https://img.shields.io/badge/status-deprecated-red) [![Version](https://img.shields.io/npm/v/@norges-domstoler/app-shell)](https://www.npmjs.com/package/@norges-domstoler/app-shell) ![License](https://img.shields.io/npm/l/@norges-domstoler/app-shell)
 
 AppShell for bruk i utvikling av applikasjoner til Norges Domstoler. Dette er en standard wrapper for en Lovisa-applikasjon.
 

--- a/packages/dds-components/README.md
+++ b/packages/dds-components/README.md
@@ -1,6 +1,6 @@
 # @norges-domstoler/dds-components
 
-![Version](https://img.shields.io/npm/v/@norges-domstoler/dds-components)
+[![Version](https://img.shields.io/npm/v/@norges-domstoler/dds-components)](https://www.npmjs.com/package/@norges-domstoler/dds-components) ![License](https://img.shields.io/npm/l/@norges-domstoler/dds-components)
 
 React UI komponenter til bruk i domstolenes tjenester.
 

--- a/packages/dds-components/README.md
+++ b/packages/dds-components/README.md
@@ -1,10 +1,10 @@
 # @norges-domstoler/dds-components
 
-![Version](https://img.shields.io/npm/v/@norges-domstoler/dds-components) [![License](https://img.shields.io/npm/l/@norges-domstoler/dds-components)](https://www.npmjs.com/package/@norges-domstoler/dds-components) ![Checks](https://github.com/domstolene/designsystem/actions/workflows/release.yml/badge.svg)
+![Version](https://img.shields.io/npm/v/@norges-domstoler/dds-components)
 
 React UI komponenter til bruk i domstolenes tjenester.
 
-Sjekk ut [Elsa - domstolenes designsystem](https://design.domstol.no/) og [Elsa Storybook](https://domstolene.github.io/designsystem) for mer dokumentasjon og demoer.
+Sjekk ut [Elsa - domstolenes designsystem](https://design.domstol.no/) og [Elsa Storybook](https://domstolene.github.io/designsystem) for dokumentasjon og demoer.
 
 ## 📦 Installasjon
 

--- a/packages/dds-formatting/README.md
+++ b/packages/dds-formatting/README.md
@@ -1,10 +1,10 @@
 # @norges-domstoler/dds-formatting
 
-![Version](https://img.shields.io/npm/v/@norges-domstoler/dds-formatting) [![License](https://img.shields.io/npm/l/@norges-domstoler/dds-formatting)](https://www.npmjs.com/package/@norges-domstoler/dds-formatting) ![Checks](https://github.com/domstolene/designsystem/actions/workflows/release.yml/badge.svg)
+[![Version](https://img.shields.io/npm/v/@norges-domstoler/dds-formatting)](https://www.npmjs.com/package/@norges-domstoler/dds-formatting) ![License](https://img.shields.io/npm/l/@norges-domstoler/dds-formatting)
 
 Tekstformatering til bruk i domstolenes tjenester.
 
-Sjekk ut [Elsa - domstolenes designsystem](https://design.domstol.no/) og [ Elsa Storybook](https://domstolene.github.io/designsystem) for mer dokumentasjon og demoer.
+Sjekk ut [Elsa - domstolenes designsystem](https://design.domstol.no/) og [ Elsa Storybook](https://domstolene.github.io/designsystem) for dokumentasjon og demoer.
 
 ## 📦 Installasjon
 

--- a/packages/dds-tokens/README.md
+++ b/packages/dds-tokens/README.md
@@ -2,32 +2,21 @@
 
 [![Version](https://img.shields.io/npm/v/@norges-domstoler/dds-design-tokens)](https://www.npmjs.com/package/@norges-domstoler/dds-design-tokens)
 
-Biblioteket inneholder design tokens brukt i [Elsa - domstolenes designsystem](https://design.domstol.no/): farger, typografi, avstander, grid, brekkpunker, størrelser, broder-radius og skygger. Design tokens kan brukes i domstolenes tjenester i bl.a. global styling og custom elementer. Ellers er det obligatorisk å bruke komponentbiblioteket [dds-components](https://www.npmjs.com/package/@norges-domstoler/dds-components).
+Biblioteket inneholder design tokens brukt i [Elsa - domstolenes designsystem](https://design.domstol.no/): farger, typografi, osv. Design tokens kan brukes i domstolenes tjenester i bl.a. global styling og custom elementer. Ellers er det obligatorisk å bruke komponentbiblioteket [dds-components](https://www.npmjs.com/package/@norges-domstoler/dds-components) i domstolenes applikasjoner.
 
 Design tokens kommer i to temaer: Core og Public. Valg av tema styres med `<ThemeProvider>` komponent som ligger i `dds-components`.
 
-Les mer om [design tokens i dokumentasjonen](https://design.domstol.no/987b33f71/p/50f2cd-design-tokens).
-
 ## 🔍 Oversikt
+
+> 💡 Se alle tokens i [Elsa Storybook](https://domstolene.github.io/designsystem/?path=/story/dds-design-tokens-tokens).
 
 Design tokens består av base-tokens og semantiske tokens.
 
 Base-tokens er variabler genererte fra Figma styles og tilsvarer identiteten til domstolene definert i designprofilen.
 
-Tanken med semantiske tokens er å innbake i navnet hva token brukes til og kunne benytte seg av temaer. Semantiske tokens bruker base-tokens til å definere logikk for hvordan base-tokens skal brukes videre i komponenter og andre elementer. F.eks., semantiske tokens kan spesifisere hva fokusfargen skal være, eller font og farger for knapper.
+Semantiske tokens har innbakt i navnet hva token brukes til, samt tillater bruk av temaer. De refererer til base-tokens og definerer logikk for deres bruk i komponenter og andre elementer. F.eks., semantiske tokens kan spesifisere fokusfargen, eller font og farger for knapper.
 
 Enkelte typer tokens er tilgjengelige kun i base-variant, da de brukes i ulike kontekster og ikke har snevret bruksområde. Dette inkluderer avstander, brekkpunkter og skygger.
-
-### 📃 Tilgjengelige tokens
-
-- border-radius
-- breakpoint
-- color
-- font
-- grid
-- icon-size
-- shadow
-- spacing
 
 ## 📦 Installasjon
 
@@ -89,7 +78,7 @@ const App = () => (
 
 ### SCSS
 
-SCSS-variabler refererer til CSS-variabler; theming skjer dermed utenfor SCSS og du kan importere .
+SCSS-variabler refererer til CSS-variabler; theming skjer dermed utenfor SCSS. Dermed trenger du å importere både `index.css` fra dds-components og `_ddsTokens.scss`.
 
 ```scss
 /* _styles.scss */
@@ -113,27 +102,3 @@ const App = () => (
   </ThemeProvider>
 );
 ```
-
-## ⌨️ For bidragsytere
-
-Bilioteket ligger under `packages/tokens`. Selve design tokens ligger i JSON-filer hentet fra Figma.
-
-### Installasjon
-
-Installer style-dictionary:
-
-```
-pnpm --filter "@norges-domstoler/dds-design-tokens" add -D style-dictionary
-```
-
-### Generere variabler fra design tokens
-
-Biblioteket bruker [Style-dictionary](https://amzn.github.io/style-dictionary) for å generere JS-konstanter, CSS-variabler og SCSS-variabler fra en eller flere JSON-filer. JSON-filen(e) ligger i `dds/properties`. For å generere variabler fra JSON kjør følgende kommando fra `/dds`:
-
-```
-node build.js
-```
-
-Genererte variabler ligger i `dds/build` organisert etter plattform.
-
-Vi bruker custom build, den ligger i `/dds/build.js`.

--- a/packages/dds-tokens/README.md
+++ b/packages/dds-tokens/README.md
@@ -1,6 +1,6 @@
 # @norges-domstoler/dds-design-tokens
 
-[![Version](https://img.shields.io/npm/v/@norges-domstoler/dds-design-tokens)](https://www.npmjs.com/package/@norges-domstoler/dds-design-tokens)
+[![Version](https://img.shields.io/npm/v/@norges-domstoler/dds-design-tokens)](https://www.npmjs.com/package/@norges-domstoler/dds-design-tokens) ![License](https://img.shields.io/npm/l/@norges-domstoler/dds-design-tokens)
 
 Biblioteket inneholder design tokens brukt i [Elsa - domstolenes designsystem](https://design.domstol.no/): farger, typografi, osv. Design tokens kan brukes i domstolenes tjenester i bl.a. global styling og custom elementer. Ellers er det obligatorisk å bruke komponentbiblioteket [dds-components](https://www.npmjs.com/package/@norges-domstoler/dds-components) i domstolenes applikasjoner.
 

--- a/packages/development-utils/README.md
+++ b/packages/development-utils/README.md
@@ -1,10 +1,10 @@
 # @norges-domstoler/development-utils
 
-![Version](https://img.shields.io/npm/v/@norges-domstoler/development-utils) [![License](https://img.shields.io/npm/l/@norges-domstoler/development-utils)](https://www.npmjs.com/package/@norges-domstoler/development-utils) ![Checks](https://github.com/domstolene/designsystem/actions/workflows/release.yml/badge.svg)
+[![Version](https://img.shields.io/npm/v/@norges-domstoler/development-utils)](https://www.npmjs.com/package/@norges-domstoler/development-utils) ![License](https://img.shields.io/npm/l/@norges-domstoler/development-utils)
 
 Forskjellige utilities for bruk i utvikling av applikasjoner til Norges Domstoler.
 
-Sjekk ut [Elsa - domstolenes designsystem](https://design.domstol.no/) og [Elsa Storybook](https://domstolene.github.io/designsystem) for mer dokumentasjon og demoer.
+Sjekk ut [Elsa - domstolenes designsystem](https://design.domstol.no/) og [Elsa Storybook](https://domstolene.github.io/designsystem) for dokumentasjon og demoer.
 
 ## 📦 Installasjon
 


### PR DESCRIPTION
Flytter all dokumentasjon som har med bidrag å gjøre fra design.domstol.no og `README.md` til `CONTRIBUTING.md`. Siden Zeroheight kan ha embedded .md-filer fra GitHub vil jeg legge den nye filen inn der vi hadde dokumentasjonen originalt. Rydder litt i alle READMEs i samme slengen.