### PR TITLE
ELSA1-545 Støtte for `size` prop i `<Tabs>`

### DIFF
--- a/.changeset/young-doors-explain.md
+++ b/.changeset/young-doors-explain.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for `size` prop i `<Tabs>` med `'medium'` og `'small'`. Bruker `'small'` som default. Justerer også på spacing i begge variantene.

--- a/packages/dds-components/src/components/Tabs/AddTabButton.tsx
+++ b/packages/dds-components/src/components/Tabs/AddTabButton.tsx
@@ -9,7 +9,6 @@ import { cn } from '../../utils';
 import focusStyles from '../helpers/styling/focus.module.css';
 import { Icon } from '../Icon';
 import { PlusIcon } from '../Icon/icons';
-import { defaultTypographyType, getTypographyCn } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 export type AddTabButtonProps = {
@@ -30,7 +29,7 @@ export const AddTabButton = forwardRef<HTMLButtonElement, AddTabButtonProps>(
 
     const buttonRef = useRef<HTMLButtonElement>(null);
     const combinedRef = useCombinedRef(ref, buttonRef);
-    const { tabContentDirection } = useTabsContext();
+    const { tabContentDirection, size } = useTabsContext();
 
     return (
       <button
@@ -40,7 +39,7 @@ export const AddTabButton = forwardRef<HTMLButtonElement, AddTabButtonProps>(
           className,
           styles.tab,
           styles[`tab--${tabContentDirection}`],
-          typographyStyles[getTypographyCn(defaultTypographyType)],
+          typographyStyles[`body-${size}`],
           focusStyles['focusable--inset'],
         )}
       >

--- a/packages/dds-components/src/components/Tabs/Tab.tsx
+++ b/packages/dds-components/src/components/Tabs/Tab.tsx
@@ -23,7 +23,6 @@ import { cn } from '../../utils';
 import focusStyles from '../helpers/styling/focus.module.css';
 import { Icon } from '../Icon';
 import { type SvgIcon } from '../Icon/utils';
-import { defaultTypographyType, getTypographyCn } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 export type TabProps = BaseComponentPropsWithChildren<
@@ -72,7 +71,7 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
 
   const itemRef = useRef<HTMLAnchorElement | HTMLButtonElement>(null);
   const combinedRef = useCombinedRef(ref, itemRef);
-  const { tabContentDirection } = useTabsContext();
+  const { tabContentDirection, size } = useTabsContext();
 
   useEffect(() => {
     if (focus) {
@@ -105,9 +104,10 @@ export const Tab = forwardRef<HTMLButtonElement, TabProps>((props, ref) => {
         cn(
           className,
           styles.tab,
+          styles[`tab--${size}--${tabContentDirection}`],
           active && styles['tab--active'],
           styles[`tab--${tabContentDirection}`],
-          typographyStyles[getTypographyCn(defaultTypographyType)],
+          typographyStyles[`body-${size}`],
           focusStyles['focusable--inset'],
         ),
         htmlProps,

--- a/packages/dds-components/src/components/Tabs/Tabs.context.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.context.tsx
@@ -1,11 +1,13 @@
 import { type RefObject, createContext, useContext } from 'react';
 
 import { type AddTabButtonProps } from './AddTabButton';
+import { type TabSize } from './Tabs';
 import { type Direction } from '../../types';
 
 interface Tabs {
   activeTab: number;
   tabsId: string;
+  size: TabSize;
   handleTabChange: (index: number) => void;
   tabListRef: RefObject<HTMLDivElement> | null;
   tabPanelsRef: RefObject<HTMLDivElement> | null;
@@ -18,6 +20,7 @@ interface Tabs {
 export const TabsContext = createContext<Tabs>({
   activeTab: 0,
   tabsId: '',
+  size: 'small',
   handleTabChange: () => null,
   tabListRef: null,
   tabPanelsRef: null,

--- a/packages/dds-components/src/components/Tabs/Tabs.module.css
+++ b/packages/dds-components/src/components/Tabs/Tabs.module.css
@@ -36,7 +36,6 @@
   cursor: pointer;
   border-bottom: 2px solid transparent;
   color: var(--dds-color-text-medium);
-  padding: var(--dds-spacing-x0-5);
   background: var(--dds-color-surface-default);
   border-top-left-radius: var(--dds-border-radius-button);
   border-top-right-radius: var(--dds-border-radius-button);
@@ -56,14 +55,32 @@
   }
 }
 
+.tab--medium--row {
+  padding: var(--dds-spacing-x0-75) var(--dds-spacing-x1)
+    var(--dds-spacing-x0-5);
+  gap: var(--dds-spacing-x0-5);
+}
+
+.tab--small--row {
+  padding: var(--dds-spacing-x0-25) var(--dds-spacing-x0-75);
+  gap: var(--dds-spacing-x0-125);
+}
+
+.tab--medium--column {
+  padding: var(--dds-spacing-x0-5) var(--dds-spacing-x1);
+  gap: var(--dds-spacing-x0-25);
+}
+
+.tab--small--column {
+  padding: var(--dds-spacing-x0-25) var(--dds-spacing-x0-75);
+}
+
 .tab--row {
   flex-direction: row;
-  gap: var(--dds-spacing-x0-5);
 }
 
 .tab--column {
   flex-direction: column;
-  gap: var(--dds-spacing-x0-25);
 }
 
 .tab--active {

--- a/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
@@ -44,25 +44,66 @@ export const Default: Story = {
   ),
 };
 
-export const Overview: Story = {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const Direction: Story = {
   render: args => (
     <StoryVStack>
-      <Tabs>
-        <TabList>
-          <Tab>Restriksjoner</Tab>
-          <Tab>Aktører</Tab>
-          <Tab>Logg</Tab>
-        </TabList>
-      </Tabs>
-      <Tabs>
+      <Tabs {...args}>
         <TabList>
           <Tab icon={NotificationsIcon}>Restriksjoner</Tab>
           <Tab icon={NotificationsIcon}>Aktører</Tab>
           <Tab icon={NotificationsIcon}>Logg</Tab>
         </TabList>
       </Tabs>
-      <Tabs tabContentDirection="column">
+      <Tabs {...args} tabContentDirection="column">
+        <TabList>
+          <Tab icon={NotificationsIcon}>Restriksjoner</Tab>
+          <Tab icon={NotificationsIcon}>Aktører</Tab>
+          <Tab icon={NotificationsIcon}>Logg</Tab>
+        </TabList>
+      </Tabs>
+    </StoryVStack>
+  ),
+};
+
+export const Sizes: Story = {
+  render: args => (
+    <StoryVStack>
+      <Tabs {...args}>
+        <TabList>
+          <Tab>Restriksjoner</Tab>
+          <Tab>Aktører</Tab>
+          <Tab>Logg</Tab>
+        </TabList>
+      </Tabs>
+      <Tabs {...args}>
+        <TabList>
+          <Tab icon={NotificationsIcon}>Restriksjoner</Tab>
+          <Tab icon={NotificationsIcon}>Aktører</Tab>
+          <Tab icon={NotificationsIcon}>Logg</Tab>
+        </TabList>
+      </Tabs>
+      <Tabs {...args} tabContentDirection="column">
+        <TabList>
+          <Tab icon={NotificationsIcon}>Restriksjoner</Tab>
+          <Tab icon={NotificationsIcon}>Aktører</Tab>
+          <Tab icon={NotificationsIcon}>Logg</Tab>
+        </TabList>
+      </Tabs>
+      <Tabs {...args} size="medium">
+        <TabList>
+          <Tab>Restriksjoner</Tab>
+          <Tab>Aktører</Tab>
+          <Tab>Logg</Tab>
+        </TabList>
+      </Tabs>
+      <Tabs {...args} size="medium">
+        <TabList>
+          <Tab icon={NotificationsIcon}>Restriksjoner</Tab>
+          <Tab icon={NotificationsIcon}>Aktører</Tab>
+          <Tab icon={NotificationsIcon}>Logg</Tab>
+        </TabList>
+      </Tabs>
+      <Tabs {...args} size="medium" tabContentDirection="column">
         <TabList>
           <Tab icon={NotificationsIcon}>Restriksjoner</Tab>
           <Tab icon={NotificationsIcon}>Aktører</Tab>

--- a/packages/dds-components/src/components/Tabs/Tabs.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.tsx
@@ -14,13 +14,18 @@ import styles from './Tabs.module.css';
 import {
   type BaseComponentPropsWithChildren,
   type Direction,
+  type Size,
   getBaseHTMLProps,
 } from '../../types';
 import { cn } from '../../utils';
 
+export type TabSize = Extract<Size, 'small' | 'medium'>;
+
 export type TabsProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
   {
+    /**Størrelse på hver `<Tab>`. */
+    size?: TabSize;
     /** Indeksen til den aktive fanen. **OBS!** Ved å sette denne vil brukere aldri kunne endre tab uten at du også registrerer en `onChange`-lytter for å ta vare på aktiv tab utenfor komponenten. */
     activeTab?: number;
     /** Ekstra logikk ved endring av aktiv fane. */
@@ -43,6 +48,7 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
     activeTab,
     onChange,
     tabContentDirection = 'row',
+    size = 'small',
     addTabButtonProps,
     width,
     children,
@@ -80,6 +86,7 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>((props, ref) => {
       value={{
         tabsId: uniqueId,
         activeTab: thisActiveTab,
+        size,
         handleTabChange,
         tabListRef,
         tabPanelsRef,


### PR DESCRIPTION
## Beskrivelse
Med `'medium'` og `'small'` som støttede verdier. Bruker `'small'` som default. Justerer også på spacing i begge variantene.

![bilde](https://github.com/user-attachments/assets/912d82cf-d7b6-4f1d-ac7d-fff77bf119ac)

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
