### PR TITLE
ELSA1-556 Fikser `body` styling bug i `<DatePicker>`

### DIFF
--- a/.changeset/plenty-spoons-tap.md
+++ b/.changeset/plenty-spoons-tap.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der åpning av kalender i `<DatePicker>` satt unødvendig styling på `body`.

--- a/packages/dds-components/src/components/date-inputs/DatePicker/CalendarPopover.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/CalendarPopover.tsx
@@ -118,7 +118,7 @@ export const CalendarPopoverContent = ({
     throw new Error('DatePicker must be used within a ThemeProvider');
   }
 
-  const portalTarget = themeContext?.el;
+  const portalTarget = themeContext.el;
   const { isOpen, onClose, anchorRef, closeButtonRef } = useContext(
     CalendarPopoverContext,
   );
@@ -132,15 +132,19 @@ export const CalendarPopoverContent = ({
     refs.setReference(anchorRef?.current ?? null);
   }, []);
 
-  useEffect(() => {
-    if (isOpen) {
-      handleElementWithBackdropMount(document.body);
-    } else {
-      handleElementWithBackdropUnmount(document.body);
-    }
+  const hasBreakpoint = !!smallScreenBreakpoint;
 
-    return () => handleElementWithBackdropUnmount(document.body);
-  }, [isOpen]);
+  useEffect(() => {
+    if (hasBreakpoint && modalRef.current?.checkVisibility()) {
+      if (isOpen) {
+        handleElementWithBackdropMount(document.body);
+      } else {
+        handleElementWithBackdropUnmount(document.body);
+      }
+
+      return () => handleElementWithBackdropUnmount(document.body);
+    }
+  }, [isOpen, hasBreakpoint]);
 
   const closeOnKeyboardBlurBack: KeyboardEventHandler<HTMLButtonElement> = (
     event: KeyboardEvent<HTMLButtonElement>,
@@ -155,6 +159,7 @@ export const CalendarPopoverContent = ({
   return (
     <>
       {portalTarget &&
+        hasBreakpoint &&
         createPortal(
           <div
             className={cn(


### PR DESCRIPTION
## Beskrivelse

Fikser bug der åpning av kalender i `<DatePicker>` satt unødvendig styling på `body`. Endrer slik at styling brukes kun når åpning av kalender viser en modal.

## Sjekkliste

### Generelt

- [ ] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [ ] I commits
  - [ ] I PR-tittelen
- [ ] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
