### PR TITLE
ELSA1-565 Bugfix `<InputStepper>` readOnly & added tests

### DIFF
--- a/.changeset/long-rockets-wash.md
+++ b/.changeset/long-rockets-wash.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug i `<InputStepper>` der readOnly-attributtet ikke faktisk førte til at feltet ble readOnly

--- a/packages/dds-components/src/components/InputStepper/InputStepper.spec.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.spec.tsx
@@ -154,4 +154,16 @@ describe('<InputStepper />', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Nullstill' }));
     expect(inputField).toHaveValue('0');
   });
+  it('should render as readOnly if readOnly is set', async () => {
+    const label = 'label';
+    render(<InputStepper label={label} maxValue={5} readOnly />);
+    const inputField = screen.getByRole('textbox');
+    expect(inputField).toHaveAttribute('readonly');
+  });
+  it('should render as disabled if disabled is set', async () => {
+    const label = 'label';
+    render(<InputStepper label={label} maxValue={5} disabled />);
+    const inputField = screen.getByRole('textbox');
+    expect(inputField).toBeDisabled;
+  });
 });

--- a/packages/dds-components/src/components/InputStepper/InputStepper.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.tsx
@@ -111,6 +111,7 @@ export const InputStepper = ({
         <StatefulInput
           type="text"
           disabled={disabled}
+          readOnly={readOnly}
           inputMode="numeric"
           pattern="-?[0-9]+"
           id={uniqueId}


### PR DESCRIPTION
## Beskrivelse

Denne PRen fikser en bug der `<InputStepper>` ikke fikk satt readOnly. Legger også til tester for readOnly og disabled

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
