### PR TITLE
ELSA1-546 `onClick` støtte i `<Tab>`

### DIFF
--- a/.changeset/shaggy-socks-smell.md
+++ b/.changeset/shaggy-socks-smell.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for `onClick` prop for individuelle `<Tab>` delkomponenter i `<Tabs>`.

--- a/packages/dds-components/src/components/Tabs/TabList.tsx
+++ b/packages/dds-components/src/components/Tabs/TabList.tsx
@@ -51,7 +51,10 @@ export const TabList = forwardRef<HTMLDivElement, TabListProps>(
               index,
               focus: focus === index && hasTabFocus,
               setFocus,
-              onClick: () => handleTabChange(index),
+              onClick: () => {
+                handleTabChange(index);
+                child.props.onClick?.();
+              },
             })
           );
         })

--- a/packages/dds-components/src/components/Tabs/Tabs.spec.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useEffect, useRef } from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '.';
 
@@ -143,6 +143,21 @@ describe('<Tabs>', () => {
     await userEvent.click(tab2);
     expect(tab1).toHaveAttribute('aria-selected', 'false');
     expect(tab2).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('tab should fire Tab onClick event', async () => {
+    const onClick = vi.fn();
+    render(
+      <Tabs>
+        <TabList>
+          <Tab onClick={onClick} />
+        </TabList>
+      </Tabs>,
+    );
+
+    const tab = screen.getByRole('tab');
+    await userEvent.click(tab);
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it('tabs should be connected to panels via aria-controls accessible name', () => {


### PR DESCRIPTION
## Beskrivelse

Støtte for `onClick` prop for individuelle `<Tab>` delkomponenter i `<Tabs>`.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
