### PR TITLE
ELSA1-584 loading state i OverflowMenuButton

### DIFF
--- a/.changeset/shaggy-snails-argue.md
+++ b/.changeset/shaggy-snails-argue.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for props `loading` og `loadingTooltip` i `<OverflowMenuButton>`.

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.module.css
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.module.css
@@ -53,6 +53,11 @@
   font-size: calc(var(--dds-font-lineheight-x1) * 1em);
 }
 
+.button-loading {
+  cursor: not-allowed;
+  position: relative;
+}
+
 .divider {
   margin-inline: var(--dds-spacing-x0-5);
   margin-block: var(--dds-spacing-x0);

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -68,6 +68,14 @@ export const Default: Story = {
                 Handling
               </OverflowMenuButton>
               <OverflowMenuButton
+                loading
+                onClick={() => {
+                  null;
+                }}
+              >
+                Handling 2
+              </OverflowMenuButton>
+              <OverflowMenuButton
                 onClick={() => {
                   null;
                 }}

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.types.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.types.tsx
@@ -2,6 +2,7 @@ import { type ComponentPropsWithRef } from 'react';
 
 import { type Placement } from '../../hooks';
 import { type BaseComponentPropsWithChildren } from '../../types';
+import { type ButtonProps } from '../Button';
 import { type SvgIcon } from '../Icon/utils';
 
 export type OverflowMenuListItemBaseProps<T extends 'span' | 'button' | 'a'> = {
@@ -13,7 +14,8 @@ export type OverflowMenuListItemBaseProps<T extends 'span' | 'button' | 'a'> = {
   purpose?: 'default' | 'danger';
 } & ComponentPropsWithRef<T>;
 
-export type OverflowMenuButtonProps = OverflowMenuListItemBaseProps<'button'>;
+export type OverflowMenuButtonProps = OverflowMenuListItemBaseProps<'button'> &
+  Pick<ButtonProps, 'loading' | 'loadingTooltip'>;
 
 export type OverflowMenuLinkProps = OverflowMenuListItemBaseProps<'a'>;
 

--- a/packages/dds-components/src/components/OverflowMenu/components/OverflowMenuButton.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/components/OverflowMenuButton.tsx
@@ -3,7 +3,11 @@ import { useEffect, useRef } from 'react';
 import { useCombinedRef } from '../../../hooks';
 import { cn } from '../../../utils';
 import focusStyles from '../../helpers/styling/focus.module.css';
+import utilStyles, {
+  invisible,
+} from '../../helpers/styling/utilStyles.module.css';
 import { Icon } from '../../Icon';
+import { Spinner } from '../../Spinner';
 import typographyStyles from '../../Typography/typographyStyles.module.css';
 import { useOverflowMenuContext } from '../OverflowMenu.context';
 import styles from '../OverflowMenu.module.css';
@@ -16,6 +20,9 @@ export const OverflowMenuButton = ({
   className,
   onClick,
   purpose = 'default',
+  loading,
+  loadingTooltip,
+  'aria-disabled': ariaDisabled,
   ref,
   ...rest
 }: OverflowMenuButtonProps) => {
@@ -43,16 +50,37 @@ export const OverflowMenuButton = ({
           typographyStyles['body-small'],
           styles['list__item--link'],
           focusStyles['focusable--inset'],
+          loading && styles['button-loading'],
         )}
-        onClick={e => {
-          onClick?.(e);
-          onClose?.();
-        }}
+        onClick={
+          loading
+            ? undefined
+            : e => {
+                onClick?.(e);
+                onClose?.();
+              }
+        }
+        aria-disabled={loading ? true : ariaDisabled ? ariaDisabled : undefined}
         {...rest}
         tabIndex={focusedRef === itemRef ? 0 : -1}
       >
-        {icon && <Icon iconSize="inherit" icon={icon} />}
-        {children}
+        {loading && (
+          <span className={cn(utilStyles['center-absolute'])}>
+            <Spinner
+              size="var(--dds-icon-size-medium)"
+              tooltip={loadingTooltip}
+            />
+          </span>
+        )}
+
+        {icon && (
+          <Icon
+            className={cn(loading && invisible)}
+            iconSize="inherit"
+            icon={icon}
+          />
+        )}
+        <span className={cn(loading && invisible)}>{children}</span>
       </button>
     </li>
   );

--- a/packages/dds-components/src/components/helpers/styling/utilStyles.module.css
+++ b/packages/dds-components/src/components/helpers/styling/utilStyles.module.css
@@ -89,3 +89,23 @@
 .invisible {
   visibility: hidden;
 }
+
+.center-absolute {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.center-absolute-y {
+  position: absolute;
+
+  top: 50%;
+  transform: translate(0, -50%);
+}
+
+.center-absolute-x {
+  position: absolute;
+  left: 50%;
+  transform: translate(-50%, 0);
+}


### PR DESCRIPTION
## Beskrivelse

Støtte for props `loading` og `loadingTooltip` i `<OverflowMenuButton>`. Rendrer spinner med tilhørende toolitp ved `loading`; Gjør initial innhold usynlig, men fortsatt tilgjengelig for skjermleser slik at den kan leses opp i kombinasjon med tooltip.

![image](https://github.com/user-attachments/assets/951b07db-52e1-4ffc-bd19-e6bbab52b731)

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
