### PR TITLE
ELSA1-542 Fikser Popover som legger seg i hjørne

### DIFF
--- a/packages/dds-components/src/components/Popover/Popover.context.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.context.tsx
@@ -1,0 +1,22 @@
+import { type Strategy } from '@floating-ui/react-dom';
+import {
+  type Dispatch,
+  type SetStateAction,
+  createContext,
+  useContext,
+} from 'react';
+
+import { type UseFloatPositionOptions } from '../../hooks';
+
+interface PopoverContextType {
+  floatStyling: { position: Strategy; top: number; left: number };
+  setFloatOptions: Dispatch<
+    SetStateAction<UseFloatPositionOptions | undefined>
+  >;
+  floatingRef: (node: HTMLElement | null) => void;
+  popoverId: string;
+}
+
+export const PopoverContext = createContext<Partial<PopoverContextType>>({});
+
+export const usePopoverContext = () => useContext(PopoverContext);

--- a/packages/dds-components/src/components/Popover/Popover.spec.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.spec.tsx
@@ -18,7 +18,7 @@ const TestComponent = () => {
   );
 };
 
-describe('<Popover />', () => {
+describe('<Popover>', () => {
   it('should have aria-controls attribute on trigger element', () => {
     render(<TestComponent />);
     const triggerElement = screen.getByRole('button');
@@ -137,5 +137,16 @@ describe('<Popover />', () => {
     await waitFor(() => {
       expect(elQuery).not.toBeInTheDocument();
     });
+  });
+
+  it('Anchor should get focus on open and Esc', async () => {
+    render(<TestComponent />);
+    const triggerButton = screen.getByRole('button');
+
+    await userEvent.keyboard('[Tab]');
+    await userEvent.keyboard('[Enter]');
+    await userEvent.keyboard('[Escape]');
+
+    expect(triggerButton).toHaveFocus();
   });
 });

--- a/packages/dds-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/dds-components/src/components/Tooltip/Tooltip.tsx
@@ -143,29 +143,27 @@ export const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
         }),
     );
 
-    const containerProps = {
-      ...getBaseHTMLProps(id, cn(className, styles.container), htmlProps, rest),
-      style,
-      onMouseLeave: combineHandlers(closeTooltip, onMouseLeave),
-      onMouseOver: combineHandlers(openTooltip, onMouseOver),
-    };
-
-    const wrapperProps = {
-      id: uniqueTooltipId,
-      ref: combinedRef,
-      role: 'tooltip',
-      'aria-hidden': !open,
-      open: open && inView,
-      style: { ...positionStyles.floating },
-    };
-
     const openCn = open && inView ? 'open' : 'closed';
 
     return (
-      <div {...containerProps}>
+      <div
+        {...getBaseHTMLProps(
+          id,
+          cn(className, styles.container),
+          htmlProps,
+          rest,
+        )}
+        style={style}
+        onMouseLeave={combineHandlers(closeTooltip, onMouseLeave)}
+        onMouseOver={combineHandlers(openTooltip, onMouseOver)}
+      >
         {anchorElement}
         <Paper
-          {...wrapperProps}
+          id={uniqueTooltipId}
+          ref={combinedRef}
+          role="tooltip"
+          aria-hidden={!open}
+          style={{ ...positionStyles.floating }}
           elevation={1}
           border="subtle"
           className={cn(

--- a/packages/dds-components/src/hooks/useFloatPosition.tsx
+++ b/packages/dds-components/src/hooks/useFloatPosition.tsx
@@ -26,7 +26,7 @@ export type Placement =
   | 'left-start'
   | 'left-end';
 
-interface UseFloatPositionOptions {
+export interface UseFloatPositionOptions {
   /**
    * Whether to update the position of the floating element on every animation frame if required.
    * This is optimized for performance but can still be costly.


### PR DESCRIPTION

## Beskrivelse

Team Sivil opplever at `<Popover>` lgger seg i hjørne og får floating styling på 0. Bruker samme implementasjon av `refs.setReference` som i `<Tooltip>` for å se om det hjelper. SIden komponenten er annerledes, bruker `context` for å sende riktige refs.

Rydder i `<Tooltip>` og andre filer i samme slengen.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
