### PR TITLE
ELSA-582 Mulighet for rendre popover i portal

### DIFF
--- a/.changeset/few-crabs-pick.md
+++ b/.changeset/few-crabs-pick.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Legger til optional property `portal`, default `false`, som angir om popover skal rendre i portal eller ikke.

--- a/packages/dds-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.stories.tsx
@@ -8,13 +8,21 @@ import { InlineButton } from '../InlineButton';
 import { LocalMessage } from '../LocalMessage';
 import { VStack } from '../Stack';
 import { StoryHStack, StoryVStack } from '../Stack/utils';
+import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
 import { Paragraph } from '../Typography';
 
 import { Popover, PopoverGroup } from '.';
 
-export default {
+const meta: Meta<typeof Popover> = {
   title: 'dds-components/Popover',
   component: Popover,
+  decorators: [
+    Story => (
+      <StoryThemeProvider>
+        <Story />
+      </StoryThemeProvider>
+    ),
+  ],
   argTypes: {
     header: { control: 'text' },
     onBlur: htmlEventArgType,
@@ -29,7 +37,9 @@ export default {
       canvas: { sourceState: 'shown' },
     },
   },
-} satisfies Meta<typeof Popover>;
+};
+
+export default meta;
 
 type Story = StoryObj<typeof Popover>;
 

--- a/packages/dds-components/src/components/Popover/Popover.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.tsx
@@ -1,5 +1,12 @@
 import { type Property } from 'csstype';
-import { type ReactNode, type RefObject, useEffect, useId } from 'react';
+import {
+  type ReactNode,
+  type RefObject,
+  useContext,
+  useEffect,
+  useId,
+} from 'react';
+import { createPortal } from 'react-dom';
 
 import styles from './Popover.module.css';
 import {
@@ -23,6 +30,7 @@ import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { CloseIcon } from '../Icon/icons';
 import { Heading } from '../Typography';
 import { usePopoverContext } from './Popover.context';
+import { ThemeContext } from '../ThemeProvider';
 
 export interface PopoverSizeProps {
   width?: Property.Width;
@@ -46,6 +54,14 @@ export type PopoverProps = BaseComponentPropsWithChildren<
      * @default "bottom"
      */
     placement?: Placement;
+    /**Angir rotnode hvor popover skal rendres.
+     * @default themeProviderRef
+     */
+    parentElement?: HTMLElement;
+    /**Angir om popover skal rendre i en portal eller ikke.
+     * @default "false"
+     */
+    portal?: boolean;
     /**Avstand fra anchor-elementet i px.
      * @default 8
      */
@@ -74,6 +90,8 @@ export const Popover = ({
   onBlur,
   children,
   placement = 'bottom',
+  parentElement,
+  portal = false,
   offset = 8,
   sizeProps,
   returnFocusOnBlur = true,
@@ -91,6 +109,8 @@ export const Popover = ({
   });
 
   const context = usePopoverContext();
+  const themeContext = useContext(ThemeContext);
+  const portalTarget = parentElement ?? themeContext?.el;
 
   const {
     floatStyling: contextFloatStyling,
@@ -165,7 +185,7 @@ export const Popover = ({
 
   const openCn = hasTransitionedIn && isOpen ? 'open' : 'closed';
 
-  return isOpen || hasTransitionedIn ? (
+  const popover = (
     <Paper
       {...getBaseHTMLProps(
         popoverId,
@@ -221,7 +241,13 @@ export const Popover = ({
         />
       )}
     </Paper>
-  ) : null;
+  );
+
+  return isOpen || hasTransitionedIn
+    ? portal && portalTarget
+      ? createPortal(popover, portalTarget)
+      : popover
+    : null;
 };
 
 Popover.displayName = 'Popover';


### PR DESCRIPTION
## Beskrivelse

Tillater bruk av popover inne i scrollable container, slik at man ikke risikerer at innhold i popover blir skjult av scroll

Eksemp
<img width="1084" alt="Screenshot 2025-03-27 at 13 59 01" src="https://github.com/user-attachments/assets/8ee74d41-650d-4aba-baf9-0ba384423904" />
el uten portal:

Eksempel med portal:
<img width="1084" alt="Screenshot 2025-03-27 at 13 58 41" src="https://github.com/user-attachments/assets/17dce8ba-c93a-43c8-879d-f65ca281fa34" />


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
