### PR TITLE
ELSA1-547 Revamp av flate-komponenter

### DIFF
--- a/.changeset/friendly-insects-explode.md
+++ b/.changeset/friendly-insects-explode.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': major
+---
+
+Endrer navn på prop `title` til `headerText`, og `titleHeadingLevel` til `headerHeadingLevel` i `<EmptyContent>`. På denne måten unngår vi forvirring med nativ HTML `title` og standardiserer navngiving.

--- a/.changeset/pretty-impalas-occur.md
+++ b/.changeset/pretty-impalas-occur.md
@@ -1,0 +1,9 @@
+---
+'@norges-domstoler/dds-components': major
+---
+
+Revamp av `<OverflowMenu>`.
+
+- Fjerner prop `onToggle` i `<OverflowMenuGroup>`. Komponenten blir standardisert og bruke kun `onClose` og `onOpen`.
+- Implementerer kontrollert tilstand. `<OverflowMenuGroup>` kan nå ta inn `isOpen` og `setIsOpen` props for bli kontrollert av konsumenten; hvis de ikke settes brukes intern håndtering. Legger også til `isInitiallyOpen`, som forteller om `<OverflowMenu>` vises på første render.
+- Fjerner props fra `<OverflowMenu>` som ble satt av forelder: `isOpen`, `anchorRef`, `onClose`, `onToggle`, `id` og implementerer React Context istedet. Vi unngår dermed rotet med props konsumenter ikke "får lov" til å sette. `<OverflowMenuGroup>` er dermed obigatorisk å bruke.

--- a/.changeset/stale-cars-wave.md
+++ b/.changeset/stale-cars-wave.md
@@ -1,0 +1,8 @@
+---
+'@norges-domstoler/dds-components': major
+---
+
+Revamp av `<Drawer>`.
+
+- Implementerer kontrollert tilstand. `<DrawerGroup>` kan nå ta inn `isOpen` og `setIsOpen` props for bli kontrollert av konsumenten; hvis de ikke settes brukes intern håndtering. Legger også til `isInitiallyOpen`, som forteller om `<Drawer>` vises på første render.
+- Fjerner props fra `<Drawer>` som ble satt av forelder: `isOpen`, `triggerRef`, `onClose`, `id` og implementerer React Context istedet. Vi unngår dermed rotet med props konsumenter ikke "får lov" til å sette. `<DrawerGroup>` er dermed obigatorisk å bruke.

--- a/packages/dds-components/src/components/Drawer/Drawer.context.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.context.tsx
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+
+interface DrawerContextType {
+  drawerId: string;
+  triggerEl: HTMLElement | null;
+  onClose: () => void;
+  isOpen: boolean;
+}
+
+export const DrawerContext = createContext<Partial<DrawerContextType>>({});
+
+export const useDrawerContext = () => useContext(DrawerContext);

--- a/packages/dds-components/src/components/Drawer/Drawer.mdx
+++ b/packages/dds-components/src/components/Drawer/Drawer.mdx
@@ -20,22 +20,24 @@ import * as DrawerStories from './Drawer.stories';
 
 Drawer bygges med følgende elementer:
 
-- **Trigger-element**: styrer en drawer, er typisk en knapp.
-- **`<Drawer>`**: er en komponent som vises når et trigger-element interageres med, vanligvis en knapp. `<Drawer>` kan ha valgfritt innhold.
-- **`<DrawerGroup>`**: håndterer lukking og åpning og gir både `<Drawer>` og trigger-elementet ARIA-attributter. Den skal ha trigger-elementet som første barn og `<Drawer>` som andre barn. Subkomponenten er valgfri å bruke. Hvis den ikke brukes må oppførsel, referanser og ARIA-attributter håndteres utenfor komponentene på eget ansvar.
+- **`<Drawer>`**: er en komponent som vises når et trigger-element interageres med. `<Drawer>` kan ha valgfritt innhold.
+- **Trigger-element**: valgrfritt element som styrer `<Drawer>`, typisk en knapp.
+- **`<DrawerGroup>`**: håndterer lukking/åpning og universell utforming. Den skal ha trigger-elementet som første barn og `<Drawer>` som andre barn.
 
 ## Props
 
 ### Drawer
 
-Hovedkomponenten.
+Hovedkomponenten. Den kan brukes kontrollert eller ikke kontrollert.
+
+**OBS!** Støtter ikke `id`; se [DrawerGroup](#drawergroup).
 
 <Canvas of={DrawerStories.Default} sourceState="shown" />
 <Controls of={DrawerStories.Default} />
 
 ### DrawerGroup
 
-En wrapper som håndterer åpning, lukking, ARIA og refs for trigger-elementet og `<Drawer>` ut av boksen. Den skal ha trigger-elementet som første barn og `<Drawer>` som andre barn. Valgfri å bruke.
+En wrapper som håndterer åpning, lukking, ARIA og refs ut av boksen. Den skal ha trigger-elementet som første barn og `<Drawer>` som andre barn. Obligatorisk å bruke.
 
 <ArgTypes of={DrawerGroup} />
 
@@ -51,35 +53,35 @@ import { Drawer, DrawerGroup, Button } from '@norges-domstoler/dds-components';
 </DrawerGroup>
 `} />
 
-### Uten `<DrawerGroup>`
+### Callbacks
 
 <Source
   code={`
-import { Drawer, Button } from '@norges-domstoler/dds-components';
-import { useState, useRef } from 'react';
+import { Drawer, DrawerGroup, Button } from '@norges-domstoler/dds-components';
 
-const [closed, setClosed] = useState(true);
-const show = () => setClosed(false);
-const close = () => setClosed(true);
-const buttonRef = useRef(null);
-const id = 'id';
+const onClose = () => {
+//din kode
+};
+const onOpen = () => {
+//din kode
+};
 
-<Button
-  onClick={show}
-  ref={buttonRef}
-  aria-expanded={!closed}
-  aria-controls={id}
-  aria-haspopup="dialog"
->
-  Åpne
-</Button>
-<Drawer
-  header="Tittel"
-  id={id}
-  triggerRef={buttonRef}
-  isOpen={!closed}
-  onClose={onClose}
->
-  Innhold
-</Drawer>
+<DrawerGroup onClose={onClose} onOpen={onOpen}>
+  <Button>Åpne</Button>
+  <Drawer header="Tittel">Innhold</Drawer>
+</DrawerGroup>
+`} />
+
+### Kontrollert
+
+<Source
+  code={`
+import { Drawer, DrawerGroup, Button } from '@norges-domstoler/dds-components';
+
+const [isOpen, setIsOpen] = useState(false);
+
+<DrawerGroup isOpne={isOpen} isetIsOpen={setIsOpen}>
+  <Button>Åpne</Button>
+  <Drawer header="Tittel">Innhold</Drawer>
+</DrawerGroup>
 `} />

--- a/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
@@ -1,7 +1,9 @@
 import { type Story } from '@storybook/blocks';
 import { type Meta, type StoryObj } from '@storybook/react';
+import { useState } from 'react';
 
 import { Button } from '../Button';
+import { StoryVStack } from '../Stack/utils';
 import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
 import { Heading, Paragraph } from '../Typography';
 
@@ -17,9 +19,8 @@ const meta: Meta<typeof Drawer> = {
     },
   },
   argTypes: {
-    isOpen: { control: false },
+    withBackdrop: { control: 'boolean' },
     htmlProps: { control: false },
-    triggerRef: { control: false },
     parentElement: { control: false },
     widthProps: { control: false },
   },
@@ -174,6 +175,62 @@ export const OverviewSizes: Story = {
       </DrawerGroup>
     </>
   ),
+};
+
+export const Controlled: Story = {
+  args: { header: 'Tittel' },
+  render: args => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <StoryVStack>
+        <span>Drawer er {isOpen ? 'åpen' : 'lukket'}.</span>
+        <DrawerGroup isOpen={isOpen} setIsOpen={setIsOpen}>
+          <Button>Åpne</Button>
+          <Drawer {...args}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+            <Button>Gjør noe</Button>
+          </Drawer>
+        </DrawerGroup>
+      </StoryVStack>
+    );
+  },
+};
+
+export const WithOnCloseAndOnOpen: Story = {
+  args: { header: 'Tittel' },
+  render: args => {
+    const [text, setText] = useState('Aktiver Drawer.');
+    const onClose = () => {
+      setText('onClose ble kalt.');
+    };
+    const onOpen = () => {
+      setText('onOpen ble kalt.');
+    };
+    return (
+      <StoryVStack>
+        <span>{text}</span>
+        <DrawerGroup onClose={onClose} onOpen={onOpen}>
+          <Button>Åpne</Button>
+          <Drawer {...args}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+            aliquip ex ea commodo consequat. Duis aute irure dolor in
+            reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+            pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+            culpa qui officia deserunt mollit anim id est laborum.
+            <Button>Gjør noe</Button>
+          </Drawer>
+        </DrawerGroup>
+      </StoryVStack>
+    );
+  },
 };
 
 export const LongContent: Story = {

--- a/packages/dds-components/src/components/Drawer/Drawer.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.tsx
@@ -2,11 +2,9 @@ import { type Property } from 'csstype';
 import {
   type MouseEvent,
   type ReactNode,
-  type RefObject,
   forwardRef,
   useContext,
   useEffect,
-  useId,
   useRef,
 } from 'react';
 import { createPortal } from 'react-dom';
@@ -17,10 +15,10 @@ import {
   useFocusTrap,
   useMountTransition,
   useOnClickOutside,
-  useOnKeyDown,
 } from '../../hooks';
 import {
   type BaseComponentPropsWithChildren,
+  type Size,
   getBaseHTMLProps,
 } from '../../types';
 import { cn } from '../../utils';
@@ -36,8 +34,9 @@ import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { CloseIcon } from '../Icon/icons';
 import { ThemeContext } from '../ThemeProvider';
 import { Heading } from '../Typography';
+import { useDrawerContext } from './Drawer.context';
 
-export type DrawerSize = 'small' | 'medium' | 'large';
+export type DrawerSize = Extract<Size, 'small' | 'medium' | 'large'>;
 export type DrawerPlacement = 'left' | 'right';
 export interface WidthProps {
   minWidth?: Property.MinWidth;
@@ -45,49 +44,43 @@ export interface WidthProps {
   width?: Property.Width;
 }
 
-export type DrawerProps = BaseComponentPropsWithChildren<
-  HTMLDivElement,
-  {
-    /**Størrelsen på `<Drawer>`.
-     * @default "small"
-     */
-    size?: DrawerSize;
-    /** Plasseringen til `<Drawer>`.
-     * @default "right"
-     */
-    placement?: DrawerPlacement;
-    /**Header for `<Drawer>`. Har default styling hvis verdien er en string. */
-    header?: string | ReactNode;
-    /**Spesifiserer om `<Drawer>` vises. **OBS!** nødvendig kun hvis `<DrawerGroup>` ikke er i bruk. */
-    isOpen?: boolean;
-    /**Funksjon kjørt ved lukking. **OBS!** nødvendig kun hvis `<DrawerGroup>` ikke er i bruk. */
-    onClose?: () => void;
-    /**Spesifiserer hvilken DOM node `<Drawer>` skal ha som forelder via React portal. Brukes med f.eks `document.getElementById("id")` eller ref (skaper ikke ny DOM node).
-     * @default themeProviderRef
-     */
-    parentElement?: HTMLElement;
-    /**Custom props for breddehåndtering ved behov. */
-    widthProps?: WidthProps;
-    /**Ref til elementet som åpner `<Drawer>`.  **OBS!** nødvendig kun hvis `<DrawerGroup>` ikke er i bruk. */
-    triggerRef?: RefObject<HTMLElement>;
-    /**
-     * Om `<Drawer>` skal vises med backdrop som gråer ut bakgrunnen.
-     */
-    withBackdrop?: boolean;
-  }
+export type DrawerProps = Omit<
+  BaseComponentPropsWithChildren<
+    HTMLDivElement,
+    {
+      /**Størrelsen på `<Drawer>`.
+       * @default "small"
+       */
+      size?: DrawerSize;
+      /** Plasseringen til `<Drawer>`.
+       * @default "right"
+       */
+      placement?: DrawerPlacement;
+      /**Header for `<Drawer>`. Returnerer default `<Heading>` hvis verdien er en `string`. */
+      header?: string | ReactNode;
+      /**Spesifiserer hvilken DOM node `<Drawer>` skal ha som forelder via React portal.
+       * Brukes med f.eks `document.getElementById("id")` eller ref (skaper ikke ny DOM node).
+       * @default themeProviderRef
+       */
+      parentElement?: HTMLElement;
+      /**Custom props for breddehåndtering ved behov. */
+      widthProps?: WidthProps;
+      /**
+       * Om `<Drawer>` skal vises med backdrop som gråer ut bakgrunnen.
+       */
+      withBackdrop?: boolean;
+    }
+  >,
+  'id'
 >;
 
 export const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
   const {
     children,
-    onClose,
     header,
-    isOpen = false,
     placement = 'right',
     parentElement,
     size = 'small',
-    triggerRef,
-    id,
     className,
     htmlProps,
     widthProps,
@@ -95,20 +88,21 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
     ...rest
   } = props;
 
-  const generatedId = useId();
-  const uniqueId = id ?? `${generatedId}-drawer`;
+  const themeContext = useContext(ThemeContext);
+
+  if (!themeContext) {
+    throw new Error('Drawer must be used within a ThemeProvider');
+  }
+
+  const portalTarget = parentElement ?? themeContext?.el;
+
+  const { isOpen = false, onClose, drawerId, triggerEl } = useDrawerContext();
+
   const hasHeader = !!header;
-  const headerId = hasHeader ? `${uniqueId}-header` : undefined;
+  const headerId = hasHeader ? `${drawerId}-header` : undefined;
 
   const drawerRef = useFocusTrap<HTMLDivElement>(isOpen);
   const combinedRef = useCombinedRef(ref, drawerRef);
-
-  useOnKeyDown(['Esc', 'Escape'], () => {
-    if (isOpen) {
-      triggerRef && triggerRef.current?.focus();
-      onClose && onClose();
-    }
-  });
 
   useEffect(() => {
     if (withBackdrop) {
@@ -125,15 +119,7 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
   const elements: Array<HTMLElement | null> = [
     drawerRef.current as HTMLElement,
   ];
-  if (triggerRef) elements.push(triggerRef.current);
-
-  const themeContext = useContext(ThemeContext);
-
-  if (!themeContext) {
-    throw new Error('Drawer must be used within a ThemeProvider');
-  }
-
-  const portalTarget = parentElement ?? themeContext?.el;
+  if (triggerEl) elements.push(triggerEl);
 
   useOnClickOutside(elements, () => {
     if (isOpen && !withBackdrop) {
@@ -159,7 +145,7 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>((props, ref) => {
       role="dialog"
       tabIndex={-1}
       {...getBaseHTMLProps(
-        uniqueId,
+        drawerId,
         cn(
           className,
           styles.container,

--- a/packages/dds-components/src/components/EmptyContent/EmptyContent.spec.tsx
+++ b/packages/dds-components/src/components/EmptyContent/EmptyContent.spec.tsx
@@ -14,7 +14,7 @@ describe('<EmptyContent>', () => {
   it('should render title text', () => {
     const message = 'message';
     const title = 'title';
-    render(<EmptyContent message={message} title={title} />);
+    render(<EmptyContent message={message} headerText={title} />);
     expect(screen.getByText(title)).toBeInTheDocument();
   });
   it('should render message link', () => {

--- a/packages/dds-components/src/components/EmptyContent/EmptyContent.tsx
+++ b/packages/dds-components/src/components/EmptyContent/EmptyContent.tsx
@@ -6,28 +6,28 @@ import { Heading, type HeadingLevel, Paragraph } from '../Typography';
 
 export type EmptyContentProps = {
   /**Tittel - kort oppsummering. */
-  title?: string;
+  headerText?: string;
   /**Nivå på overskriften. Sørg for at den følger hierarkiet på siden.
    * @default 2
    */
-  titleHeadingLevel?: HeadingLevel;
+  headerHeadingLevel?: HeadingLevel;
   /**Melding - beskrivelse og forklaring på hvordan brukeren kan få innhold. Kan inneholde lenker og andre interaktive elementer. */
   message: ReactNode;
 } & HTMLAttributes<HTMLDivElement>;
 
 export function EmptyContent({
-  title,
+  headerText,
   message,
-  titleHeadingLevel = 2,
+  headerHeadingLevel = 2,
   className,
   ...rest
 }: EmptyContentProps) {
   return (
     <div {...rest} className={cn(className, styles.containter)}>
       <div className={styles.text}>
-        {title && (
-          <Heading level={titleHeadingLevel} typographyType="headingMedium">
-            {title}
+        {headerText && (
+          <Heading level={headerHeadingLevel} typographyType="headingMedium">
+            {headerText}
           </Heading>
         )}
         <Paragraph className={styles.message}>{message}</Paragraph>

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.tsx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 
 import styles from './InternalHeader.module.css';
 import { type InternalHeaderProps } from './InternalHeader.types';
@@ -14,6 +14,7 @@ import {
   OverflowMenuButton,
   type OverflowMenuButtonProps,
   OverflowMenuDivider,
+  OverflowMenuGroup,
   OverflowMenuLink,
   type OverflowMenuLinkProps,
   OverflowMenuList,
@@ -38,23 +39,14 @@ export const InternalHeader = (props: InternalHeaderProps) => {
     ...rest
   } = props;
 
-  const [contextMenuIsClosed, setContextMenuIsClosed] = useState(true);
   const [currentPage, setCurrentPage] = useState<string | undefined>(
     currentPageHref,
   );
 
-  const buttonRef = useRef<HTMLButtonElement>(null);
-
   const handleCurrentPageChange = (href: string) => {
     setCurrentPage(href);
-    onCurrentPageChange && onCurrentPageChange();
+    onCurrentPageChange?.();
   };
-
-  const handleContextMenuClick = () => {
-    setContextMenuIsClosed(!contextMenuIsClosed);
-  };
-
-  const onOveflowMenuClose = () => setContextMenuIsClosed(true);
 
   const hasNavigationElements = !!navItems && navItems.length > 0;
   const hasContextMenuElements =
@@ -142,67 +134,64 @@ export const InternalHeader = (props: InternalHeaderProps) => {
               ],
           )}
         >
-          <Button
-            ref={buttonRef}
-            icon={hasNavInContextMenu ? MenuIcon : MoreVerticalIcon}
-            purpose="tertiary"
-            onClick={handleContextMenuClick}
-            aria-haspopup="menu"
-            aria-expanded={!contextMenuIsClosed ? true : undefined}
-            aria-label="åpne meny"
-          />
-          <OverflowMenu
-            isOpen={!contextMenuIsClosed}
-            onClose={onOveflowMenuClose}
-            anchorRef={buttonRef}
-            className={styles['context-menu']}
-          >
-            {user && (
-              <OverflowMenuList>
-                {user.href ? (
-                  <OverflowMenuLink icon={PersonIcon} {...user} />
-                ) : (
-                  <OverflowMenuSpan icon={PersonIcon} {...user} />
-                )}
-              </OverflowMenuList>
-            )}
-            {hasNavInContextMenu && (
-              <nav
-                aria-label="sidenavigasjon"
-                className={cn(
-                  styles['nav--in-menu--small-screen'],
-                  styles[`nav--in-menu--small-screen-${smallScreenBreakpoint}`],
-                )}
-              >
+          <OverflowMenuGroup>
+            <Button
+              icon={hasNavInContextMenu ? MenuIcon : MoreVerticalIcon}
+              purpose="tertiary"
+              aria-label="åpne meny"
+            />
+            <OverflowMenu className={styles['context-menu']}>
+              {user && (
                 <OverflowMenuList>
-                  {navItems.map(item => (
-                    <OverflowMenuLink {...item} />
-                  ))}
-                </OverflowMenuList>
-              </nav>
-            )}
-            {hasNavInContextMenu && hasContextMenuElements && (
-              <OverflowMenuDivider
-                className={cn(
-                  styles['menu-divider'],
-                  styles[`menu-divider--small-screen-${smallScreenBreakpoint}`],
-                )}
-              />
-            )}
-            {hasContextMenuElements && (
-              <OverflowMenuList>
-                {contextMenuItems.map(item => {
-                  return item.href ? (
-                    <OverflowMenuLink {...(item as OverflowMenuLinkProps)} />
+                  {user.href ? (
+                    <OverflowMenuLink icon={PersonIcon} {...user} />
                   ) : (
-                    <OverflowMenuButton
-                      {...(item as OverflowMenuButtonProps)}
-                    />
-                  );
-                })}
-              </OverflowMenuList>
-            )}
-          </OverflowMenu>
+                    <OverflowMenuSpan icon={PersonIcon} {...user} />
+                  )}
+                </OverflowMenuList>
+              )}
+              {hasNavInContextMenu && (
+                <nav
+                  aria-label="sidenavigasjon"
+                  className={cn(
+                    styles['nav--in-menu--small-screen'],
+                    styles[
+                      `nav--in-menu--small-screen-${smallScreenBreakpoint}`
+                    ],
+                  )}
+                >
+                  <OverflowMenuList>
+                    {navItems.map(item => (
+                      <OverflowMenuLink {...item} />
+                    ))}
+                  </OverflowMenuList>
+                </nav>
+              )}
+              {hasNavInContextMenu && hasContextMenuElements && (
+                <OverflowMenuDivider
+                  className={cn(
+                    styles['menu-divider'],
+                    styles[
+                      `menu-divider--small-screen-${smallScreenBreakpoint}`
+                    ],
+                  )}
+                />
+              )}
+              {hasContextMenuElements && (
+                <OverflowMenuList>
+                  {contextMenuItems.map(item => {
+                    return item.href ? (
+                      <OverflowMenuLink {...(item as OverflowMenuLinkProps)} />
+                    ) : (
+                      <OverflowMenuButton
+                        {...(item as OverflowMenuButtonProps)}
+                      />
+                    );
+                  })}
+                </OverflowMenuList>
+              )}
+            </OverflowMenu>
+          </OverflowMenuGroup>
         </div>
       )}
     </div>

--- a/packages/dds-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/dds-components/src/components/Modal/Modal.stories.tsx
@@ -21,6 +21,8 @@ const meta: Meta<typeof Modal> = {
   argTypes: {
     header: { control: 'text' },
     parentElement: { control: false },
+    onClose: { control: false },
+    isOpen: { control: false },
     triggerRef: { control: false },
     initialFocusRef: { control: false },
     htmlProps: { control: false },
@@ -37,6 +39,7 @@ export default meta;
 type Story = StoryObj<typeof Modal>;
 
 export const Default: Story = {
+  args: { onClose: undefined },
   render: args => {
     const [closed, setClosed] = useState(true);
     const show = () => setClosed(false);
@@ -49,12 +52,7 @@ export const Default: Story = {
         <Button aria-haspopup="dialog" onClick={show} ref={buttonRef}>
           Åpne
         </Button>
-        <Modal
-          {...args}
-          triggerRef={buttonRef}
-          isOpen={!closed}
-          onClose={close}
-        >
+        <Modal {...args} triggerRef={buttonRef} isOpen={!closed}>
           <ModalBody>Modal</ModalBody>
           <ModalActions>
             <Button onClick={close}>OK</Button>
@@ -68,19 +66,14 @@ export const Default: Story = {
   },
 };
 
-export const Overview: Story = {
+export const Closable: Story = {
   args: { header: 'Tittel', onClose: undefined },
   render: args => {
     const [closed, setClosed] = useState(true);
     const show = () => setClosed(false);
     const close = () => setClosed(true);
 
-    const [closed2, setClosed2] = useState(true);
-    const show2 = () => setClosed2(false);
-    const close2 = () => setClosed2(true);
-
     const buttonRef = useRef<HTMLButtonElement>(null);
-    const buttonRef2 = useRef<HTMLButtonElement>(null);
 
     return (
       <StoryHStack>
@@ -93,23 +86,10 @@ export const Overview: Story = {
           triggerRef={buttonRef}
           onClose={close}
         >
-          <ModalBody>Lukkbar modal</ModalBody>
+          <ModalBody>Ikke lukkbar modal</ModalBody>
           <ModalActions>
             <Button onClick={close}>OK</Button>
             <Button purpose="secondary" onClick={close}>
-              Avbryt
-            </Button>
-          </ModalActions>
-        </Modal>
-        <Button aria-haspopup="dialog" onClick={show2} ref={buttonRef2}>
-          Åpne ikke lukkbar
-        </Button>
-        <Modal {...args} isOpen={!closed2} triggerRef={buttonRef2}>
-          <ModalBody>Ikke lukkbar modal</ModalBody>
-          <ModalActions>
-            <Button onClick={close2}>OK</Button>
-
-            <Button purpose="secondary" onClick={close2}>
               Avbryt
             </Button>
           </ModalActions>

--- a/packages/dds-components/src/components/Modal/Modal.tsx
+++ b/packages/dds-components/src/components/Modal/Modal.tsx
@@ -37,19 +37,19 @@ import { Heading } from '../Typography';
 export type ModalProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
   {
-    /**Spesifiserer om modal skal vises. */
+    /**Spesifiserer om `<Modal>` skal åpnes. */
     isOpen?: boolean;
-    /**Funksjon kjørt ved lukking; Settes hvis modal skal være lukkbar. Legger en lukkeknapp i hjørnet og kjøres ved Esc-trykk, lukkeknappklikk og museklikk utenfor. */
+    /**Funksjon kjørt ved lukking; gjør at `<Modal>` blir lukkbar via: Esc-tast, klikk utenfor, klikk på dedikert lukkeknapp. */
     onClose?: () => void;
-    /**Spesifiserer hvilken DOM node `<Modal>` skal ha som forelder via React portal. Brukes med f.eks `document.getElementById("id")` eller ref (skaper ikke ny DOM node).
+    /**Fordeler DOM node for `<Modal>` via React portal. Brukes med f.eks `document.getElementById("id")` eller `ref` (skaper ikke ny DOM node).
      * @default themeProviderRef
      */
     parentElement?: HTMLElement;
-    /**Tittel/header i modal. Setter også `aria-labelledby`. */
+    /**Header i `<Modal>`. Returnerer default `<Heading>` ved `string`. Setter også `aria-labelledby`. */
     header?: string | ReactNode;
     /**Ref som brukes til returnering av fokus. */
     triggerRef?: RefObject<HTMLElement>;
-    /**Ref som skal motta fokus når Modal åpnes. Hvis utelatt blir Modal fokusert. */
+    /**Ref som skal motta fokus når `<Modal>` åpnes. Hvis utelatt blir `<Modal>` fokusert. */
     initialFocusRef?: RefObject<HTMLElement>;
     /** Gjør at innholdet kan scrolles */
     scrollable?: boolean;
@@ -79,7 +79,7 @@ export const Modal = forwardRef<HTMLDivElement, ModalProps>((props, ref) => {
   const combinedRef = useCombinedRef(ref, modalRef);
   const handleClose = () => {
     if (onClose && isOpen) {
-      triggerRef && triggerRef.current?.focus();
+      triggerRef?.current?.focus();
       onClose();
     }
   };

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.context.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.context.tsx
@@ -1,24 +1,41 @@
 import {
+  type Dispatch,
   type ReactNode,
   type RefObject,
+  type SetStateAction,
   createContext,
   useContext,
   useEffect,
   useState,
 } from 'react';
 
-import { useRoveFocus } from '../../hooks';
+import {
+  type FloatingStyles,
+  type UseFloatPositionOptions,
+  useRoveFocus,
+} from '../../hooks';
 
 type FocusableElement = HTMLButtonElement | HTMLAnchorElement;
 
-interface OverflowMenuContextProps {
+interface CommonContextProps {
   isOpen: boolean;
-  onToggle?: () => void;
   onClose?: () => void;
+  menuRef?: (node: HTMLElement | null) => void;
+  menuId?: string;
+  floatStyling?: FloatingStyles;
+  setFloatOptions?: Dispatch<
+    SetStateAction<UseFloatPositionOptions | undefined>
+  >;
+}
+type OverflowMenuContextProps = CommonContextProps & {
   registerItem: (ref: RefObject<FocusableElement>) => void;
   unregisterItem: (ref: RefObject<FocusableElement>) => void;
   focusedRef?: RefObject<FocusableElement>;
-}
+};
+
+export type OverflowMenuContextProviderProps = CommonContextProps & {
+  children: ReactNode;
+};
 
 const OverflowMenuContext = createContext<OverflowMenuContextProps>({
   isOpen: false,
@@ -26,21 +43,12 @@ const OverflowMenuContext = createContext<OverflowMenuContextProps>({
   unregisterItem: () => null,
 });
 
-export interface OverflowMenuContextProviderProps {
-  isOpen: boolean;
-  onToggle?: () => void;
-  onClose?: () => void;
-  children: ReactNode;
-}
-
 export function OverflowMenuContextProvider({
-  isOpen,
-  onToggle,
-  onClose,
   children,
+  ...rest
 }: OverflowMenuContextProviderProps) {
   const [items, setItems] = useState<Array<RefObject<FocusableElement>>>([]);
-  const [focusIndex] = useRoveFocus(items.length, isOpen);
+  const [focusIndex] = useRoveFocus(items.length, rest.isOpen);
 
   useEffect(() => {
     items[focusIndex]?.current?.focus();
@@ -49,9 +57,7 @@ export function OverflowMenuContextProvider({
   return (
     <OverflowMenuContext.Provider
       value={{
-        isOpen,
-        onToggle,
-        onClose,
+        ...rest,
         registerItem: ref => setItems(prev => [...prev, ref]),
         unregisterItem: ref =>
           setItems(prev => prev.filter(item => item !== ref)),
@@ -63,6 +69,6 @@ export function OverflowMenuContextProvider({
   );
 }
 
-export const useOverflowMenu = () => {
+export const useOverflowMenuContext = () => {
   return useContext(OverflowMenuContext);
 };

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.mdx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.mdx
@@ -29,10 +29,10 @@ import * as OverflowMenuStories from './OverflowMenu.stories';
 OverflowMenu er en komponent som viser og skjuler en meny med handlinger og/eller lenker når brukeren trykker på en knapp - anchor-elementet. Den består følgende elementer:
 
 - **`<OverflowMenu>`** - selve menyen.
-- **Anchor-element** - valgfritt element som åpner menyen. `<OverflowMenu>` posisjoneres i forhold til anchor-elementet.
-- **`<OverflowMenuGroup>`** - wrapper som håndterer åpning, lukking, refs og universell utforming. Den skal ha `<OverflowMenu>` og anchor-element som barn. Ikke obligatorisk å bruke, men overnevnt må isåfall håndteres på eget ansvar.
+- **Anchor-element** - valgfritt element som åpner menyen, typisk en knapp. `<OverflowMenu>` posisjoneres i forhold til anchor-elementet.
+- **`<OverflowMenuGroup>`** - wrapper som håndterer åpning/lukking og universell utforming. Den skal ha `<OverflowMenu>` og anchor-element som barn. Obligatorisk å bruke.
 
-Menyen bygges med dedikerte subkomponenter. Følgende subkomponenter brukes som barn i `<OverflowMenu>`:
+Menyen bygges med dedikerte delkomponenter som barn i `<OverflowMenu>`:
 
 - **`<OverflowMenuList>`** - en liste med elementer.
 - **`<OverflowMenuButton>`** - knapp. Brukes som barn i `<OverflowMenuList>`.
@@ -41,63 +41,13 @@ Menyen bygges med dedikerte subkomponenter. Følgende subkomponenter brukes som 
 - **`<OverflowMenuListHeader>`** - overskift for en liste. Brukes over `<OverflowMenuList>`.
 - **`<OverflowMenuDivider>`** - divider som kan brukes som skille mellom lister.
 
-## Bruk
-
-<Source
-  code={`import { OverflowMenu, OverflowMenuGroup, Button } from '@norges-domstoler/dds-components';
-
-<OverflowMenuGroup>
-  <Button>Åpne meny</Button>
-  <OverflowMenu>
-    <OverflowMenuList>
-      <OverflowMenuListHeader>Overskrift</OverflowMenuListHeader>
-      <OverflowMenuButton onClick={() => {}}>Handling</OverflowMenuButton>
-      <OverflowMenuLink href="/">Lenke</OverflowMenuLink>
-    </OverflowMenuList>
-    <OverflowMenuDivider />
-    <OverflowMenuList>
-      <OverflowMenuListHeader>Overskrift</OverflowMenuListHeader>
-      <OverflowMenuButton onClick={() => {}}>Handling</OverflowMenuButton>
-      <OverflowMenuLink href="/">Lenke</OverflowMenuLink>
-    </OverflowMenuList>
-  </OverflowMenu>
-</OverflowMenuGroup>
-`} />
-
-### Uten `<OverflowMenuGroup>`
-
-<Source
-  code={`
-  import { OverflowMenu, Button } from '@norges-domstoler/dds-components';
-  import { useState, useRef } from 'react';
-
-const [isClosed, setIsClosed] = useState(true);
-const toggle = () => setIsClosed(!isClosed);
-const close = () => setIsClosed(true);
-const buttonRef = userRef(null);
-const id = 'id';
-
-<Button
-  ref={buttonRef}
-  aria-haspopup="menu"
-  aria-expanded={!isClosed ? true : undefined}
-  aria-controls={id}
->
-  Åpne meny
-</Button>
-<OverflowMenu isOpen={!isClosed} onClose={close} anchorRef={buttonRef} id={id}>
-  <OverflowMenuList>
-    <OverflowMenuButton onClick={() => {}}>Handling</OverflowMenuButton>
-    <OverflowMenuLink href="/">Lenke</OverflowMenuLink>
-  </OverflowMenuList>
-</OverflowMenu>
-`} />
-
 ## Props
 
 ### OverflowMenu
 
-Hovedkomponenten `<OverflowMenu>`.
+Hovedkomponenten `<OverflowMenu>`. Kan brukes kontrollert eller ikke kontrollert.
+
+**OBS!** Støtter ikke `id`; se [OverflowMenuGroup](#overflowmenugroup).
 
 <Canvas>
   <Story of={OverflowMenuStories.Default} />
@@ -106,23 +56,13 @@ Hovedkomponenten `<OverflowMenu>`.
 
 ### OverflowMenuGroup
 
-En wrapper som håndterer åpning, lukking, ARIA og refs for trigger-elementet og `<OverflowMenu>` ut av boksen. Den skal ha anchor-elementet som første barn og `<OverflowMenu>` som andre barn. Ikke obligatorisk, men da må oppførsel osv. håndteres utenfor komponenten.
+En wrapper som håndterer åpning/lukking og universell utforming ut av boksen. Den skal ha anchor-elementet som første barn og `<OverflowMenu>` som andre barn. Obligatorisk å bruke.
 
 <ArgTypes of={OverflowMenuGroup} />
 
 ### OverflowMenuList
 
 Liste med elementer. Returnerer `<ul>`.
-
-### OverflowMenuListHeader
-
-Overskrift for en liste ved behov. Returnerer `<h2>` inni `<li>` for å opprettholde overskriftshierarki på siden. Brukes som barn i `<OverflowMenuList>`.
-
-### OverflowMenuDivider
-
-Skillelinje. Brukes mellom lister.
-
-<ArgTypes of={OverflowMenuDivider} />
 
 ### OverflowMenuButton
 
@@ -145,6 +85,80 @@ Statisk element. Returnerer `<span>` inni `<li>`. Brukes som barn i `<OverflowMe
 
 <ArgTypes of={OverflowMenuSpan} />
 Støtter også alle native props.
+
+### OverflowMenuListHeader
+
+Overskrift for en liste ved behov. Returnerer `<h2>` inni `<li>` for å opprettholde overskriftshierarki på siden. Brukes som barn i `<OverflowMenuList>`.
+
+### OverflowMenuDivider
+
+Skillelinje. Brukes mellom lister.
+
+<ArgTypes of={OverflowMenuDivider} />
+
+## Bruk
+
+<Source
+  code={`import { OverflowMenu, OverflowMenuGroup, Button } from '@norges-domstoler/dds-components';
+
+<OverflowMenuGroup>
+  <Button>Åpne meny</Button>
+  <OverflowMenu>
+    <OverflowMenuListHeader>Overskrift</OverflowMenuListHeader>
+    <OverflowMenuList>
+      <OverflowMenuButton onClick={() => {}}>Handling</OverflowMenuButton>
+      <OverflowMenuLink href="/">Lenke</OverflowMenuLink>
+    </OverflowMenuList>
+    <OverflowMenuDivider />
+    <OverflowMenuListHeader>Overskrift</OverflowMenuListHeader>
+    <OverflowMenuList>
+      <OverflowMenuButton onClick={() => {}}>Handling</OverflowMenuButton>
+      <OverflowMenuLink href="/">Lenke</OverflowMenuLink>
+    </OverflowMenuList>
+  </OverflowMenu>
+</OverflowMenuGroup>
+`} />
+
+### Callbacks
+
+<Source
+  code={`import { OverflowMenu, OverflowMenuGroup, Button } from '@norges-domstoler/dds-components';
+
+const onClose = () => {
+//din kode
+};
+const onOpen = () => {
+//din kode
+};
+
+<OverflowMenuGroup onClose={onClose} onOpen={onOpen}>
+  <Button>Åpne meny</Button>
+  <OverflowMenu>
+    <OverflowMenuList>
+      <OverflowMenuButton onClick={() => {}}>Handling</OverflowMenuButton>
+      <OverflowMenuButton onClick={() => {}}>Handling</OverflowMenuButton>
+    </OverflowMenuList>
+  </OverflowMenu>
+</OverflowMenuGroup>
+`} />
+
+### Kontrollert
+
+<Source
+  code={`import { OverflowMenu, OverflowMenuGroup, Button } from '@norges-domstoler/dds-components';
+
+const [isOpen, setIsOpen] = useState(false);
+
+<OverflowMenuGroup isOpne={isOpen} isetIsOpen={setIsOpen}>
+  <Button>Åpne meny</Button>
+  <OverflowMenu>
+    <OverflowMenuList>
+      <OverflowMenuButton onClick={() => {}}>Handling</OverflowMenuButton>
+      <OverflowMenuButton onClick={() => {}}>Handling</OverflowMenuButton>
+    </OverflowMenuList>
+  </OverflowMenu>
+</OverflowMenuGroup>
+`} />
 
 ## Eksempler
 

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.spec.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.spec.tsx
@@ -41,7 +41,7 @@ function TestComponent({ link, item, span }: props) {
   );
 }
 
-describe('<OverflowMenu />', () => {
+describe('<OverflowMenu>', () => {
   it('should display context menu item as button', () => {
     render(<TestComponent item={item} />);
     const buttonElement = screen.getByRole('button');
@@ -70,10 +70,10 @@ describe('<OverflowMenu />', () => {
     expect(menuOpened).toHaveAttribute('aria-hidden', 'false');
   });
 
-  it('should call onToggle event on button click', async () => {
+  it('should call onClose event on button click', async () => {
     const event = vi.fn();
     render(
-      <OverflowMenuGroup onToggle={event}>
+      <OverflowMenuGroup onClose={event}>
         <Button />
         <OverflowMenu />
       </OverflowMenuGroup>,
@@ -81,7 +81,9 @@ describe('<OverflowMenu />', () => {
 
     const menuButton = screen.getByRole('button');
     await userEvent.click(menuButton);
+    expect(event).not.toBeCalled();
 
+    await userEvent.click(menuButton);
     expect(event).toBeCalled();
   });
 

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -1,4 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react';
+import { useState } from 'react';
 
 import { Button } from '../Button';
 import { EditIcon, MenuIcon, PersonIcon, TrashIcon } from '../Icon/icons';
@@ -20,13 +21,12 @@ export default {
   component: OverflowMenu,
   argTypes: {
     offset: { control: 'number' },
-    anchorRef: { control: false },
     htmlProps: { control: false },
   },
   parameters: {
     docs: {
       story: { height: '350px', inline: true },
-      canvas: { sourceState: 'hidden' },
+      canvas: { sourceState: 'shown' },
     },
   },
 } satisfies Meta<typeof OverflowMenu>;
@@ -82,6 +82,65 @@ export const Default: Story = {
                 icon={TrashIcon}
                 purpose="danger"
               >
+                Slett
+              </OverflowMenuButton>
+            </OverflowMenuList>
+          </OverflowMenu>
+        </OverflowMenuGroup>
+      </VStack>
+    );
+  },
+};
+
+export const Controlled: Story = {
+  render: args => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <VStack>
+        Menyen er {isOpen ? 'åpen' : 'lukket'}.
+        <OverflowMenuGroup isOpen={isOpen} setIsOpen={setIsOpen}>
+          <Button icon={MenuIcon} aria-label="Åpne meny" />
+          <OverflowMenu {...args}>
+            <OverflowMenuList>
+              <OverflowMenuButton
+                onClick={() => {
+                  null;
+                }}
+                icon={EditIcon}
+              >
+                Rediger
+              </OverflowMenuButton>
+              <OverflowMenuButton
+                onClick={() => {
+                  null;
+                }}
+                icon={TrashIcon}
+                purpose="danger"
+              >
+                Slett
+              </OverflowMenuButton>
+            </OverflowMenuList>
+          </OverflowMenu>
+        </OverflowMenuGroup>
+      </VStack>
+    );
+  },
+};
+
+export const WithOnOpenAndOnClose: Story = {
+  render: args => {
+    const [text, setText] = useState('aktiver Popover');
+    const onOpen = () => setText('onOpen ble kalt');
+    const onClose = () => setText('onClose ble kalt');
+    return (
+      <VStack>
+        {text}.
+        <OverflowMenuGroup onOpen={onOpen} onClose={onClose}>
+          <Button icon={MenuIcon} aria-label="Åpne meny" />
+          <OverflowMenu {...args}>
+            <OverflowMenuList>
+              <OverflowMenuButton icon={EditIcon}>Rediger</OverflowMenuButton>
+              <OverflowMenuButton icon={TrashIcon} purpose="danger">
                 Slett
               </OverflowMenuButton>
             </OverflowMenuList>
@@ -155,9 +214,7 @@ export const WithNavigation: Story = {
               <OverflowMenuList>
                 <OverflowMenuLink href="/">Link</OverflowMenuLink>
                 <OverflowMenuLink href="/">Link</OverflowMenuLink>
-                <OverflowMenuLink href="/" purpose="danger">
-                  Link
-                </OverflowMenuLink>
+                <OverflowMenuLink href="/">Link</OverflowMenuLink>
               </OverflowMenuList>
             </nav>
           </OverflowMenu>

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.types.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.types.tsx
@@ -2,7 +2,6 @@ import {
   type AnchorHTMLAttributes,
   type ButtonHTMLAttributes,
   type HTMLAttributes,
-  type RefObject,
 } from 'react';
 
 import { type Placement } from '../../hooks';
@@ -27,26 +26,19 @@ export type OverflowMenuLinkProps = OverflowMenuListItemBaseProps &
 export type OverflowMenuSpanProps = OverflowMenuListItemBaseProps &
   HTMLAttributes<HTMLSpanElement>;
 
-export type OverflowMenuProps = BaseComponentPropsWithChildren<
-  HTMLDivElement,
-  {
-    /**Plassering av menyen i forhold til anchor-elementet.
-     * @default "bottom-end"
-     */
-    placement?: Placement;
-    /**Avstand fra anchor-elementet i px.
-     * @default 2
-     */
-    offset?: number;
-    /**Spesifiserer om menyen skal vises. **OBS!** nødvendig kun hvis `<OverflowMenuGroup />` ikke brukes.
-     * @default false
-     */
-    isOpen?: boolean;
-    /**Callback for å lukke menyen. **OBS!** nødvendig kun hvis `<OverflowMenuGroup />` ikke brukes.  */
-    onClose?: () => void;
-    /**Callback for å toggle menyen. **OBS!** nødvendig kun hvis `<OverflowMenuGroup />` ikke brukes.  */
-    onToggle?: () => void;
-    /**Ref til elementet som styrer menyen. **OBS!** nødvendig kun hvis ``<OverflowMenuGroup />` ikke brukes.  */
-    anchorRef?: RefObject<HTMLButtonElement>;
-  }
+export type OverflowMenuProps = Omit<
+  BaseComponentPropsWithChildren<
+    HTMLDivElement,
+    {
+      /**Plassering av menyen i forhold til anchor-elementet.
+       * @default "bottom-end"
+       */
+      placement?: Placement;
+      /**Avstand fra anchor-elementet i px.
+       * @default 2
+       */
+      offset?: number;
+    }
+  >,
+  'id'
 >;

--- a/packages/dds-components/src/components/OverflowMenu/components/OverflowMenuButton.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/components/OverflowMenuButton.tsx
@@ -5,7 +5,7 @@ import { cn } from '../../../utils';
 import focusStyles from '../../helpers/styling/focus.module.css';
 import { Icon } from '../../Icon';
 import typographyStyles from '../../Typography/typographyStyles.module.css';
-import { useOverflowMenu } from '../OverflowMenu.context';
+import { useOverflowMenuContext } from '../OverflowMenu.context';
 import styles from '../OverflowMenu.module.css';
 import { type OverflowMenuButtonProps } from '../OverflowMenu.types';
 
@@ -26,8 +26,8 @@ export const OverflowMenuButton = forwardRef<
   const itemRef = useRef<HTMLButtonElement>(null);
   const combinedRef = useCombinedRef(ref, itemRef);
 
-  const { onToggle, onClose, registerItem, unregisterItem, focusedRef } =
-    useOverflowMenu();
+  const { onClose, registerItem, unregisterItem, focusedRef } =
+    useOverflowMenuContext();
 
   useEffect(() => {
     registerItem(itemRef);
@@ -49,9 +49,8 @@ export const OverflowMenuButton = forwardRef<
           focusStyles['focusable--inset'],
         )}
         onClick={e => {
-          onClick && onClick(e);
-          onClose && onClose();
-          onToggle && onToggle();
+          onClick?.(e);
+          onClose?.();
         }}
         {...rest}
         tabIndex={focusedRef === itemRef ? 0 : -1}

--- a/packages/dds-components/src/components/OverflowMenu/components/OverflowMenuLink.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/components/OverflowMenuLink.tsx
@@ -5,7 +5,7 @@ import { cn } from '../../../utils';
 import focusStyles from '../../helpers/styling/focus.module.css';
 import { Icon } from '../../Icon';
 import typographyStyles from '../../Typography/typographyStyles.module.css';
-import { useOverflowMenu } from '../OverflowMenu.context';
+import { useOverflowMenuContext } from '../OverflowMenu.context';
 import styles from '../OverflowMenu.module.css';
 import { type OverflowMenuLinkProps } from '../OverflowMenu.types';
 
@@ -27,8 +27,8 @@ export const OverflowMenuLink = forwardRef<
   const itemRef = useRef<HTMLAnchorElement>(null);
   const combinedRef = useCombinedRef(ref, itemRef);
 
-  const { onToggle, onClose, registerItem, unregisterItem, focusedRef } =
-    useOverflowMenu();
+  const { onClose, registerItem, unregisterItem, focusedRef } =
+    useOverflowMenuContext();
 
   useEffect(() => {
     registerItem(itemRef);
@@ -51,9 +51,8 @@ export const OverflowMenuLink = forwardRef<
         )}
         href={href}
         onClick={e => {
-          onClick && onClick(e);
-          onClose && onClose();
-          onToggle && onToggle();
+          onClick?.(e);
+          onClose?.();
         }}
         {...rest}
         tabIndex={focusedRef === itemRef ? 0 : -1}

--- a/packages/dds-components/src/components/Popover/Popover.context.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.context.tsx
@@ -1,4 +1,3 @@
-import { type Strategy } from '@floating-ui/react-dom';
 import {
   type Dispatch,
   type SetStateAction,
@@ -6,10 +5,10 @@ import {
   useContext,
 } from 'react';
 
-import { type UseFloatPositionOptions } from '../../hooks';
+import { type FloatingStyles, type UseFloatPositionOptions } from '../../hooks';
 
 interface PopoverContextType {
-  floatStyling: { position: Strategy; top: number; left: number };
+  floatStyling: FloatingStyles;
   setFloatOptions: Dispatch<
     SetStateAction<UseFloatPositionOptions | undefined>
   >;

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 import { ProgressTracker } from './ProgressTracker';
 import { Button } from '../Button';
-import { Drawer } from '../Drawer';
+import { Drawer, DrawerGroup } from '../Drawer';
 import { Fieldset } from '../Fieldset';
 import {
   ArrowRightIcon,
@@ -227,14 +227,41 @@ export const SmallScreen: Story = {
     return (
       <>
         <VStack align="left" gap="x1.5">
-          <Button
-            purpose="secondary"
-            onClick={() => setDrawerOpen(true)}
-            iconPosition="right"
-            icon={ChevronRightIcon}
-          >
-            Steg {activeStep + 1} av 4
-          </Button>
+          <DrawerGroup isOpen={isDrawerOpen} setIsOpen={setDrawerOpen}>
+            <Button
+              purpose="secondary"
+              iconPosition="right"
+              icon={ChevronRightIcon}
+            >
+              Steg {activeStep + 1} av 4
+            </Button>
+            <Drawer>
+              <ProgressTracker
+                {...args}
+                activeStep={activeStep}
+                onStepChange={step => {
+                  setDrawerOpen(false);
+                  setActiveStep(step);
+                }}
+              >
+                <ProgressTracker.Item completed={completedSteps.has(0)}>
+                  Parter med lang tekst
+                </ProgressTracker.Item>
+                <ProgressTracker.Item completed={completedSteps.has(1)}>
+                  Slutning
+                </ProgressTracker.Item>
+                <ProgressTracker.Item completed={completedSteps.has(2)}>
+                  Vedlegg
+                </ProgressTracker.Item>
+                <ProgressTracker.Item
+                  completed={completedSteps.has(3)}
+                  disabled
+                >
+                  Sammendrag
+                </ProgressTracker.Item>
+              </ProgressTracker>
+            </Drawer>
+          </DrawerGroup>
           {activeStep >= 0 && <div>Steg {activeStep + 1}</div>}
           <Button
             onClick={() => {
@@ -247,29 +274,6 @@ export const SmallScreen: Story = {
             Sett steg ferdig
           </Button>
         </VStack>
-        <Drawer isOpen={isDrawerOpen} onClose={() => setDrawerOpen(false)}>
-          <ProgressTracker
-            {...args}
-            activeStep={activeStep}
-            onStepChange={step => {
-              setDrawerOpen(false);
-              setActiveStep(step);
-            }}
-          >
-            <ProgressTracker.Item completed={completedSteps.has(0)}>
-              Parter med lang tekst
-            </ProgressTracker.Item>
-            <ProgressTracker.Item completed={completedSteps.has(1)}>
-              Slutning
-            </ProgressTracker.Item>
-            <ProgressTracker.Item completed={completedSteps.has(2)}>
-              Vedlegg
-            </ProgressTracker.Item>
-            <ProgressTracker.Item completed={completedSteps.has(3)} disabled>
-              Sammendrag
-            </ProgressTracker.Item>
-          </ProgressTracker>
-        </Drawer>
       </>
     );
   },
@@ -364,31 +368,29 @@ export const RealWorldRosponsiveExample: Story = {
       <div className="story-grid">
         <div>
           <div className="story-mobile">
-            <Button
-              purpose="secondary"
-              onClick={() => setProgressTrackerDrawerOpen(true)}
-              iconPosition="right"
-              icon={ChevronRightIcon}
+            <DrawerGroup
+              isOpen={progressTrackerDrawerOpen}
+              setIsOpen={setProgressTrackerDrawerOpen}
             >
-              Steg {activeStep + 1} av {steps.length}
-            </Button>
+              <Button
+                purpose="secondary"
+                iconPosition="right"
+                icon={ChevronRightIcon}
+              >
+                Steg {activeStep + 1} av {steps.length}
+              </Button>
+              <Drawer>
+                <ProgressTracker
+                  {...args}
+                  activeStep={activeStep}
+                  onStepChange={newStep => setActiveStep(newStep)}
+                >
+                  {stepItems}
+                </ProgressTracker>
+              </Drawer>
+            </DrawerGroup>
           </div>
           {formSteps[activeStep]}
-        </div>
-
-        <div className="story-mobile">
-          <Drawer
-            isOpen={progressTrackerDrawerOpen}
-            onClose={() => setProgressTrackerDrawerOpen(false)}
-          >
-            <ProgressTracker
-              {...args}
-              activeStep={activeStep}
-              onStepChange={newStep => setActiveStep(newStep)}
-            >
-              {stepItems}
-            </ProgressTracker>
-          </Drawer>
         </div>
         <div className="story-desktop">
           <ProgressTracker

--- a/packages/dds-components/src/components/SplitButton/SplitButton.tsx
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.tsx
@@ -60,7 +60,7 @@ export const SplitButton = forwardRef<HTMLDivElement, SplitButtonProps>(
           iconPosition="left"
           className={styles.main}
         />
-        <OverflowMenuGroup onToggle={() => setIsOpen(!isOpen)}>
+        <OverflowMenuGroup isOpen={isOpen} setIsOpen={setIsOpen}>
           <Button
             {...buttonStyleProps}
             icon={isOpen ? ChevronUpIcon : ChevronDownIcon}

--- a/packages/dds-components/src/hooks/useFloatPosition.tsx
+++ b/packages/dds-components/src/hooks/useFloatPosition.tsx
@@ -47,14 +47,16 @@ export interface UseFloatPositionOptions {
   placement?: Placement;
 }
 
+export interface FloatingStyles {
+  position: Strategy;
+  top: number;
+  left: number;
+}
+
 interface UseFloatPosition {
   refs: UseFloatingReturn['refs'];
   styles: {
-    floating: {
-      position: Strategy;
-      top: number;
-      left: number;
-    };
+    floating: FloatingStyles;
     arrow:
       | {
           [x: string]: string | number;


### PR DESCRIPTION
## Beskrivelse
Standardisering av bruk av flate-komponenter.

- Revamp av `<OverflowMenu>`.
    - Fjerner prop `onToggle` i `<OverflowMenuGroup>`. Komponenten blir standardisert og bruker kun `onClose` og `onOpen`.
    - Implementerer kontrollert tilstand. `<OverflowMenuGroup>` kan nå ta inn `isOpen` og `setIsOpen` props for bli kontrollert av konsumenten; hvis de ikke settes brukes intern håndtering. Legger også til `isInitiallyOpen`, som forteller om `<OverflowMenu>` vises på første render.
    - Fjerner props fra `<OverflowMenu>` som ble satt av forelder: `isOpen`, `anchorRef`, `onClose`, `onToggle`, `id` og implementerer React Context istedet. Vi unngår dermed rotet med props konsumenter ikke "får lov" til å sette. `<OverflowMenuGroup>` er dermed obigatorisk å bruke.
- Revamp av `<Drawer>`.
    - Implementerer kontrollert tilstand. `<DrawerGroup>` kan nå ta inn `isOpen` og `setIsOpen` props for bli kontrollert av konsumenten; hvis de ikke settes brukes intern håndtering. Legger også til `isInitiallyOpen`, som forteller om `<Drawer>` vises på første render.
    - Fjerner props fra `<Drawer>` som ble satt av forelder: `isOpen`, `triggerRef`, `onClose`, `id` og implementerer React Context istedet. Vi unngår dermed rotet med props konsumenter ikke "får lov" til å sette. `<DrawerGroup>` er dermed obigatorisk å bruke.
- Endrer navn på prop `title` til `headerText`, og `titleHeadingLevel` til `headerHeadingLevel` i `<EmptyContent>`. På denne måten unngår vi forvirring med nativ HTML `title` og standardiserer navngiving.
## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
