### PR TITLE
ELSA1-575 Slår av temastyring i stories som ikke trenger det

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -37,7 +37,15 @@ const preview: Preview = {
   },
   decorators: [
     /** Styring av theme med toggle bar i hver story */
-    Story => {
+    /** Hvis story ikke skal ha theme-styring returner fast theme  */
+    (Story, context) => {
+      if (context.parameters.disableGlobalDecorator) {
+        return (
+          <ThemeProvider>
+            <Story />
+          </ThemeProvider>
+        );
+      }
       const [theme, setTheme] = useState<DdsTheme>('core');
       nameCounter++;
 

--- a/packages/dds-components/src/hooks/useRoveFocus.stories.tsx
+++ b/packages/dds-components/src/hooks/useRoveFocus.stories.tsx
@@ -5,6 +5,9 @@ import { UseRoveFocusExample } from './UseRoveFocusExample';
 export default {
   title: 'dds-components/Hooks/useRoveFocus',
   component: UseRoveFocusExample,
+  parameters: {
+    disableGlobalDecorator: true,
+  },
   argTypes: {
     active: {
       control: 'boolean',

--- a/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBannerProvider.mdx
+++ b/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBannerProvider.mdx
@@ -1,4 +1,5 @@
-import { Meta } from '@storybook/addon-docs';
+import { Canvas, Controls, Meta } from '@storybook/addon-docs';
+import { Default } from './EnvironmentBannerProvider.stories';
 
 <Meta title="development-utils/EnvironmentBannerProvider" />
 
@@ -6,6 +7,9 @@ import { Meta } from '@storybook/addon-docs';
 
 Denne komponenten kan brukes for å hjelpe utviklere/testere med å se hvilket miljø de jobber i. Den viser en banner (med unik farge per miljø) øverst på siden med miljønavnet.
 I produksjon (ved `environment="PROD"`) eller ved et ukjent miljø er den skjult, så du trenger ikke å håndtere skjuling av banneren.
+
+<Canvas of={Default} />
+<Controls of={Default} />
 
 ## 🔨 Bruk
 

--- a/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBannerProvider.stories.tsx
+++ b/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBannerProvider.stories.tsx
@@ -6,6 +6,7 @@ const meta: Meta<typeof EnvironmentBannerProvider> = {
   title: 'development-utils/EnvironmentBannerProvider',
   component: EnvironmentBannerProvider,
   parameters: {
+    disableGlobalDecorator: true,
     docs: {
       story: { inline: true },
       canvas: { sourceState: 'shown' },

--- a/stories/Tokens/Tokens.stories.tsx
+++ b/stories/Tokens/Tokens.stories.tsx
@@ -1,3 +1,5 @@
+import { type Meta } from '@storybook/react';
+
 import {
   BorderRadiusGenerator,
   BreakpointsGenerator,
@@ -11,9 +13,13 @@ import {
 } from './utils';
 import { ZIndexGenerator } from './utils/ZIndexGenerator';
 
-export default {
+const meta: Meta = {
   title: 'dds-design-tokens/Tokens',
+  parameters: {
+    disableGlobalDecorator: true,
+  },
 };
+export default meta;
 
 export const BorderRadius = () => {
   return (

--- a/stories/Tokens/TypographyBase.stories.tsx
+++ b/stories/Tokens/TypographyBase.stories.tsx
@@ -1,3 +1,5 @@
+import { type Meta } from '@storybook/react';
+
 import {
   FontFamilyGenerator,
   FontLetterSpacingGenerator,
@@ -9,9 +11,14 @@ import {
   wrapperStyle,
 } from './utils';
 
-export default {
+const meta: Meta = {
   title: 'dds-design-tokens/Tokens/Typography base',
+  parameters: {
+    disableGlobalDecorator: true,
+  },
 };
+
+export default meta;
 
 export const FontFamily = () => {
   return <div style={wrapperStyle}>{FontFamilyGenerator()}</div>;


### PR DESCRIPTION
## Beskrivelse

Enkelte stories skal ikke ha theme-toggle: tokens, hooks, EnvironmentBannerProvider. Implementerer støtte for å kunne slå den av.

Før:
![bilde](https://github.com/user-attachments/assets/7588e3c1-c64c-428b-a0a7-4a09bb757908)

Etter:
![bilde](https://github.com/user-attachments/assets/b59eaac8-a74c-496c-acfe-12712524ad1f)



## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
