### PR TITLE
ELSA1-558 Støtte for kontrollert `<Popover>`

### DIFF
--- a/.changeset/wise-hornets-pull.md
+++ b/.changeset/wise-hornets-pull.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for kontrollert `<Popover>` uten `<PopoverGroup>` for corner cases.

--- a/packages/dds-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.stories.tsx
@@ -1,9 +1,10 @@
 import { type Meta, type StoryObj } from '@storybook/react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { type Placement } from '../../hooks';
 import { Button } from '../Button';
 import { InlineButton } from '../InlineButton';
+import { LocalMessage } from '../LocalMessage';
 import { VStack } from '../Stack';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
 import { Paragraph } from '../Typography';
@@ -19,6 +20,8 @@ export default {
     header: { control: 'text' },
     offset: { control: 'number' },
     returnFocusOnBlur: { control: 'boolean' },
+    isOpen: { control: false },
+    anchorRef: { control: false },
     htmlProps: { control: false },
     sizeProps: { control: false },
   },
@@ -230,6 +233,47 @@ export const InlineExample: Story = {
         det vanskelig for deg å vente, så ta det opp på forhånd med den som har
         innkalt deg.
       </Paragraph>
+    );
+  },
+};
+
+export const Custom: Story = {
+  render: args => {
+    const [isOpen, setIsOpen] = useState(false);
+    const bRef = useRef<HTMLButtonElement>(null);
+    const id = 'id';
+    return (
+      <VStack gap="x1">
+        <LocalMessage purpose="warning" message="Brukes kun ved corner cases" />
+
+        <Button
+          ref={bRef}
+          onClick={() => {
+            setIsOpen(!isOpen);
+          }}
+          aria-controls={id}
+          aria-expanded={isOpen}
+          aria-haspopup={id}
+        >
+          Åpne
+        </Button>
+        <Popover
+          {...args}
+          id={id}
+          isOpen={isOpen}
+          anchorRef={bRef}
+          onClose={() => {
+            setIsOpen(false);
+          }}
+        >
+          <VStack align="start">
+            <Paragraph withMargins>
+              Dette er en popover med tekst og knapp
+            </Paragraph>
+            <Button>Klikk</Button>
+          </VStack>
+        </Popover>
+      </VStack>
     );
   },
 };

--- a/packages/dds-components/src/hooks/useOnClickOutside.tsx
+++ b/packages/dds-components/src/hooks/useOnClickOutside.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
  * ```
  * const [isOpen, setOpen] = useState(true);
  * const ref = useRef<HTMLElement>(null);
- * useOnClickOutside(ref, () => setOpen(false));
+ * useOnClickOutside(ref.current, () => setOpen(false));
  *
  * return <div ref={ref}>innhold</div>
  * ```
@@ -15,12 +15,14 @@ import { useEffect } from 'react';
  */
 
 export function useOnClickOutside(
-  element: HTMLElement | null | Array<HTMLElement | null>,
+  element: HTMLElement | null | Array<HTMLElement | null | undefined>,
   handler: (event: MouseEvent | TouchEvent) => void,
 ) {
   useEffect(() => {
     const listener = (event: MouseEvent | TouchEvent) => {
-      const elements = Array.isArray(element) ? element : [element];
+      const elements = Array.isArray(element)
+        ? element
+        : [element].filter(Boolean);
 
       const hasClickedInside = elements.some(el =>
         el?.contains(event.target as HTMLElement),


### PR DESCRIPTION
## Beskrivelse

Støtte for kontrollert `<Popover>` uten `<PopoverGroup>` i corner cases. Behov hos Beramming.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
