### PR TITLE
ELSA1-581 `htmlProps` blir ikke satt i `<Tab>`

### DIFF
--- a/.changeset/empty-worlds-buy.md
+++ b/.changeset/empty-worlds-buy.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Fikser bug der `htmlProps`-prop ikke ble satt og setter standardverdien `type='button'` i `<Tab>`. På denne måten vil ikke bytting mellom faner trigge submit hvis `<Tabs>` ligger i `<form>`.

--- a/packages/dds-components/src/components/Tabs/Tab.tsx
+++ b/packages/dds-components/src/components/Tabs/Tab.tsx
@@ -24,6 +24,11 @@ import { Icon } from '../Icon';
 import { type SvgIcon } from '../Icon/utils';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
+type PickedAttributes = Pick<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'onClick' | 'onKeyDown'
+>;
+
 export type TabProps = BaseComponentPropsWithChildren<
   HTMLButtonElement,
   {
@@ -43,8 +48,8 @@ export type TabProps = BaseComponentPropsWithChildren<
      * @default "1fr"
      */
     width?: CSS.Properties['width'];
-  } & Pick<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'onKeyDown'>,
-  Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onClick' | 'onKeyDown'>
+  } & PickedAttributes,
+  Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof PickedAttributes>
 >;
 
 export const Tab = ({
@@ -58,7 +63,7 @@ export const Tab = ({
   onKeyDown,
   id,
   className,
-  htmlProps,
+  htmlProps = {},
   width = '1fr',
   ref,
   ...rest
@@ -70,6 +75,9 @@ export const Tab = ({
   const itemRef = useRef<HTMLAnchorElement | HTMLButtonElement>(null);
   const combinedRef = useCombinedRef(ref, itemRef);
   const { tabContentDirection, size } = useTabsContext();
+
+  const { type = 'button', ...restHtmlProps } = htmlProps;
+  const fixedHtmlProps = { type, ...restHtmlProps };
 
   useEffect(() => {
     if (focus) {
@@ -85,14 +93,14 @@ export const Tab = ({
 
   const handleOnClick = (e: MouseEvent<HTMLButtonElement>) => {
     handleSelect();
-    onClick && onClick(e);
+    onClick?.(e);
   };
 
   const handleOnKeyDown = (
     e: KeyboardEvent<HTMLAnchorElement> & KeyboardEvent<HTMLButtonElement>,
   ) => {
     handleSelect();
-    onKeyDown && onKeyDown(e);
+    onKeyDown?.(e);
   };
 
   return (
@@ -108,7 +116,7 @@ export const Tab = ({
           typographyStyles[`body-${size}`],
           focusStyles['focusable--inset'],
         ),
-        htmlProps,
+        fixedHtmlProps,
         rest,
       )}
       ref={combinedRef}

--- a/packages/dds-components/src/components/Tabs/TabList.tsx
+++ b/packages/dds-components/src/components/Tabs/TabList.tsx
@@ -55,6 +55,7 @@ export const TabList = ({
           cloneElement(child, {
             id: `${tabsId}-tab-${index}`,
             htmlProps: {
+              ...child.props.htmlProps,
               'aria-controls': `${tabsId}-panel-${index}`,
             },
             active: activeTab === index,

--- a/packages/dds-components/src/components/Tabs/Tabs.mdx
+++ b/packages/dds-components/src/components/Tabs/Tabs.mdx
@@ -38,7 +38,7 @@ Ytterste container som styrer hvilket panel skal vises via indeks. Har `<TabList
 
 ### Tab
 
-En fane. Tilhørende `<TabPanel>` vises ved museklikk.
+En fane. Tilhørende `<TabPanel>` vises ved museklikk. Har `type="button"` som default.
 
 <ArgTypes of={Tab} />
 
@@ -68,7 +68,6 @@ For å endre på bredden til tabs kan du bruke `width`-attributtet. Her støttes
 
 En liste med `<Tab>`. Setter attributter som `aria-controls` og roving focus for barna. `<TabList>` skal ha `<Tab>` som barn i samme rekkefølge som tilhørende paneler i `<TabPanels>`.
 
-<ArgTypes of={TabList} />
 Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface.
 
 ### TabPanel


### PR DESCRIPTION
## Beskrivelse

Fikser bug der `htmlProps`-prop ikke ble satt og setter standardverdien `type='button'` i `<Tab>`. På denne måten vil ikke bytting mellom faner trigge submit hvis `<Tabs>` ligger i `<form>`.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
