### PR TITLE
ELSA1-520 Fikser tvunget `undefined` verdi for props i Storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -32,6 +32,7 @@ const config: StorybookConfig = {
   typescript: {
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
+      shouldRemoveUndefinedFromOptional: true,
       shouldExtractLiteralValuesFromEnum: true,
       propFilter: prop =>
         prop.parent ? !/node_modules/.test(prop.parent.fileName) : true,

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -15,6 +15,7 @@ let nameCounter = 0;
 
 const preview: Preview = {
   parameters: {
+    controls: { sort: 'requiredFirst' },
     options: {
       storySort: {
         method: 'alphabetical',
@@ -31,6 +32,7 @@ const preview: Preview = {
           </Unstyled>
         </DocsContainer>
       ),
+      controls: { sort: 'requiredFirst' },
     },
   },
   decorators: [

--- a/packages/dds-components/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/dds-components/src/components/Accordion/Accordion.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import {
   DetailList,
@@ -25,8 +26,7 @@ export default {
     },
   },
   argTypes: {
-    isExpanded: { control: 'boolean' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
 } satisfies Meta<typeof Accordion>;
 

--- a/packages/dds-components/src/components/BackLink/BackLink.stories.tsx
+++ b/packages/dds-components/src/components/BackLink/BackLink.stories.tsx
@@ -1,5 +1,7 @@
 import { type StoryObj } from '@storybook/react';
 
+import { categoryHtml, htmlEventArgType } from '../../storybook/helpers';
+
 import { BackLink } from '.';
 
 export default {
@@ -12,12 +14,10 @@ export default {
     },
   },
   argTypes: {
-    label: {
-      control: 'text',
-    },
     href: {
-      control: 'text',
+      table: categoryHtml,
     },
+    onClick: htmlEventArgType,
   },
 };
 

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumb.stories.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumb.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { categoryHtml } from '../../storybook/helpers';
 import { StoryVStack } from '../Stack/utils';
 
 import { Breadcrumb } from '.';
@@ -13,7 +14,12 @@ export default {
       canvas: { sourceState: 'shown' },
     },
   },
-  argTypes: { href: { control: { type: 'text' } } },
+  argTypes: {
+    href: {
+      control: 'text',
+      table: categoryHtml,
+    },
+  },
 } satisfies Meta<typeof Breadcrumb>;
 
 type Story = StoryObj<typeof Breadcrumb>;

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { StoryVStack } from '../Stack/utils';
 
 import { Breadcrumb, Breadcrumbs } from '.';
@@ -12,6 +13,9 @@ export default {
       story: { inline: true },
       canvas: { sourceState: 'shown' },
     },
+  },
+  argTypes: {
+    htmlProps: htmlPropsArgType,
   },
 } satisfies Meta<typeof Breadcrumbs>;
 

--- a/packages/dds-components/src/components/Button/Button.stories.tsx
+++ b/packages/dds-components/src/components/Button/Button.stories.tsx
@@ -1,6 +1,11 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { ArrowLeftIcon } from '../..';
+import {
+  categoryHtml,
+  htmlEventArgType,
+  htmlPropsArgType,
+} from '../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
 
 import { Button } from '.';
@@ -15,14 +20,14 @@ export default {
     },
   },
   argTypes: {
-    loading: { control: 'boolean' },
-    fullWidth: { control: 'boolean' },
-    href: { control: 'text' },
+    href: { table: categoryHtml },
     children: { control: 'text' },
-    loadingTooltip: { control: 'text' },
-    htmlProps: { control: false },
-    target: { control: false },
+    target: { control: false, table: categoryHtml },
     icon: { control: false },
+    htmlProps: htmlPropsArgType,
+    onClick: htmlEventArgType,
+    onBlur: htmlEventArgType,
+    onFocus: htmlEventArgType,
   },
 } satisfies Meta<typeof Button>;
 

--- a/packages/dds-components/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/dds-components/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { categoryHtml, htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button/Button';
 import { StoryVStack } from '../Stack/utils';
 
@@ -15,10 +16,10 @@ export default {
     },
   },
   argTypes: {
-    role: { control: 'text' },
-    'aria-label': { control: 'text' },
-    'aria-labelledby': { control: 'text' },
-    htmlProps: { control: false },
+    role: { control: 'text', table: categoryHtml },
+    'aria-label': { table: categoryHtml },
+    'aria-labelledby': { table: categoryHtml },
+    htmlProps: htmlPropsArgType,
   },
 } satisfies Meta<typeof ButtonGroup>;
 

--- a/packages/dds-components/src/components/Card/Card.stories.tsx
+++ b/packages/dds-components/src/components/Card/Card.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import {
   DescriptionList,
   DescriptionListDesc,
@@ -27,7 +28,7 @@ export default {
     },
   },
   argTypes: {
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
     cardRef: { control: false },
   },
 } satisfies Meta<typeof Card>;

--- a/packages/dds-components/src/components/Card/Card.tsx
+++ b/packages/dds-components/src/components/Card/Card.tsx
@@ -26,7 +26,7 @@ type BaseCardProps<T extends HTMLElement> = BaseComponentPropsWithChildren<
 >;
 
 export type InfoCardProps = BaseCardProps<HTMLDivElement> & {
-  /** Spesifiserer funksjonalitet og formål med komponenten. **OBS!** ved `'navigation'` må `href` oppgis. Ved `'expandable'` må alle `<Card />` grupperte sammen ligge egen `<div>` container. */
+  /** Spesifiserer funksjonalitet og formål med komponenten. **OBS!** ved `'navigation'` må `href` oppgis. */
   cardType: 'info';
 };
 

--- a/packages/dds-components/src/components/Chip/Chip.stories.tsx
+++ b/packages/dds-components/src/components/Chip/Chip.stories.tsx
@@ -1,5 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
+
 import { Chip } from '.';
 
 export default {
@@ -12,8 +14,7 @@ export default {
     },
   },
   argTypes: {
-    text: { control: { type: 'text' } },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
 } satisfies Meta<typeof Chip>;
 

--- a/packages/dds-components/src/components/Chip/ChipGroup.stories.tsx
+++ b/packages/dds-components/src/components/Chip/ChipGroup.stories.tsx
@@ -1,5 +1,7 @@
 import { type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
+
 import { Chip, ChipGroup } from '.';
 
 export default {
@@ -12,7 +14,7 @@ export default {
     },
   },
   argTypes: {
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
 };
 

--- a/packages/dds-components/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/packages/dds-components/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { CallIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
 import { Typography } from '../Typography';
@@ -21,7 +22,7 @@ export default {
     },
   },
   argTypes: {
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
 } satisfies Meta<typeof DescriptionList>;
 

--- a/packages/dds-components/src/components/DetailList/DetailList.stories.tsx
+++ b/packages/dds-components/src/components/DetailList/DetailList.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { InlineButton } from '../InlineButton';
 
 import { DetailList, DetailListDesc, DetailListRow, DetailListTerm } from '.';
@@ -13,9 +14,7 @@ export default {
     },
   },
   argTypes: {
-    htmlProps: { control: false },
-    withDividers: { control: 'boolean' },
-    striped: { control: 'boolean' },
+    htmlProps: htmlPropsArgType,
   },
 } satisfies Meta<typeof DetailList>;
 

--- a/packages/dds-components/src/components/Divider/Divider.stories.tsx
+++ b/packages/dds-components/src/components/Divider/Divider.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { Contrast } from '../Contrast';
 import { Typography } from '../Typography';
 
@@ -15,7 +16,7 @@ export default {
     },
   },
   argTypes: {
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
 } satisfies Meta<typeof Divider>;
 

--- a/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
@@ -2,6 +2,7 @@ import { type Story } from '@storybook/blocks';
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { StoryVStack } from '../Stack/utils';
 import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
@@ -19,8 +20,7 @@ const meta: Meta<typeof Drawer> = {
     },
   },
   argTypes: {
-    withBackdrop: { control: 'boolean' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
     parentElement: { control: false },
     widthProps: { control: false },
   },

--- a/packages/dds-components/src/components/EmptyContent/EmptyContent.stories.tsx
+++ b/packages/dds-components/src/components/EmptyContent/EmptyContent.stories.tsx
@@ -7,12 +7,6 @@ import { Link } from '../Typography';
 export default {
   title: 'dds-components/EmptyContent',
   component: EmptyContent,
-  argTypes: {
-    title: {
-      name: 'title',
-      type: { name: 'string', required: false },
-    },
-  },
   parameters: {
     docs: {
       story: { inline: true },
@@ -24,7 +18,7 @@ export default {
 type Story = StoryObj<typeof EmptyContent>;
 
 export const Default: Story = {
-  args: { title: 'Tittel', message: 'Dette er en tekst.' },
+  args: { headerText: 'Tittel', message: 'Dette er en tekst.' },
 };
 
 export const Overview: Story = {
@@ -60,7 +54,7 @@ export const Overview: Story = {
 
 export const ComplexContent: Story = {
   args: {
-    title: 'Tittel',
+    headerText: 'Tittel',
     message: (
       <>
         Dette er en forklaring. Du kan <Link href="/">registrere en aktør</Link>

--- a/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
+++ b/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
@@ -2,6 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { useRef, useState } from 'react';
 
 import { FavStar } from './FavStar';
+import { categoryHtml, htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { AttachmentIcon } from '../Icon/icons';
@@ -21,9 +22,9 @@ const meta: Meta<typeof FavStar> = {
     },
   },
   argTypes: {
-    checked: { control: { type: 'boolean' } },
-    defaultChecked: { control: false },
-    htmlProps: { control: false },
+    checked: { control: false, table: categoryHtml },
+    defaultChecked: { table: categoryHtml },
+    htmlProps: htmlPropsArgType,
   },
 };
 

--- a/packages/dds-components/src/components/Feedback/Feedback.stories.tsx
+++ b/packages/dds-components/src/components/Feedback/Feedback.stories.tsx
@@ -8,56 +8,11 @@ export default {
   title: 'dds-components/Feedback',
   component: Feedback,
   argTypes: {
-    layout: {
-      control: {
-        type: 'radio',
-        options: {
-          vertical: 'vertical',
-          horizontal: 'horizontal',
-        },
-      },
-    },
-    ratingLabel: {
-      control: 'text',
-    },
     ratingValue: {
       options: [null, 'positive', 'negative'],
       control: {
         type: 'radio',
       },
-    },
-    positiveFeedbackLabel: {
-      control: 'text',
-    },
-    negativeFeedbackLabel: {
-      control: 'text',
-    },
-    feedbackTextValue: {
-      control: 'text',
-    },
-    thumbUpTooltip: {
-      control: 'text',
-    },
-    thumbDownTooltip: {
-      control: 'text',
-    },
-    ratingSubmittedTitle: {
-      control: 'text',
-    },
-    submittedTitle: {
-      control: 'text',
-    },
-    textAreaTip: {
-      control: 'text',
-    },
-    feedbackTextAreaExcluded: {
-      control: 'boolean',
-    },
-    loading: {
-      control: 'boolean',
-    },
-    isSubmitted: {
-      control: 'boolean',
     },
   },
   parameters: {

--- a/packages/dds-components/src/components/Fieldset/Fieldset.stories.tsx
+++ b/packages/dds-components/src/components/Fieldset/Fieldset.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { Fieldset } from './Fieldset';
+import { categoryHtml, htmlPropsArgType } from '../../storybook/helpers';
 import { TextInput } from '../TextInput';
 import { Legend } from '../Typography';
 
@@ -8,8 +9,8 @@ export default {
   title: 'dds-components/Fieldset',
   component: Fieldset,
   argTypes: {
-    disabled: { control: { type: 'boolean' } },
-    htmlProps: { control: false },
+    disabled: { table: categoryHtml },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/FileUploader/FileUploader.stories.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.stories.tsx
@@ -2,6 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { FileUploader } from './FileUploader';
+import { categoryHtml } from '../../storybook/helpers';
 import { StoryVStack } from '../Stack/utils';
 import { Heading, Paragraph } from '../Typography';
 
@@ -9,17 +10,8 @@ export default {
   title: 'dds-components/FileUploader',
   component: FileUploader,
   argTypes: {
-    label: { control: 'text' },
-    dropAreaLabel: { control: 'text' },
-    btnLabel: { control: 'text' },
-    tip: { control: 'text' },
-    maxFiles: { control: 'number' },
-    withDragAndDrop: { control: 'boolean' },
-    errorMessage: { control: 'text' },
-    required: { control: 'boolean' },
-    disabled: { control: 'boolean' },
     width: { control: 'text' },
-    id: { control: false },
+    id: { control: false, table: categoryHtml },
     initialFiles: { control: false },
     accept: { control: false },
   },
@@ -33,13 +25,7 @@ export default {
 
 type Story = StoryObj<typeof FileUploader>;
 
-export const Default: Story = {
-  args: {
-    label: 'Last opp fil',
-    dropAreaLabel: 'Dra og slipp fil her eller',
-    btnLabel: 'Velg fil',
-  },
-};
+export const Default: Story = {};
 
 const SingleFileUploader = () => {
   const [files, setFiles] = useState<Array<File>>([]);

--- a/packages/dds-components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.tsx
@@ -25,11 +25,11 @@ export type FileUploaderProps = {
   /**Ledetekst for filopplaster. */
   label?: string;
   /**Ledetekst for slippsonen. Denne teksten skal, av UU-hensyn, henge sammen med den usynlige teksten: "velg fil med påfølgende knapp"
-   * @default "Dra og slipp filer her eller"
+   * @default Dra og slipp filer her eller
    */
   dropAreaLabel?: string;
   /**Ledetekst for opplastingsknappen.
-   * @default "Velg fil"
+   * @default Velg fil
    */
   btnLabel?: string;
   /**Hjelpetekst. */

--- a/packages/dds-components/src/components/GlobalMessage/GlobalMessage.stories.tsx
+++ b/packages/dds-components/src/components/GlobalMessage/GlobalMessage.stories.tsx
@@ -1,15 +1,14 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { GlobalMessage } from './GlobalMessage';
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { StoryVStack } from '../Stack/utils';
 
 export default {
   title: 'dds-components/GlobalMessage',
   component: GlobalMessage,
   argTypes: {
-    message: { control: 'text' },
-    closable: { control: 'boolean' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Grid/Grid.stories.tsx
+++ b/packages/dds-components/src/components/Grid/Grid.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { FilterIcon, PlusIcon } from '../Icon/icons';
 import { InternalHeader } from '../InternalHeader';
@@ -16,6 +17,12 @@ import { Grid, GridChild } from '.';
 export default {
   title: 'dds-components/Grid',
   component: Grid,
+  argTypes: {
+    htmlProps: htmlPropsArgType,
+    columnGap: { control: false },
+    maxWidth: { control: false },
+    rowGap: { control: false },
+  },
   parameters: {
     docs: {
       story: { inline: true },

--- a/packages/dds-components/src/components/Grid/GridChild.stories.tsx
+++ b/packages/dds-components/src/components/Grid/GridChild.stories.tsx
@@ -6,7 +6,7 @@ export default {
   title: 'dds-components/Grid/GridChild',
   component: GridChild,
   argTypes: {
-    gridRow: { control: 'text' },
+    gridRow: { control: false },
     justifySelf: { control: 'text' },
     // feil props vises i tabell, quick fix for å unngå forvirring
     // TODO: fikse åvise riktige props

--- a/packages/dds-components/src/components/Icon/Icon.stories.tsx
+++ b/packages/dds-components/src/components/Icon/Icon.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { OpenExternalIcon as OpenExternal } from './icons/openExternal';
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { StoryHStack } from '../Stack/utils';
 import { Paragraph } from '../Typography';
 
@@ -11,7 +12,7 @@ export default {
   component: Icon,
   argTypes: {
     color: { control: 'text' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
     icon: { control: false },
   },
   parameters: {

--- a/packages/dds-components/src/components/InlineEdit/InlineEdit.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEdit.stories.tsx
@@ -3,29 +3,21 @@ import { useState } from 'react';
 
 import { InlineEditInput } from './InlineEditInput';
 import { InlineEditTextArea } from './InlineEditTextArea';
+import { htmlEventArgType } from '../../storybook/helpers';
 import { StoryVStack } from '../Stack/utils';
 
 export default {
   title: 'dds-components/InlineEdit',
   component: InlineEditInput,
   argTypes: {
-    emptiable: { control: { type: 'boolean' } },
-    error: { control: { type: 'boolean' } },
-    errorMessage: { control: { type: 'text' } },
     width: { control: { type: 'text' } },
+    onFocus: htmlEventArgType,
+    onBlur: htmlEventArgType,
+    onChange: htmlEventArgType,
   },
   parameters: {
     controls: {
-      exclude: [
-        'style',
-        'className',
-        'onFocus',
-        'onBlur',
-        'onChange',
-        'onSetValue',
-        'inputRef',
-        'children',
-      ],
+      exclude: ['style', 'className', 'onSetValue', 'inputRef', 'children'],
     },
   },
 } satisfies Meta<typeof InlineEditInput>;

--- a/packages/dds-components/src/components/InlineEdit/InlineEditInput.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEditInput.stories.tsx
@@ -9,11 +9,7 @@ export default {
   title: 'dds-components/InlineEdit/InlineEditInput',
   component: InlineEditInput,
   argTypes: {
-    emptiable: { control: { type: 'boolean' } },
-    error: { control: { type: 'boolean' } },
-    errorMessage: { control: { type: 'text' } },
     width: { control: { type: 'text' } },
-    hideIcon: { control: { type: 'boolean' } },
   },
   parameters: {
     controls: {

--- a/packages/dds-components/src/components/InlineEdit/InlineEditTextArea.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEditTextArea.stories.tsx
@@ -9,11 +9,7 @@ export default {
   title: 'dds-components/InlineEdit/InlineEditTextArea',
   component: InlineEditTextArea,
   argTypes: {
-    emptiable: { control: { type: 'boolean' } },
-    error: { control: { type: 'boolean' } },
-    errorMessage: { control: { type: 'text' } },
     width: { control: { type: 'text' } },
-    hideIcon: { control: { type: 'boolean' } },
   },
   parameters: {
     controls: {

--- a/packages/dds-components/src/components/InputMessage/InputMessage.stories.tsx
+++ b/packages/dds-components/src/components/InputMessage/InputMessage.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { StoryHStack } from '../Stack/utils';
 
 import { InputMessage } from '.';
@@ -8,8 +9,7 @@ export default {
   title: 'dds-components/InputMessage',
   component: InputMessage,
   argTypes: {
-    message: { control: 'text' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
@@ -2,6 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { InputStepper } from './InputStepper';
+import { categoryHtml, htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
 
@@ -9,21 +10,10 @@ export default {
   title: 'dds-components/InputStepper',
   component: InputStepper,
   argTypes: {
-    componentSize: { control: 'radio' },
-    label: { control: 'text' },
-    decreaseButtonLabel: { control: 'text' },
-    increaseButtonLabel: { control: 'text' },
-    maxValue: { control: 'number' },
-    minValue: { control: 'number' },
-    step: { control: 'number' },
-    defaultValue: { control: 'number' },
-    disabled: { control: 'boolean' },
-    readOnly: { control: 'boolean' },
-    errorMessage: { control: 'text' },
-    tip: { control: 'text' },
-    value: { control: 'number' },
-    onChange: { control: false },
-    htmlProps: { control: false },
+    defaultValue: { control: 'number', table: categoryHtml },
+    disabled: { table: categoryHtml },
+    value: { control: 'number', table: categoryHtml },
+    htmlProps: htmlPropsArgType,
   },
 
   parameters: {

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.stories.tsx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { EditIcon } from '../Icon/icons';
 import { StoryVStack } from '../Stack/utils';
 
@@ -9,14 +10,10 @@ export default {
   title: 'dds-components/InternalHeader',
   component: InternalHeader,
   argTypes: {
-    applicationName: { control: 'text' },
-    applicationDesc: { control: 'text' },
-    currentPageHref: { control: 'text' },
-    applicationHref: { control: 'text' },
     navItems: { control: false },
     contextMenuItems: { control: false },
     user: { control: false },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/List/List.stories.tsx
+++ b/packages/dds-components/src/components/List/List.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { StoryHStack } from '../Stack/utils';
 import { Typography } from '../Typography';
 
@@ -15,7 +16,7 @@ export default {
     },
   },
   argTypes: {
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
 } satisfies Meta<typeof List>;
 

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { LocalMessage } from './LocalMessage';
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { List, ListItem } from '../List';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
 import { Heading, Paragraph } from '../Typography';
@@ -9,13 +10,8 @@ export default {
   title: 'dds-components/LocalMessage',
   component: LocalMessage,
   argTypes: {
-    message: {
-      control: 'text',
-      defaultValue: 'En tilfeldig melding',
-    },
     width: { control: 'text' },
-    closable: { control: 'boolean' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/dds-components/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useRef, useState } from 'react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { Search } from '../Search';
 import { StoryHStack } from '../Stack/utils';
@@ -25,7 +26,7 @@ const meta: Meta<typeof Modal> = {
     isOpen: { control: false },
     triggerRef: { control: false },
     initialFocusRef: { control: false },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { EditIcon, MenuIcon, PersonIcon, TrashIcon } from '../Icon/icons';
 import { VStack } from '../Stack';
@@ -20,8 +21,7 @@ export default {
   title: 'dds-components/OverflowMenu',
   component: OverflowMenu,
   argTypes: {
-    offset: { control: 'number' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { StoryVStack } from '../Stack/utils';
 import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
 
@@ -9,13 +10,8 @@ const meta: Meta<typeof Pagination> = {
   title: 'dds-components/Pagination',
   component: Pagination,
   argTypes: {
-    withCounter: { control: 'boolean' },
-    withPagination: { control: 'boolean' },
-    withSelect: { control: 'boolean' },
-    defaultItemsPerPage: { control: 'number' },
-    defaultActivePage: { control: 'number' },
     selectOptions: { control: false },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.stories.tsx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
+import { categoryHtml } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
 
@@ -10,14 +11,10 @@ export default {
   title: 'dds-components/PhoneInput',
   component: PhoneInput,
   argTypes: {
-    label: { control: { type: 'text' } },
-    tip: { control: { type: 'text' } },
-    errorMessage: { control: 'text' },
     width: { control: 'text' },
-    selectLabel: { control: 'text' },
-    required: { control: { type: 'boolean' } },
-    disabled: { control: { type: 'boolean' } },
-    readOnly: { control: { type: 'boolean' } },
+    required: { control: 'boolean', table: categoryHtml },
+    disabled: { control: 'boolean', table: categoryHtml },
+    readOnly: { control: 'boolean' },
     selectRef: { control: false },
     value: { control: false },
     defaultValue: { control: false },

--- a/packages/dds-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.stories.tsx
@@ -2,6 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { useRef, useState } from 'react';
 
 import { type Placement } from '../../hooks';
+import { htmlEventArgType, htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { InlineButton } from '../InlineButton';
 import { LocalMessage } from '../LocalMessage';
@@ -15,14 +16,11 @@ export default {
   title: 'dds-components/Popover',
   component: Popover,
   argTypes: {
-    withCloseButton: { control: 'boolean' },
-    placement: { control: 'text' },
     header: { control: 'text' },
-    offset: { control: 'number' },
-    returnFocusOnBlur: { control: 'boolean' },
+    onBlur: htmlEventArgType,
     isOpen: { control: false },
     anchorRef: { control: false },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
     sizeProps: { control: false },
   },
   parameters: {

--- a/packages/dds-components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/dds-components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -8,11 +8,7 @@ export default {
   title: 'dds-components/ProgressBar',
   component: ProgressBar,
   argTypes: {
-    tip: { control: 'text' },
-    errorMessage: { control: 'text' },
     width: { control: 'text' },
-    value: { control: 'number' },
-    max: { control: 'number' },
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
@@ -2,6 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { ProgressTracker } from './ProgressTracker';
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { Drawer, DrawerGroup } from '../Drawer';
 import { Fieldset } from '../Fieldset';
@@ -24,8 +25,7 @@ export default {
   title: 'dds-components/ProgressTracker',
   component: ProgressTracker,
   argTypes: {
-    activeStep: { control: 'number' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Search/Search.stories.tsx
+++ b/packages/dds-components/src/components/Search/Search.stories.tsx
@@ -8,8 +8,6 @@ export default {
   title: 'dds-components/Search',
   component: Search,
   argTypes: {
-    tip: { control: 'text' },
-    label: { control: 'text' },
     buttonProps: { control: false },
   },
   parameters: {

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { categoryHtml } from '../../../storybook/helpers';
 import { StoryVStack } from '../../Stack/utils';
 
 import { NativeSelect, NativeSelectPlaceholder } from '.';
@@ -18,8 +19,8 @@ export default {
     tip: { control: 'text' },
     errorMessage: { control: 'text' },
     width: { control: 'text' },
-    disabled: { control: 'boolean' },
-    required: { control: 'boolean' },
+    disabled: { control: 'boolean', table: categoryHtml },
+    required: { control: 'boolean', table: categoryHtml },
     readOnly: { control: 'boolean' },
   },
 } satisfies Meta<typeof NativeSelect>;

--- a/packages/dds-components/src/components/Select/Select.stories.tsx
+++ b/packages/dds-components/src/components/Select/Select.stories.tsx
@@ -14,9 +14,6 @@ const meta: Meta<typeof Select> = {
   title: 'dds-components/Select/Select',
   component: Select,
   argTypes: {
-    label: { control: 'text' },
-    tip: { control: 'text' },
-    errorMessage: { control: 'text' },
     width: { control: 'text' },
     placeholder: { control: 'text' },
     isDisabled: { control: 'boolean' },

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { categoryHtml, htmlPropsArgType } from '../../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../../Stack/utils';
 
 import { Checkbox } from '.';
@@ -8,12 +9,16 @@ export default {
   title: 'dds-components/Checkbox',
   component: Checkbox,
   argTypes: {
-    label: { control: { type: 'text' } },
-    error: { control: { type: 'boolean' } },
-    disabled: { control: { type: 'boolean' } },
-    readOnly: { control: { type: 'boolean' } },
-    indeterminate: { control: { type: 'boolean' } },
-    htmlProps: { control: false },
+    disabled: { table: categoryHtml },
+    htmlProps: htmlPropsArgType,
+    'aria-describedby': { control: false, table: categoryHtml },
+    name: { control: false, table: categoryHtml },
+    checked: { control: false, table: categoryHtml },
+    defaultChecked: { control: false, table: categoryHtml },
+    value: { control: false, table: categoryHtml },
+    defaultValue: { control: false, table: categoryHtml },
+    onChange: { control: false, table: categoryHtml },
+    onBlur: { control: false, table: categoryHtml },
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../../storybook/helpers';
 import { Fieldset } from '../../Fieldset';
 import { StoryHStack, StoryVStack } from '../../Stack/utils';
 import { Legend } from '../../Typography';
@@ -10,12 +11,10 @@ export default {
   title: 'dds-components/Checkbox/CheckboxGroup',
   component: CheckboxGroup,
   argTypes: {
-    label: { control: { type: 'text' } },
-    tip: { control: { type: 'text' } },
-    errorMessage: { control: { type: 'text' } },
-    required: { control: { type: 'boolean' } },
-    disabled: { control: { type: 'boolean' } },
-    readOnly: { control: { type: 'boolean' } },
+    required: { control: 'boolean' },
+    disabled: { control: 'boolean' },
+    readOnly: { control: 'boolean' },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { categoryHtml, htmlPropsArgType } from '../../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../../Stack/utils';
 
 import { RadioButton } from '.';
@@ -8,11 +9,8 @@ export default {
   title: 'dds-components/RadioButton',
   component: RadioButton,
   argTypes: {
-    label: { control: { type: 'text' } },
-    error: { control: { type: 'boolean' } },
-    disabled: { control: { type: 'boolean' } },
-    readOnly: { control: { type: 'boolean' } },
-    htmlProps: { control: false },
+    disabled: { table: categoryHtml },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/SkipToContent/SkipToContent.stories.tsx
+++ b/packages/dds-components/src/components/SkipToContent/SkipToContent.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { Heading } from '../Typography';
 
 import { SkipToContent } from '.';
@@ -8,9 +9,8 @@ export default {
   title: 'dds-components/SkipToContent',
   component: SkipToContent,
   argTypes: {
-    text: { control: 'text' },
     top: { control: 'text' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/dds-components/src/components/Spinner/Spinner.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { StoryHStack } from '../Stack/utils';
 
 import { Spinner } from '.';
@@ -10,8 +11,7 @@ export default {
   argTypes: {
     color: { control: 'text' },
     size: { control: 'text' },
-    tooltip: { control: 'text', defaultValue: 'Innlasting pågår' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Stack/Stack.stories.tsx
+++ b/packages/dds-components/src/components/Stack/Stack.stories.tsx
@@ -1,12 +1,13 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { HStack, VStack } from './Stack';
+import { htmlPropsArgType } from '../../storybook/helpers';
 
 export default {
   title: 'dds-components/Stack',
   component: HStack,
   argTypes: {
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
     align: { control: 'text' },
     justify: { control: 'text' },
   },

--- a/packages/dds-components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
+++ b/packages/dds-components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
@@ -22,19 +22,6 @@ import { CollapsibleTable } from '.';
 const meta: Meta<typeof CollapsibleTable> = {
   title: 'dds-components/Table/CollapsibleTable',
   component: CollapsibleTable,
-  argTypes: {
-    isCollapsed: {
-      control: { type: 'boolean' },
-    },
-    stickyHeader: {
-      control: { type: 'boolean' },
-    },
-    withDividers: {
-      control: {
-        type: 'boolean',
-      },
-    },
-  },
   parameters: {
     controls: {
       exclude: ['headerValues', 'definingColumnIndex'],

--- a/packages/dds-components/src/components/Table/normal/Table.stories.tsx
+++ b/packages/dds-components/src/components/Table/normal/Table.stories.tsx
@@ -20,18 +20,6 @@ import { type SortOrder, Table } from '.';
 const meta: Meta<typeof Table> = {
   title: 'dds-components/Table',
   component: Table,
-  argTypes: {
-    stickyHeader: {
-      control: {
-        type: 'boolean',
-      },
-    },
-    withDividers: {
-      control: {
-        type: 'boolean',
-      },
-    },
-  },
   parameters: {
     docs: {
       story: { inline: true },

--- a/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { NotificationsIcon } from '../Icon/icons';
 import { StoryVStack } from '../Stack/utils';
 import { TextArea } from '../TextArea';
@@ -13,9 +14,8 @@ export default {
   component: Tabs,
   argTypes: {
     width: { control: 'text' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
     addTabButtonProps: { control: false },
-    activeTab: { control: 'number' },
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/dds-components/src/components/Tag/Tag.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
 
 import { Tag } from '.';
@@ -8,10 +9,8 @@ export default {
   title: 'dds-components/Tag',
   component: Tag,
   argTypes: {
-    text: { control: 'text' },
-    withIcon: { control: 'boolean' },
     children: { control: 'text' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
 } satisfies Meta<typeof Tag>;
 

--- a/packages/dds-components/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/dds-components/src/components/TextArea/TextArea.stories.tsx
@@ -1,20 +1,18 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { TextArea } from './TextArea';
+import { categoryHtml } from '../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
 
 export default {
   title: 'dds-components/TextArea',
   component: TextArea,
   argTypes: {
-    label: { control: 'text' },
-    tip: { control: 'text' },
-    errorMessage: { control: 'text' },
     width: { control: 'text' },
-    maxLength: { control: 'number' },
-    required: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    readOnly: { control: 'boolean' },
+    maxLength: { control: 'number', table: categoryHtml },
+    required: { control: 'boolean', table: categoryHtml },
+    disabled: { control: 'boolean', table: categoryHtml },
+    readOnly: { control: 'boolean', table: categoryHtml },
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { categoryHtml } from '../../storybook/helpers';
 import { MailIcon } from '../Icon/icons';
 import { LocalMessage } from '../LocalMessage';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
@@ -10,17 +11,12 @@ export default {
   title: 'dds-components/TextInput',
   component: TextInput,
   argTypes: {
-    label: { control: { type: 'text' } },
-    tip: { control: { type: 'text' } },
-    errorMessage: { control: { type: 'text' } },
     width: { control: { type: 'text' } },
-    withCharacterCounter: { control: { type: 'boolean' } },
-    maxLength: { control: { type: 'number' } },
-    required: { control: { type: 'boolean' } },
-    disabled: { control: { type: 'boolean' } },
-    readOnly: { control: { type: 'boolean' } },
+    maxLength: { control: 'number', table: categoryHtml },
+    required: { control: 'boolean', table: categoryHtml },
+    disabled: { control: 'boolean', table: categoryHtml },
+    readOnly: { control: 'boolean', table: categoryHtml },
     prefix: { control: { type: 'text' } },
-    suffix: { control: { type: 'text' } },
     icon: { control: { disable: true } },
   },
   parameters: {

--- a/packages/dds-components/src/components/TextInput/TextInput.types.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.types.tsx
@@ -7,14 +7,12 @@ export type TextInputProps = InputProps & {
   /** Ikonet som vises i komponenten. */
   icon?: SvgIcon;
   /**
-   * Prefiks som vises før inputfeltet.
-   * OBS! Prefiks leses ikke av skjermleser og skal derfor ikke brukes som en erstatter
-   * for en beskrivende label. */
+   * Prefiks som vises før inputfeltet. **OBS!** Prefiks leses ikke av skjermleser og skal derfor ikke brukes som en erstatter for en beskrivende label.
+   * */
   prefix?: string;
   /**
-   * Suffiks som vises etter inputfeltet.
-   * OBS! Suffiks leses ikke av skjermleser og skal derfor ikke brukes som en erstatter
-   * for en beskrivende label. */
+   * Suffiks som vises etter inputfeltet. **OBS!** Suffiks leses ikke av skjermleser og skal derfor ikke brukes som en erstatter for en beskrivende label.
+   */
   suffix?: string;
 };
 

--- a/packages/dds-components/src/components/Toggle/Toggle.mdx
+++ b/packages/dds-components/src/components/Toggle/Toggle.mdx
@@ -20,5 +20,3 @@ import * as ToggleStories from './Toggle.stories';
 
 <Canvas of={ToggleStories.Preview} />
 <Controls of={ToggleStories.Preview} />
-
-Native HTML-attributter `aria-describedby`, `name`, `value`, `defaultValue`, `onBlur` støttes på toppnivå.

--- a/packages/dds-components/src/components/Toggle/Toggle.stories.tsx
+++ b/packages/dds-components/src/components/Toggle/Toggle.stories.tsx
@@ -1,6 +1,11 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
+import {
+  categoryHtml,
+  htmlEventArgType,
+  htmlPropsArgType,
+} from '../../storybook/helpers';
 import { Button } from '../Button';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
 
@@ -11,12 +16,15 @@ export default {
   component: Toggle,
   argTypes: {
     children: { control: 'text' },
-    disabled: { control: 'boolean' },
-    readOnly: { control: 'boolean' },
-    isLoading: { control: 'boolean' },
-    checked: { control: 'boolean' },
-    defaultChecked: { control: 'boolean' },
-    htmlProps: { control: false },
+    disabled: { table: categoryHtml },
+    checked: { table: categoryHtml },
+    defaultChecked: { table: categoryHtml },
+    value: { control: 'boolean', table: categoryHtml },
+    defaultValue: { control: 'boolean', table: categoryHtml },
+    name: { table: categoryHtml },
+    'aria-describedby': { table: categoryHtml },
+    onBlur: htmlEventArgType,
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { PlusCircledIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
 
@@ -10,11 +11,9 @@ export default {
   title: 'dds-components/ToggleBar',
   component: ToggleBar,
   argTypes: {
-    label: { control: 'text' },
-    name: { control: 'text' },
     width: { control: 'text' },
     value: { control: false },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/packages/dds-components/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { categoryHtml, htmlPropsArgType } from '../../storybook/helpers';
 import { NotificationsIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
 
@@ -9,8 +10,15 @@ export default {
   title: 'dds-components/ToggleButton',
   component: ToggleButton,
   argTypes: {
-    label: { control: 'text' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
+    'aria-describedby': { control: 'text', table: categoryHtml },
+    name: { control: false, table: categoryHtml },
+    checked: { control: false, table: categoryHtml },
+    defaultChecked: { control: 'boolean', table: categoryHtml },
+    value: { control: false, table: categoryHtml },
+    defaultValue: { control: false, table: categoryHtml },
+    onChange: { control: false, table: categoryHtml },
+    onBlur: { control: false, table: categoryHtml },
     icon: { control: false },
   },
   parameters: {

--- a/packages/dds-components/src/components/ToggleButton/ToggleButtonGroup.stories.tsx
+++ b/packages/dds-components/src/components/ToggleButton/ToggleButtonGroup.stories.tsx
@@ -1,13 +1,14 @@
 import { type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
+
 import { ToggleButton, ToggleButtonGroup } from '.';
 
 export default {
   title: 'dds-components/ToggleButton/ToggleButtonGroup',
   component: ToggleButtonGroup,
   argTypes: {
-    label: { control: 'text' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
     labelId: { control: false },
   },
   parameters: {

--- a/packages/dds-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/dds-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { HelpIcon } from '../Icon/icons';
 import { VStack } from '../Stack';
@@ -11,9 +12,7 @@ export default {
   title: 'dds-components/Tooltip',
   component: Tooltip,
   argTypes: {
-    text: { control: 'text' },
-    delay: { control: 'number' },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
     children: { control: false },
     tooltipId: { control: false },
   },

--- a/packages/dds-components/src/components/Typography/Caption/Caption.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Caption/Caption.stories.tsx
@@ -1,13 +1,14 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../../storybook/helpers';
+
 import { Caption } from '.';
 
 export default {
   title: 'dds-components/Typography/Caption',
   component: Caption,
   argTypes: {
-    withMargins: { control: { type: 'boolean' } },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../../storybook/helpers';
 import { StoryVStack } from '../../Stack/utils';
 
 import { Heading } from '.';
@@ -8,8 +9,7 @@ export default {
   title: 'dds-components/Typography/Heading',
   component: Heading,
   argTypes: {
-    withMargins: { control: { type: 'boolean' } },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Typography/Label/Label.mdx
+++ b/packages/dds-components/src/components/Typography/Label/Label.mdx
@@ -21,5 +21,3 @@ import * as LabelStories from './Label.stories';
 
 <Canvas of={LabelStories.Default} />
 <Controls of={LabelStories.Default} />
-
-`htmlFor` støttes på toppnivå.

--- a/packages/dds-components/src/components/Typography/Label/Label.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Label/Label.stories.tsx
@@ -1,13 +1,15 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { categoryHtml, htmlPropsArgType } from '../../../storybook/helpers';
+
 import { Label } from '.';
 
 export default {
   title: 'dds-components/Typography/Label',
   component: Label,
   argTypes: {
-    withMargins: { control: { type: 'boolean' } },
-    htmlProps: { control: false },
+    htmlFor: { control: false, table: categoryHtml },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Typography/Legend/Legend.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Legend/Legend.stories.tsx
@@ -1,13 +1,13 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { Legend } from '..';
+import { htmlPropsArgType } from '../../../storybook/helpers';
 
 export default {
   title: 'dds-components/Typography/Legend',
   component: Legend,
   argTypes: {
-    withMargins: { control: { type: 'boolean' } },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Typography/Link/Link.mdx
+++ b/packages/dds-components/src/components/Typography/Link/Link.mdx
@@ -25,8 +25,6 @@ import * as LinkStories from './Link.stories';
 <Canvas of={LinkStories.Default} />
 <Controls of={LinkStories.Default} />
 
-`onClick`, `href` og `target` støttes på toppnivå.
-
 ## Retningslinjer
 
 - En lenke må ha `href` prop for assisterende teknologi skal tolke elementet riktig.

--- a/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
@@ -1,5 +1,10 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import {
+  categoryHtml,
+  htmlEventArgType,
+  htmlPropsArgType,
+} from '../../../storybook/helpers';
 import { StoryVStack } from '../../Stack/utils';
 import { Paragraph } from '../Paragraph';
 
@@ -9,12 +14,10 @@ export default {
   title: 'dds-components/Typography/Link',
   component: Link,
   argTypes: {
-    external: { control: { type: 'boolean' } },
-    typographyType: { control: { type: 'select' } },
-    withMargins: { control: { type: 'boolean' } },
-    withVisited: { control: { type: 'boolean' } },
-    href: { control: { type: 'text' } },
-    htmlProps: { control: false },
+    href: { control: 'text', table: categoryHtml },
+    onClick: htmlEventArgType,
+    target: { control: false, table: categoryHtml },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Typography/Paragraph/Paragraph.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Paragraph/Paragraph.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../../storybook/helpers';
 import { StoryVStack } from '../../Stack/utils';
 
 import { Paragraph } from '.';
@@ -8,9 +9,7 @@ export default {
   title: 'dds-components/Typography/Paragraph',
   component: Paragraph,
   argTypes: {
-    typographyType: { control: { type: 'select' } },
-    withMargins: { control: { type: 'boolean' } },
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Typography/Typography/Typography.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.stories.tsx
@@ -1,22 +1,19 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { Typography } from '..';
+import { categoryHtml, htmlPropsArgType } from '../../../storybook/helpers';
 import { StoryVStack } from '../../Stack/utils';
 
 export default {
   title: 'dds-components/Typography/Typography',
   component: Typography,
   argTypes: {
-    children: { control: { type: 'text' } },
-    typographyType: { control: { type: 'select' } },
-    bold: { control: { type: 'boolean' } },
-    italic: { control: { type: 'boolean' } },
-    withMargins: { control: { type: 'boolean' } },
-    externalLink: { control: { type: 'boolean' } },
-    color: { control: { type: 'text' } },
-    href: { control: { type: 'text' } },
-    as: { control: { type: 'text' } },
-    htmlProps: { control: false },
+    children: { control: 'text' },
+    color: { control: 'text' },
+    href: { control: 'text', table: categoryHtml },
+    target: { control: false, table: categoryHtml },
+    as: { control: 'text' },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { Table } from '../Table/normal';
 import { Link, Paragraph } from '../Typography';
@@ -10,7 +11,7 @@ export default {
   title: 'dds-components/VisuallyHidden',
   component: VisuallyHidden,
   argTypes: {
-    htmlProps: { control: false },
+    htmlProps: htmlPropsArgType,
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
@@ -32,26 +32,8 @@ const meta: Meta<typeof DatePicker> = {
     },
   },
   argTypes: {
-    label: {
-      control: 'text',
-    },
-    tip: {
-      control: 'text',
-    },
-    errorMessage: {
-      control: 'text',
-    },
     width: {
       control: 'text',
-    },
-    showWeekNumbers: {
-      control: 'boolean',
-    },
-    isDisabled: {
-      control: 'boolean',
-    },
-    isReadOnly: {
-      control: 'boolean',
     },
   },
   decorators: [

--- a/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.stories.tsx
+++ b/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.stories.tsx
@@ -11,11 +11,7 @@ const meta: Meta<typeof TimePicker> = {
   title: 'dds-components/TimePicker',
   component: TimePicker,
   argTypes: {
-    width: { control: { type: 'text' } },
-    tip: { control: { type: 'text' } },
-    errorMessage: { control: { type: 'text' } },
-    isDisabled: { control: { type: 'boolean' } },
-    isReadOnly: { control: { type: 'boolean' } },
+    width: { control: 'text' },
     className: { table: { disable: true } },
   },
   parameters: {

--- a/packages/dds-components/src/storybook/helpers.tsx
+++ b/packages/dds-components/src/storybook/helpers.tsx
@@ -1,0 +1,17 @@
+import { type ArgTypes } from '@storybook/react';
+
+export const categories = {
+  html: 'HTML attributes',
+};
+
+export const categoryHtml = { category: categories.html };
+
+export const htmlPropsArgType: Partial<ArgTypes> = {
+  control: { disable: true },
+  table: categoryHtml,
+};
+
+export const htmlEventArgType: Partial<ArgTypes> = {
+  control: { disable: true },
+  table: categoryHtml,
+};

--- a/packages/dds-components/src/types/BaseComponentProps.ts
+++ b/packages/dds-components/src/types/BaseComponentProps.ts
@@ -20,7 +20,7 @@ export type BaseComponentProps<
     HTMLAttributes<TElement> = HTMLAttributes<TElement>,
 > = Pick<THTMLAttributesProps, 'id' | 'className'> &
   TOtherProps & {
-    /**Ekstra HTML-attributter som vil settes på elementet som genereres. Untatt `id` og `className` som settes på toppnivå. */
+    /**Native HTML-attributter som vil settes på elementet som genereres. Untatt `id`, `className` (og eventuelle andre attributter spesifisert i dokumentasjonen) som settes på toppnivå. */
     htmlProps?: THTMLAttributesProps;
   };
 


### PR DESCRIPTION
## Beskrivelse

Props med default verdi kunne få verdien `undefined` tvunget på seg, noe som resulterte i rare stories. Fjerner `undefined` fra kontrollere via config.

Før:
![bilde](https://github.com/user-attachments/assets/8e84ce12-c3ba-4533-93a4-12f479ed7349)

Etter:
![bilde](https://github.com/user-attachments/assets/b8cb638d-3fdb-4fbd-8bff-dbe4ffe61c9e)

Implementerer [ELSA1-548](https://domstol.atlassian.net/browse/ELSA1-548) (kategorisering av props) i samme slengen, da det var en del overlap grunnet hvordan ny config håndterer types. HTML props som settes på roten (både native og `htmlProps` prop) ligger nå i kategori "HTML attributes" for hver komponent:
![bilde](https://github.com/user-attachments/assets/e425b6d6-e9a4-481c-8b0e-2d277d504f44)
 
Fikser sortering av props, slik at påkrevde props er prioritert og resten er sortert alfabetisk:

![bilde](https://github.com/user-attachments/assets/0dda3c84-ae1c-47f1-a906-6d4f794d6931)


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`


[ELSA1-548]: https://domstol.atlassian.net/browse/ELSA1-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ