### PR TITLE
ELSA1-576 Formatering av beløp

### DIFF
--- a/.changeset/clean-olives-punch.md
+++ b/.changeset/clean-olives-punch.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-formatting': minor
+---
+
+Nye formateringsfunksjoner for beløp: `formatBeloep()` og `formatInputBeloep()`.

--- a/packages/dds-formatting/src/beloep/formatBeloep.test.ts
+++ b/packages/dds-formatting/src/beloep/formatBeloep.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatBeloep } from './formatBeloep';
+
+describe('formatBeloep()', () => {
+  it('should format number to NOK', () => {
+    expect(formatBeloep(12345678901).replace(/\u00A0/g, ' ')).toEqual(
+      '12 345 678 901,00 kr',
+    );
+  });
+  it('should format number with decimals to NOK', () => {
+    expect(formatBeloep(12345678901.23).replace(/\u00A0/g, ' ')).toBe(
+      '12 345 678 901,23 kr',
+    );
+  });
+  it('should format number with many decimals to NOK', () => {
+    expect(formatBeloep(12345678901.23423).replace(/\u00A0/g, ' ')).toBe(
+      '12 345 678 901,23 kr',
+    );
+  });
+  it('should format number below 1 to NOK', () => {
+    expect(formatBeloep(0.23423).replace(/\u00A0/g, ' ')).toBe('0,23 kr');
+  });
+});

--- a/packages/dds-formatting/src/beloep/formatBeloep.ts
+++ b/packages/dds-formatting/src/beloep/formatBeloep.ts
@@ -1,0 +1,12 @@
+/**
+ * Formaterer number beløp i henhold til retningslinjene for beløp i Elsa.
+ *
+ * @param beloep - beløpet som skal formateres.
+ */
+export const formatBeloep = (beloep: number): string => {
+  return new Intl.NumberFormat('nb-NO', {
+    style: 'currency',
+    currency: 'NOK',
+    maximumFractionDigits: 2,
+  }).format(beloep);
+};

--- a/packages/dds-formatting/src/beloep/formatInputBeloep.test.ts
+++ b/packages/dds-formatting/src/beloep/formatInputBeloep.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatInputBeloep } from './formatInputBeloep';
+
+describe('formatInputBeloep()', () => {
+  it('should format amount to NOK without currency', () => {
+    expect(formatInputBeloep('12345678901').replace(/\u00A0/g, ' ')).toEqual(
+      '12 345 678 901',
+    );
+  });
+  it('should format amount to NOK without currency and with trailing decimals', () => {
+    expect(
+      formatInputBeloep('12345678901', true).replace(/\u00A0/g, ' '),
+    ).toEqual('12 345 678 901,00');
+  });
+  it('should format amount with dot decimals to NOK without currency', () => {
+    expect(formatInputBeloep('12345678901.23').replace(/\u00A0/g, ' ')).toBe(
+      '12 345 678 901,23',
+    );
+  });
+  it('should format amount with comma decimals to NOK without currency', () => {
+    expect(formatInputBeloep('12345678901,23').replace(/\u00A0/g, ' ')).toBe(
+      '12 345 678 901,23',
+    );
+  });
+  it('should format dot decimal amount to NOK without currency', () => {
+    expect(formatInputBeloep('.23').replace(/\u00A0/g, ' ')).toBe('0,23');
+  });
+  it('should format comma decimal amount to NOK without currency', () => {
+    expect(formatInputBeloep(',23').replace(/\u00A0/g, ' ')).toBe('0,23');
+  });
+  it('should return empty string if amount has more than 2 decimals', () => {
+    expect(formatInputBeloep('12345678901.23423').replace(/\u00A0/g, ' ')).toBe(
+      '',
+    );
+  });
+  it('should return empty string if amount is not a number', () => {
+    expect(formatInputBeloep('qwerty').replace(/\u00A0/g, ' ')).toBe('');
+  });
+  it('should return empty string if amount is empty', () => {
+    expect(formatInputBeloep('').replace(/\u00A0/g, ' ')).toBe('');
+  });
+  it('should return empty string if amount is invalid', () => {
+    expect(formatInputBeloep('1,2,3').replace(/\u00A0/g, ' ')).toBe('');
+  });
+});

--- a/packages/dds-formatting/src/beloep/formatInputBeloep.ts
+++ b/packages/dds-formatting/src/beloep/formatInputBeloep.ts
@@ -1,0 +1,39 @@
+const NUMBER_WITH_TWO_DECIMALS = /^[0-9]*([.][0-9]{0,2})?$/;
+
+/**
+ * Formaterer string beløp (f.eks. i inputfelt) i henhold til retningslinjene for beløp i Elsa.
+ * Hvis beløpet er ugyldig vil funksjonen returnere tom string.
+ * @param beloep - beløpet som skal formateres.
+ * @param withTrailingDecimals - om desimaltall skal vises hvis beløpet ikke indkludrer desimaltall.
+ */
+
+export function formatInputBeloep(
+  beloep: string,
+  withTrailingDecimals?: boolean,
+): string {
+  let value = beloep;
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  if (value.includes(',')) {
+    value = value.replace(',', '.');
+  }
+
+  if (value.startsWith(',')) {
+    value = '0' + value;
+  }
+
+  if (!NUMBER_WITH_TWO_DECIMALS.test(value)) {
+    return '';
+  }
+
+  const numberValue = parseFloat(value);
+  if (isNaN(numberValue)) return '';
+
+  return new Intl.NumberFormat('nb-NO', {
+    style: 'decimal',
+    minimumFractionDigits: withTrailingDecimals ? 2 : 0,
+    maximumFractionDigits: 2,
+  }).format(numberValue);
+}

--- a/packages/dds-formatting/src/beloep/index.ts
+++ b/packages/dds-formatting/src/beloep/index.ts
@@ -1,0 +1,2 @@
+export * from './formatBeloep';
+export * from './formatInputBeloep';

--- a/packages/dds-formatting/src/index.ts
+++ b/packages/dds-formatting/src/index.ts
@@ -1,4 +1,5 @@
 export * from './bank';
+export * from './beloep';
 export * from './dato';
 export * from './foedselsnummer';
 export * from './organisation';


### PR DESCRIPTION
## Beskrivelse

Implementerer formateringsfunksjoner for beløp, `formatBeloep()` for tall og `formatInputBeloep()` for typisk tekstlig input, son ekskluderer valuta.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
