### PR TITLE
ELSA1-543 Revamp av `<Popover>`-komponenten

### DIFF
--- a/.changeset/gold-cougars-collect.md
+++ b/.changeset/gold-cougars-collect.md
@@ -1,0 +1,11 @@
+---
+'@norges-domstoler/dds-components': major
+---
+
+Revamp av `<Popover>`-komponenten.
+
+- Fjerner props `onCloseButtonClick` og `onTriggerClick`, legger til `onOpen` og `onClose` i `<PopoverGroup>`. På denne måten vil konsumentene kunne legge til callbacks basert på status på `<Popover>` uten å henge seg oppi detaljer rundt implementasjonen.
+- Implementerer kontrollert tilstand. `<PopoverGroup>` kan nå ta inn `isOpen` og `setIsOpen` for bli kontrollert av konsumenten; hvis de ikke settes brukes intern håndtering. Legger også til `isInitiallyOpen`, som forteller om `<Popover>` vises på første render. Propen var tidligere kalt `isOpen`, så nå skiller vi mellom initial og kontrollert tilstand.
+- Bytter navn på `title` prop til `header` i `<Popover>`. Det er mer riktig, og i tillegg unngår vi forvirring der en konsument kan tro at vi mener native HTML `title`.
+- Fjerner props fra `<Popover>` som ble satt av forelder: `isOpen`, `anchorElement`, `onClose`, og implementerer React Context istedet. Vi unngår dermed rotet med props konsumenter ikke "får lov" til å sette.
+- Fjerner `onCloseButtonClick` fra `<Popover>`. Vi dropper støtte for callback på så detaljert oppførsel; det erstattes med `onOpen` og `onClose` i `<PopoverGroup>`.

--- a/.changeset/gold-cougars-collect.md
+++ b/.changeset/gold-cougars-collect.md
@@ -5,7 +5,7 @@
 Revamp av `<Popover>`-komponenten.
 
 - Fjerner props `onCloseButtonClick` og `onTriggerClick`, legger til `onOpen` og `onClose` i `<PopoverGroup>`. På denne måten vil konsumentene kunne legge til callbacks basert på status på `<Popover>` uten å henge seg oppi detaljer rundt implementasjonen.
-- Implementerer kontrollert tilstand. `<PopoverGroup>` kan nå ta inn `isOpen` og `setIsOpen` for bli kontrollert av konsumenten; hvis de ikke settes brukes intern håndtering. Legger også til `isInitiallyOpen`, som forteller om `<Popover>` vises på første render. Propen var tidligere kalt `isOpen`, så nå skiller vi mellom initial og kontrollert tilstand.
+- Implementerer kontrollert tilstand. `<PopoverGroup>` kan nå ta inn `isOpen` og `setIsOpen` for å bli kontrollert av konsumenten; hvis de ikke settes brukes intern håndtering. Legger også til `isInitiallyOpen`, som forteller om `<Popover>` vises på første render. Propen var tidligere kalt `isOpen`, så nå skiller vi mellom initial og kontrollert tilstand.
 - Bytter navn på `title` prop til `header` i `<Popover>`. Det er mer riktig, og i tillegg unngår vi forvirring der en konsument kan tro at vi mener native HTML `title`.
 - Fjerner props fra `<Popover>` som ble satt av forelder: `isOpen`, `anchorElement`, `onClose`, og implementerer React Context istedet. Vi unngår dermed rotet med props konsumenter ikke "får lov" til å sette.
 - Fjerner `onCloseButtonClick` fra `<Popover>`. Vi dropper støtte for callback på så detaljert oppførsel; det erstattes med `onOpen` og `onClose` i `<PopoverGroup>`.

--- a/packages/dds-components/src/components/Popover/Popover.context.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.context.tsx
@@ -15,6 +15,9 @@ interface PopoverContextType {
   >;
   floatingRef: (node: HTMLElement | null) => void;
   popoverId: string;
+  anchorEl: HTMLElement;
+  onClose: () => void;
+  isOpen: boolean;
 }
 
 export const PopoverContext = createContext<Partial<PopoverContextType>>({});

--- a/packages/dds-components/src/components/Popover/Popover.mdx
+++ b/packages/dds-components/src/components/Popover/Popover.mdx
@@ -21,7 +21,7 @@ import * as PopoverStories from './Popover.stories';
 Komponenten består av tre elementer:
 
 - **`<Popover>`** - en komponent som dukker opp via museklikk på anchor-elementet.
-- **Anchor-element**, som er også et trigger-element. Et valgfritt interaktivt element, typisk en knapp, som åpner og lukker popover. Elementet får attributtene `onClick`, `ref`, `aria-haspopup` og `aria-controls` fra `<PopoverGroup>`.
+- **Anchor-element**, som er også et trigger-element. Et valgfritt interaktivt element, typisk en knapp, som åpner og lukker popover. Elementet får attributtene `onClick`, `ref`, `aria-haspopup` og `aria-controls` fra `<PopoverGroup>`; hvis disse attributter settes direkte på elementet blir de overskrevet.
 - **`<PopoverGroup>`** - wrapper for to barn: anchor-element `<Popover>`. Den håndterer oppførsel og universell utforming.
 
 ## Props

--- a/packages/dds-components/src/components/Popover/Popover.module.css
+++ b/packages/dds-components/src/components/Popover/Popover.module.css
@@ -6,11 +6,11 @@
     var(--dds-spacing-x1-5) var(--dds-spacing-x1);
 }
 
-.content--closable--no-title {
+.content--closable--no-header {
   margin-top: var(--dds-spacing-x2);
 }
 
-.title {
+.header {
   margin-right: var(--dds-spacing-x2);
 }
 

--- a/packages/dds-components/src/components/Popover/Popover.spec.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.spec.tsx
@@ -49,20 +49,20 @@ describe('<Popover>', () => {
     expect(popover).toBeInTheDocument();
   });
 
-  it('should render title when opened', async () => {
-    const title = 'title';
+  it('should render header when opened', async () => {
+    const header = 'header';
     render(
       <PopoverGroup>
         <Button>{buttonLabel}</Button>
-        <Popover title={title} />
+        <Popover header={header} />
       </PopoverGroup>,
     );
     const button = screen.getByText(buttonLabel);
 
     await userEvent.click(button);
 
-    const titleElement = screen.getByText(title);
-    expect(titleElement).toBeInTheDocument();
+    const headerElement = screen.getByText(header);
+    expect(headerElement).toBeInTheDocument();
   });
 
   it('should render content when opened', async () => {
@@ -94,31 +94,30 @@ describe('<Popover>', () => {
     });
   });
 
-  it('should run onclick event for closing button', async () => {
+  it('should run onOpen event', async () => {
     const event = vi.fn();
     render(
-      <PopoverGroup isOpen onCloseButtonClick={event}>
-        <Button />
-        <Popover withCloseButton />
-      </PopoverGroup>,
-    );
-
-    const closeButton = screen.getAllByRole('button')[1];
-
-    await userEvent.click(closeButton);
-
-    expect(event).toHaveBeenCalled();
-  });
-
-  it('should run onclick event for trigger element', async () => {
-    const event = vi.fn();
-    render(
-      <PopoverGroup onTriggerClick={event}>
+      <PopoverGroup onOpen={event}>
         <Button />
         <Popover />
       </PopoverGroup>,
     );
     const triggerButton = screen.getByRole('button');
+    await userEvent.click(triggerButton);
+    expect(event).toHaveBeenCalled();
+  });
+
+  it('should run onClose event', async () => {
+    const event = vi.fn();
+    render(
+      <PopoverGroup onClose={event}>
+        <Button />
+        <Popover />
+      </PopoverGroup>,
+    );
+    const triggerButton = screen.getByRole('button');
+    await userEvent.click(triggerButton);
+    expect(event).not.toHaveBeenCalled();
     await userEvent.click(triggerButton);
     expect(event).toHaveBeenCalled();
   });

--- a/packages/dds-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.stories.tsx
@@ -1,4 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react';
+import { useState } from 'react';
 
 import { type Placement } from '../../hooks';
 import { Button } from '../Button';
@@ -15,16 +16,16 @@ export default {
   argTypes: {
     withCloseButton: { control: 'boolean' },
     placement: { control: 'text' },
-    title: { control: 'text' },
+    header: { control: 'text' },
     offset: { control: 'number' },
+    returnFocusOnBlur: { control: 'boolean' },
     htmlProps: { control: false },
     sizeProps: { control: false },
-    anchorElement: { control: false },
   },
   parameters: {
     docs: {
       story: { inline: true, height: '300px' },
-      canvas: { sourceState: 'hidden' },
+      canvas: { sourceState: 'shown' },
     },
   },
 } satisfies Meta<typeof Popover>;
@@ -56,7 +57,7 @@ export const ContentOverview: Story = {
       <div>
         <PopoverGroup>
           <Button>Åpne</Button>
-          <Popover {...args} title="Tittel">
+          <Popover {...args} header="Tittel">
             <VStack align="start">
               <Paragraph withMargins>
                 Dette er en popover med tittel, innhold og lukkeknapp
@@ -69,7 +70,7 @@ export const ContentOverview: Story = {
       <div>
         <PopoverGroup>
           <Button>Åpne</Button>
-          <Popover {...args} title="Tittel" withCloseButton={false}>
+          <Popover {...args} header="Tittel" withCloseButton={false}>
             <VStack align="start">
               <Paragraph withMargins>
                 Dette er en popover med tittel og innhold
@@ -136,6 +137,54 @@ export const PlacementOverview: Story = {
   },
 };
 
+export const Controlled: Story = {
+  render: args => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <VStack>
+        åpen: {isOpen.toString()}
+        <PopoverGroup isOpen={isOpen} setIsOpen={setIsOpen}>
+          <Button>Åpne</Button>
+          <Popover {...args}>
+            <VStack align="start">
+              <Paragraph withMargins>
+                Dette er en popover med tekst og knapp
+              </Paragraph>
+              <Button>Klikk</Button>
+            </VStack>
+          </Popover>
+        </PopoverGroup>
+      </VStack>
+    );
+  },
+};
+
+export const WithOnOpenAndOnClose: Story = {
+  render: args => {
+    const [text, setText] = useState('aktiver Popover');
+    const onOpen = () => setText('Popover ble åpnet');
+    const onClose = () => setText('Popover ble lukket');
+
+    return (
+      <VStack>
+        {text}
+        <PopoverGroup onClose={onClose} onOpen={onOpen}>
+          <Button>Åpne</Button>
+          <Popover {...args}>
+            <VStack align="start">
+              <Paragraph withMargins>
+                Dette er en popover med tekst og knapp
+              </Paragraph>
+              <Button>Klikk</Button>
+            </VStack>
+          </Popover>
+        </PopoverGroup>
+      </VStack>
+    );
+  },
+};
+
 export const Overflow: Story = {
   render: args => (
     <PopoverGroup>
@@ -169,7 +218,7 @@ export const InlineExample: Story = {
         en redegjørelse fra{' '}
         <PopoverGroup>
           <InlineButton>advokatene</InlineButton>
-          <Popover {...args} title="Advokat">
+          <Popover {...args} header="Advokat">
             <Paragraph withMargins>Dette er en definisjon</Paragraph>
           </Popover>
         </PopoverGroup>{' '}

--- a/packages/dds-components/src/components/Popover/PopoverGroup.tsx
+++ b/packages/dds-components/src/components/Popover/PopoverGroup.tsx
@@ -1,7 +1,9 @@
 import {
+  type Dispatch,
   Children as ReactChildren,
   type ReactElement,
   type ReactNode,
+  type SetStateAction,
   cloneElement,
   isValidElement,
   useId,
@@ -14,58 +16,86 @@ import {
   type UseFloatPositionOptions,
   useCombinedRef,
   useFloatPosition,
+  useOnClickOutside,
   useOnKeyDown,
 } from '../../hooks';
 
 export interface PopoverGroupProps {
-  /**Callback når det trykkes på lukkeknappen. */
-  onCloseButtonClick?: () => void;
-  /** Callback når det trykkes på anchor-elementet (trigger-elementet). */
-  onTriggerClick?: () => void;
-  /**Forteller `<Popover>` om den skal være åpen.  */
-  isOpen?: boolean;
-  /** `id` til `<Popover>.` */
-  popoverId?: string;
   /** Barna til wrapperen: anchor-element som det første og `<Popover>` som det andre.  */
   children: ReactNode;
+  /**Forteller `<Popover>` om den skal være åpen på første render.  */
+  isInitiallyOpen?: boolean;
+  /**Implementerer kontrollert tilstand: forteller `<Popover>` om den skal være åpen.  */
+  isOpen?: boolean;
+  /**Implementerer kontrollert tilstand: funksjon for å kontrollere `isOpen`.  */
+  setIsOpen?: Dispatch<SetStateAction<boolean>>;
+  /**Callback når <Popover> åpnes. */
+  onOpen?: () => void;
+  /**Callback når <Popover> lukkes. */
+  onClose?: () => void;
+  /** `id` til `<Popover>.` */
+  popoverId?: string;
 }
 
 export const PopoverGroup = ({
-  isOpen = false,
-  onCloseButtonClick,
-  onTriggerClick,
+  isOpen: propIsOpen,
+  setIsOpen: propSetIsOpen,
+  onClose,
+  onOpen,
+  isInitiallyOpen = false,
   children,
   popoverId,
 }: PopoverGroupProps) => {
-  const [open, setOpen] = useState(isOpen);
+  const [internalIsOpen, internalSetIsOpen] = useState(isInitiallyOpen);
+
+  const open = propIsOpen ?? internalIsOpen;
+  const setOpen = propSetIsOpen ?? internalSetIsOpen;
 
   const generatedId = useId();
   const uniquePopoverId = popoverId ?? `${generatedId}-popover`;
   const [floatOptions, setFloatOptions] = useState<UseFloatPositionOptions>();
   const { refs, styles: positionStyles } = useFloatPosition(null, floatOptions);
 
-  const handleOnCloseButtonClick = () => {
+  const handleClose = () => {
     setOpen(false);
-    onCloseButtonClick && onCloseButtonClick();
+    onClose && onClose();
   };
 
-  const handleOnTriggerClick = () => {
-    setOpen(!open);
-    onTriggerClick && onTriggerClick();
+  const handleOpen = () => {
+    setOpen(true);
+    onOpen && onOpen();
+  };
+
+  const handleToggle = () => {
+    if (open) {
+      handleClose();
+    } else {
+      handleOpen();
+    }
   };
 
   const buttonRef = useRef<HTMLElement>(null);
   const anchorRef = refs.setReference;
-  const combinedRef = useCombinedRef(buttonRef, anchorRef);
+  const combinedAnchorRef = useCombinedRef(buttonRef, anchorRef);
+
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const floatingRef = refs.setFloating;
+  const combinedPopoverRef = useCombinedRef(popoverRef, floatingRef);
 
   useOnKeyDown(['Esc', 'Escape'], () => {
     if (open) {
-      setOpen(false);
+      handleClose();
       buttonRef.current?.focus();
     }
   });
 
-  const handleClose = () => setOpen(false);
+  const elements: Array<HTMLElement | null> = [popoverRef.current!];
+  if (buttonRef.current) elements.push(buttonRef.current);
+
+  useOnClickOutside(elements, () => {
+    if (open) handleClose();
+  });
+
   const isAnchorChild = (i: number): boolean => i === 0;
 
   const Children = ReactChildren.map(children, (child, childIndex) => {
@@ -76,16 +106,10 @@ export const PopoverGroup = ({
             'aria-haspopup': 'dialog',
             'aria-controls': uniquePopoverId,
             'aria-expanded': open,
-            onClick: handleOnTriggerClick,
-            ref: combinedRef,
+            onClick: handleToggle,
+            ref: combinedAnchorRef,
           })
-        : cloneElement(child as ReactElement, {
-            isOpen: open,
-            'aria-hidden': !open,
-            onCloseButtonClick: handleOnCloseButtonClick,
-            anchorElement: buttonRef.current,
-            onClose: handleClose,
-          }))
+        : child)
     );
   });
 
@@ -94,8 +118,11 @@ export const PopoverGroup = ({
       value={{
         floatStyling: positionStyles.floating,
         setFloatOptions,
-        floatingRef: refs.setFloating,
+        floatingRef: combinedPopoverRef,
         popoverId: uniquePopoverId,
+        onClose: handleClose,
+        isOpen: open,
+        anchorEl: buttonRef.current ?? undefined,
       }}
     >
       {Children}


### PR DESCRIPTION
## Beskrivelse 

Komponenten var implementert på en utdatert måte og manglet støtte for kontrollert tilstand.

- Fjerner props `onCloseButtonClick` og `onTriggerClick`, legger til `onOpen` og `onClose` i `<PopoverGroup>`. På denne måten vil konsumentene kunne legge til callbacks basert på status på `<Popover>` uten å henge seg oppi detaljer rundt implementasjonen.
- Implementerer kontrollert tilstand. `<PopoverGroup>` kan nå ta inn `isOpen` og `setIsOpen` for bli kontrollert av konsumenten; hvis de ikke settes brukes intern håndtering. Legger også til `isInitiallyOpen`, som forteller om `<Popover>` vises på første render. Propen var tidligere kalt `isOpen`, så nå skiller vi mellom initial og kontrollert tilstand.
- Bytter navn på `title` prop til `header` i `<Popover>`. Det er mer riktig, og i tillegg unngår vi forvirring der en konsument kan tro at vi mener native HTML `title`.
- Fjerner props fra `<Popover>` som ble satt av forelder: `isOpen`, `anchorElement`, `onClose`, og implementerer React Context istedet. Vi unngår dermed rotet med props konsumenter ikke "får lov" til å sette.
- Fjerner `onCloseButtonClick` fra `<Popover>`. Vi dropper støtte for callback på så detaljert oppførsel; det erstattes med `onOpen` og `onClose` i `<PopoverGroup>`.

Skal gå gjennom andre flate-komponenter og se om de trenger en oppdatering, så kommer de ut på samme breaking.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
