### PR TITLE
ELSA1-568 Fjerner unødvendig type casting

### DIFF
--- a/packages/dds-components/src/components/Accordion/AccordionBody.tsx
+++ b/packages/dds-components/src/components/Accordion/AccordionBody.tsx
@@ -21,7 +21,12 @@ export const AccordionBody = ({
 }: AccordionBodyProps) => {
   const { bodyContentRef, bodyProps } = useAccordionContext();
 
-  const { className: bodyContextCn, id, height, ...restBodyProps } = bodyProps;
+  const {
+    className: bodyContextCn,
+    id,
+    height,
+    ...restBodyProps
+  } = bodyProps ?? {};
 
   const styleVariables: Properties = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/dds-components/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/dds-components/src/components/Accordion/AccordionHeader.tsx
@@ -37,7 +37,7 @@ export const AccordionHeader = ({
   ...rest
 }: AccordionHeaderProps) => {
   const { isExpanded, headerProps } = useAccordionContext();
-  const { id, ...restHeaderProps } = headerProps;
+  const { id, ...restHeaderProps } = headerProps ?? {};
 
   return (
     <button

--- a/packages/dds-components/src/components/BackLink/BackLink.tsx
+++ b/packages/dds-components/src/components/BackLink/BackLink.tsx
@@ -2,7 +2,7 @@ import { type ComponentPropsWithRef } from 'react';
 
 import styles from './BackLink.module.css';
 import { Icon } from '../Icon';
-import * as icons from '../Icon/icons';
+import { ArrowLeftIcon } from '../Icon/icons';
 import { Link } from '../Typography';
 
 export type BackLinkProps = {
@@ -16,11 +16,7 @@ export const BackLink = ({ label, ref, ...rest }: BackLinkProps) => {
   return (
     <nav ref={ref} aria-label="Gå tilbake">
       <Link {...rest}>
-        <Icon
-          icon={icons.ArrowLeftIcon}
-          iconSize="inherit"
-          className={styles.icon}
-        />
+        <Icon icon={ArrowLeftIcon} iconSize="inherit" className={styles.icon} />
         {label}
       </Link>
     </nav>

--- a/packages/dds-components/src/components/Card/CardExpandable/CardExpandableBody.tsx
+++ b/packages/dds-components/src/components/Card/CardExpandable/CardExpandableBody.tsx
@@ -29,7 +29,12 @@ export const CardExpandableBody = ({
 }: CardExpandableBodyProps) => {
   const { bodyContentRef, bodyProps } = useAccordionContext();
 
-  const { className: bodyContextCn, id, height, ...restBodyProps } = bodyProps;
+  const {
+    className: bodyContextCn,
+    id,
+    height,
+    ...restBodyProps
+  } = bodyProps ?? {};
 
   const styleVariables: Properties = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/dds-components/src/components/Card/CardExpandable/CardExpandableHeader.tsx
+++ b/packages/dds-components/src/components/Card/CardExpandable/CardExpandableHeader.tsx
@@ -49,7 +49,7 @@ export const CardExpandableHeader = ({
       'var(--dds-spacing-x1) var(--dds-spacing-x0-75) var(--dds-spacing-x1) var(--dds-spacing-x1-5)',
   };
 
-  const { id, ...restHeaderProps } = headerProps;
+  const { id, ...restHeaderProps } = headerProps ?? {};
 
   return (
     <button

--- a/packages/dds-components/src/components/Drawer/Drawer.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.tsx
@@ -114,9 +114,7 @@ export const Drawer = ({
     }
   }, [isOpen]);
 
-  const elements: Array<HTMLElement | null> = [
-    drawerRef.current as HTMLElement,
-  ];
+  const elements: Array<HTMLElement | null> = [drawerRef.current];
   if (triggerEl) elements.push(triggerEl);
 
   useOnClickOutside(elements, () => {

--- a/packages/dds-components/src/components/Drawer/DrawerGroup.tsx
+++ b/packages/dds-components/src/components/Drawer/DrawerGroup.tsx
@@ -3,7 +3,6 @@ import {
   type Dispatch,
   type HTMLAttributes,
   Children as ReactChildren,
-  type ReactElement,
   type ReactNode,
   type SetStateAction,
   cloneElement,
@@ -81,20 +80,17 @@ export const DrawerGroup = ({
 
   const Children = ReactChildren.map(children, (child, childIndex) => {
     return (
-      isValidElement(child) &&
+      isValidElement<
+        DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>
+      >(child) &&
       (childIndex === 0
-        ? cloneElement(
-            child as ReactElement<
-              DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>
-            >,
-            {
-              'aria-haspopup': 'dialog',
-              'aria-controls': uniqueDrawerId,
-              'aria-expanded': isOpen,
-              ref: triggerRef,
-              onClick: handleOpen,
-            },
-          )
+        ? cloneElement(child, {
+            'aria-haspopup': 'dialog',
+            'aria-controls': uniqueDrawerId,
+            'aria-expanded': isOpen,
+            ref: triggerRef,
+            onClick: handleOpen,
+          })
         : child)
     );
   });

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenuGroup.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenuGroup.tsx
@@ -3,7 +3,6 @@ import {
   type Dispatch,
   type HTMLAttributes,
   Children as ReactChildren,
-  type ReactElement,
   type ReactNode,
   type SetStateAction,
   cloneElement,
@@ -103,20 +102,17 @@ export const OverflowMenuGroup = ({
 
   const Children = ReactChildren.map(children, (child, childIndex) => {
     return (
-      isValidElement(child) &&
+      isValidElement<
+        DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>
+      >(child) &&
       (childIndex === 0
-        ? cloneElement(
-            child as ReactElement<
-              DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>
-            >,
-            {
-              'aria-haspopup': 'menu',
-              'aria-controls': uniqueOverflowMenuId,
-              'aria-expanded': isOpen,
-              onClick: handleToggle,
-              ref: combinedAnchorRef,
-            },
-          )
+        ? cloneElement(child, {
+            'aria-haspopup': 'menu',
+            'aria-controls': uniqueOverflowMenuId,
+            'aria-expanded': isOpen,
+            onClick: handleToggle,
+            ref: combinedAnchorRef,
+          })
         : child)
     );
   });

--- a/packages/dds-components/src/components/Pagination/Pagination.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.tsx
@@ -120,12 +120,12 @@ export const Pagination = ({
           const isActive = item === activePage;
           return (
             <li key={`pagination-item-${i}`} className={styles.list__item}>
-              {item !== 'truncator' ? (
+              {item !== 'truncator' && typeof item === 'number' ? (
                 <Button
                   purpose={isActive ? 'primary' : 'secondary'}
                   size="small"
                   onClick={event => {
-                    onPageChange(event, item as number);
+                    onPageChange(event, item);
                   }}
                   aria-label={
                     isActive

--- a/packages/dds-components/src/components/Popover/Popover.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.tsx
@@ -15,7 +15,7 @@ import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../types';
-import { cn } from '../../utils';
+import { cn, isEmpty } from '../../utils';
 import { Button } from '../Button';
 import { Paper } from '../helpers';
 import focusStyles from '../helpers/styling/focus.module.css';
@@ -102,7 +102,7 @@ export const Popover = ({
     anchorEl: contextAnchorEl,
   } = context;
 
-  const hasContext = contextPopoverId !== undefined;
+  const hasContext = !isEmpty(context);
   const generatedId = useId();
   const uniquePopoverId = id ?? `${generatedId}-popover`;
 

--- a/packages/dds-components/src/components/Popover/PopoverGroup.tsx
+++ b/packages/dds-components/src/components/Popover/PopoverGroup.tsx
@@ -3,7 +3,6 @@ import {
   type Dispatch,
   type HTMLAttributes,
   Children as ReactChildren,
-  type ReactElement,
   type ReactNode,
   type SetStateAction,
   cloneElement,
@@ -102,20 +101,17 @@ export const PopoverGroup = ({
 
   const Children = ReactChildren.map(children, (child, childIndex) => {
     return (
-      isValidElement(child) &&
+      isValidElement<
+        DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>
+      >(child) &&
       (isAnchorChild(childIndex)
-        ? cloneElement(
-            child as ReactElement<
-              DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement>
-            >,
-            {
-              'aria-haspopup': 'dialog',
-              'aria-controls': uniquePopoverId,
-              'aria-expanded': open,
-              onClick: handleToggle,
-              ref: combinedAnchorRef,
-            },
-          )
+        ? cloneElement(child, {
+            'aria-haspopup': 'dialog',
+            'aria-controls': uniquePopoverId,
+            'aria-expanded': open,
+            onClick: handleToggle,
+            ref: combinedAnchorRef,
+          })
         : child)
     );
   });

--- a/packages/dds-components/src/components/Select/SelectComponents.tsx
+++ b/packages/dds-components/src/components/Select/SelectComponents.tsx
@@ -134,11 +134,7 @@ export const DDSControl = <TValue, IsMulti extends boolean>(
   const { className, ...rest } = props;
 
   return (
-    <div
-      data-testid={
-        dataTestId ? ((dataTestId + '-control') as string) : undefined
-      }
-    >
+    <div data-testid={dataTestId ? dataTestId + '-control' : undefined}>
       <Control
         {...rest}
         className={cn(

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.tsx
@@ -36,8 +36,6 @@ export const Checkbox = ({
 
   const { style, className: htmlPropsClassName, ...restHtmlProps } = htmlProps;
 
-  type AriaChecked = 'mixed' | boolean | undefined;
-
   const isReadOnly = readOnly || checkboxGroup?.readOnly;
   const hasError = error || checkboxGroup?.error;
   const isDisabled = disabled || checkboxGroup?.disabled;
@@ -64,7 +62,7 @@ export const Checkbox = ({
         ])}
         aria-invalid={hasError ? true : undefined}
         aria-labelledby={checkboxGroup?.uniqueGroupId}
-        aria-checked={indeterminate ? ('mixed' as AriaChecked) : undefined}
+        aria-checked={indeterminate ? 'mixed' : undefined}
         aria-readonly={isReadOnly}
         type="checkbox"
         data-indeterminate={indeterminate}

--- a/packages/dds-components/src/components/Table/normal/Table.stories.tsx
+++ b/packages/dds-components/src/components/Table/normal/Table.stories.tsx
@@ -15,7 +15,7 @@ import { Checkbox } from '../../SelectionControl/Checkbox';
 import { StoryThemeProvider } from '../../ThemeProvider/utils/StoryThemeProvider';
 import { Link, Paragraph } from '../../Typography';
 
-import { type SortOrder, Table } from '.';
+import { Table } from '.';
 
 const meta: Meta<typeof Table> = {
   title: 'dds-components/Table',
@@ -532,7 +532,7 @@ export const Sortable: Story = {
           return {
             ...headerCell,
             isSorted: false,
-            sortOrder: headerCell.sortOrder ? ('none' as SortOrder) : undefined,
+            sortOrder: headerCell.sortOrder ? 'none' : undefined,
           };
         },
       );

--- a/packages/dds-components/src/components/Tabs/TabList.tsx
+++ b/packages/dds-components/src/components/Tabs/TabList.tsx
@@ -3,7 +3,6 @@ import {
   Children,
   type ComponentPropsWithRef,
   type FocusEvent,
-  type ReactElement,
   cloneElement,
   isValidElement,
   useState,
@@ -53,7 +52,7 @@ export const TabList = ({
         };
         return (
           isValidElement<TabProps>(child) &&
-          cloneElement(child as ReactElement<TabProps>, {
+          cloneElement(child, {
             id: `${tabsId}-tab-${index}`,
             htmlProps: {
               'aria-controls': `${tabsId}-panel-${index}`,

--- a/packages/dds-components/src/components/helpers/AccordionBase/AccordionContext.tsx
+++ b/packages/dds-components/src/components/helpers/AccordionBase/AccordionContext.tsx
@@ -9,6 +9,7 @@ import {
   type AccordionBodyProps,
   type AccordionHeaderProps,
 } from './useAccordion';
+import { isEmpty } from '../../../utils';
 
 interface AccordionContext {
   headerProps: AccordionHeaderProps;
@@ -27,14 +28,13 @@ export const AccordionContextProvider = ({
   return <AccordionContext value={values}>{children}</AccordionContext>;
 };
 
-export const useAccordionContext = (): AccordionContext => {
+export const useAccordionContext = (): Partial<AccordionContext> => {
   const context = useContext(AccordionContext);
-
-  if (!context) {
+  if (isEmpty(context)) {
     throw new Error(
       'useAccordionContext must be used within a AccordionContextProvider. Have you wrapped <AccordionHeader> and <AccordionBody> inside a <Accordion>, or <CardAccordionHeader> and <CardAccordionBody> inside a <CardAccordion>?',
     );
   }
 
-  return context as AccordionContext;
+  return context;
 };

--- a/packages/dds-components/src/utils/index.ts
+++ b/packages/dds-components/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './getFocusableElements';
 export * from './getScrollbarSize';
 export * from './icon';
 export * from './idGenerator';
+export * from './object';
 export * from './readonlyEventHandlers';
 export * from './searchFilter';
 export * from './text';

--- a/packages/dds-components/src/utils/object.tsx
+++ b/packages/dds-components/src/utils/object.tsx
@@ -1,0 +1,2 @@
+export const isEmpty = (obj: object) =>
+  Object.keys(obj).length === 0 && obj.constructor === Object;


### PR DESCRIPTION
## Beskrivelse

Bruker type argument  med `ReactElement`, sjekker for tomt objekt for context, fikser andre mindre instanser.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
