### PR TITLE
ELSA1-592 Støtte for `typographyType` i `<Legend>`

### DIFF
--- a/.changeset/lazy-apes-brush.md
+++ b/.changeset/lazy-apes-brush.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Ny prop i `<Legend>`: `typoghraphyType`. Den støtter typografistilier for overskrifter. Brukes når komponenten trenger størrelsen tilpasset etter overskriftshierarki ellers på siden.

--- a/.changeset/tender-hairs-sing.md
+++ b/.changeset/tender-hairs-sing.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fjerner fast spacing på bunnen i `<Legend>` ved bruk av `withMargins` prop; den arver nå spacing fra valgt typografistil.

--- a/packages/dds-components/src/components/Typography/Legend/Legend.tsx
+++ b/packages/dds-components/src/components/Typography/Legend/Legend.tsx
@@ -2,28 +2,33 @@ import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../../types';
-import { type BaseTypographyProps, Typography } from '../Typography';
+import {
+  type BaseTypographyProps,
+  Typography,
+  type TypographyHeadingType,
+} from '../Typography';
 
 export type LegendProps = BaseComponentPropsWithChildren<
   HTMLLegendElement,
-  BaseTypographyProps
+  BaseTypographyProps & {
+    /**Typografistil basert på utvalget for HTML heading elementer.  */
+    typographyType?: TypographyHeadingType;
+  }
 >;
 
 export const Legend = ({
   id,
   className,
   htmlProps,
-  children,
+  typographyType = 'headingLarge',
   ...rest
 }: LegendProps) => {
   return (
     <Typography
       {...getBaseHTMLProps(id, className, htmlProps, rest)}
       as="legend"
-      typographyType="headingLarge"
-    >
-      {children}
-    </Typography>
+      typographyType={typographyType}
+    />
   );
 };
 

--- a/packages/dds-components/src/components/Typography/Typography/Typography.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.tsx
@@ -110,7 +110,6 @@ export const Typography = (props: TypographyProps) => {
           typographyStyles[typographyCn],
           withMargins && typographyStyles[`${typographyCn}--margins`],
           isLegend(as) && typographyStyles.legend,
-          isLegend(as) && withMargins && typographyStyles['legend--margins'],
           isCaption(as) &&
             withMargins &&
             typographyStyles['caption--withMargins'],

--- a/packages/dds-components/src/components/Typography/typographyStyles.module.css
+++ b/packages/dds-components/src/components/Typography/typographyStyles.module.css
@@ -234,10 +234,6 @@
   padding-inline: 0;
 }
 
-:where(.legend--margins) {
-  margin-bottom: var(--dds-spacing-x1-5);
-}
-
 :where(.caption--withMargins) {
   display: table-caption;
 }

--- a/packages/dds-components/stories/patterns/Form.stories.tsx
+++ b/packages/dds-components/stories/patterns/Form.stories.tsx
@@ -165,70 +165,17 @@ export const FormWithSteps = () => {
       <Heading level={2} withMargins>
         {steps[0]}
       </Heading>
-      <form
+      <VStack
+        as="form"
+        gap="x1"
         onSubmit={e => {
           completeStep(0, e);
         }}
       >
-        <VStack gap="x1">
-          <Fieldset>
-            <Legend withMargins>Overskrift for gruppe</Legend>
-            <FieldsetGroup>
-              <TextInput label="Ledetekst" />
-              <NativeSelect label="Ledetekst">
-                <option></option>
-                <option>Valg 1</option>
-                <option>Valg 2</option>
-                <option>Valg 3</option>
-              </NativeSelect>
-            </FieldsetGroup>
-          </Fieldset>
-          <Fieldset>
-            <Legend withMargins>Overskrift for gruppe</Legend>
-            <FieldsetGroup>
-              <TextInput label="Ledetekst" />
-              <NativeSelect label="Ledetekst">
-                <option></option>
-                <option>Valg 1</option>
-                <option>Valg 2</option>
-                <option>Valg 3</option>
-              </NativeSelect>
-            </FieldsetGroup>
-          </Fieldset>
-          <Fieldset>
-            <Legend withMargins>Adresse</Legend>
-            <FieldsetGroup>
-              <TextInput label="Adresse" />
-              <Box
-                display="flex"
-                flexDirection={{
-                  xs: 'column',
-                }}
-                gap="x1.5"
-              >
-                <TextInput width="94px" label="Postnummer" />
-                <TextInput label="Sted" readOnly width="202px" />
-              </Box>
-            </FieldsetGroup>
-          </Fieldset>
-          <HStack gap="x1.5" paddingBlock="x1 0">
-            <Button>Neste</Button>
-            <Button purpose="tertiary">Avbryt og forkast</Button>
-          </HStack>
-        </VStack>
-      </form>
-    </Fragment>,
-    <Fragment key={1}>
-      <Heading level={2} withMargins>
-        {steps[1]}
-      </Heading>
-      <form
-        onSubmit={e => {
-          completeStep(1, e);
-        }}
-      >
         <Fieldset>
-          <Legend withMargins>Overskrift for gruppe</Legend>
+          <Legend withMargins typographyType="headingMedium">
+            Overskrift for gruppe
+          </Legend>
           <FieldsetGroup>
             <TextInput label="Ledetekst" />
             <NativeSelect label="Ledetekst">
@@ -240,7 +187,72 @@ export const FormWithSteps = () => {
           </FieldsetGroup>
         </Fieldset>
         <Fieldset>
-          <Legend withMargins>Overskrift for gruppe</Legend>
+          <Legend withMargins typographyType="headingMedium">
+            Overskrift for gruppe
+          </Legend>
+          <FieldsetGroup>
+            <TextInput label="Ledetekst" />
+            <NativeSelect label="Ledetekst">
+              <option></option>
+              <option>Valg 1</option>
+              <option>Valg 2</option>
+              <option>Valg 3</option>
+            </NativeSelect>
+          </FieldsetGroup>
+        </Fieldset>
+        <Fieldset>
+          <Legend withMargins typographyType="headingMedium">
+            Adresse
+          </Legend>
+          <FieldsetGroup>
+            <TextInput label="Adresse" />
+            <Box
+              display="flex"
+              flexDirection={{
+                xs: 'column',
+              }}
+              gap="x1.5"
+            >
+              <TextInput width="94px" label="Postnummer" />
+              <TextInput label="Sted" readOnly width="202px" />
+            </Box>
+          </FieldsetGroup>
+        </Fieldset>
+        <HStack gap="x1.5" paddingBlock="x1 0">
+          <Button>Neste</Button>
+          <Button purpose="tertiary">Avbryt og forkast</Button>
+        </HStack>
+      </VStack>
+    </Fragment>,
+    <Fragment key={1}>
+      <Heading level={2} withMargins>
+        {steps[1]}
+      </Heading>
+      <VStack
+        as="form"
+        gap="x1"
+        onSubmit={e => {
+          completeStep(1, e);
+        }}
+      >
+        <Fieldset>
+          <Legend withMargins typographyType="headingMedium">
+            Overskrift for gruppe
+          </Legend>
+          <FieldsetGroup>
+            <TextInput label="Ledetekst" />
+            <NativeSelect label="Ledetekst">
+              <option></option>
+              <option>Valg 1</option>
+              <option>Valg 2</option>
+              <option>Valg 3</option>
+            </NativeSelect>
+          </FieldsetGroup>
+        </Fieldset>
+        <Fieldset>
+          <Legend withMargins typographyType="headingMedium">
+            Overskrift for gruppe
+          </Legend>
           <FieldsetGroup>
             <TextInput label="Ledetekst" />
             <NativeSelect label="Ledetekst">
@@ -252,10 +264,10 @@ export const FormWithSteps = () => {
           </FieldsetGroup>
         </Fieldset>
         <HStack gap="x1.5" paddingBlock="x1 0">
-          <Button>Neste</Button>
+          <Button>Send inn</Button>
           <Button purpose="tertiary">Avbryt og forkast</Button>
         </HStack>
-      </form>
+      </VStack>
     </Fragment>,
   ];
   return (
@@ -295,16 +307,6 @@ export const FormWithSteps = () => {
             <span className="required-mark">*</span>.
           </Paragraph>
           <VStack gap="x1">
-            {activeStep > 0 && (
-              <Button
-                purpose="secondary"
-                icon={ArrowLeftIcon}
-                onClick={() => previousStep()}
-              >
-                Forrige steg
-              </Button>
-            )}
-
             <ShowHide showBelow="sm">
               <DrawerGroup
                 isOpen={progressTrackerDrawerOpen}
@@ -327,6 +329,15 @@ export const FormWithSteps = () => {
                 </Drawer>
               </DrawerGroup>
             </ShowHide>
+            {activeStep > 0 && (
+              <Button
+                purpose="secondary"
+                icon={ArrowLeftIcon}
+                onClick={() => previousStep()}
+              >
+                Forrige steg
+              </Button>
+            )}
           </VStack>
           {formSteps[activeStep]}
         </GridChild>
@@ -383,7 +394,9 @@ export const FormWithStepsCustomGrid = () => {
       >
         <VStack gap="x1">
           <Fieldset>
-            <Legend withMargins>Overskrift for gruppe</Legend>
+            <Legend withMargins typographyType="headingMedium">
+              Overskrift for gruppe
+            </Legend>
             <FieldsetGroup>
               <TextInput label="Ledetekst" />
               <NativeSelect label="Ledetekst">
@@ -395,7 +408,9 @@ export const FormWithStepsCustomGrid = () => {
             </FieldsetGroup>
           </Fieldset>
           <Fieldset>
-            <Legend withMargins>Overskrift for gruppe</Legend>
+            <Legend withMargins typographyType="headingMedium">
+              Overskrift for gruppe
+            </Legend>
             <FieldsetGroup>
               <TextInput label="Ledetekst" />
               <NativeSelect label="Ledetekst">
@@ -421,7 +436,9 @@ export const FormWithStepsCustomGrid = () => {
         }}
       >
         <Fieldset>
-          <Legend withMargins>Overskrift for gruppe</Legend>
+          <Legend withMargins typographyType="headingMedium">
+            Overskrift for gruppe
+          </Legend>
           <FieldsetGroup>
             <TextInput label="Ledetekst" />
             <NativeSelect label="Ledetekst">
@@ -433,7 +450,9 @@ export const FormWithStepsCustomGrid = () => {
           </FieldsetGroup>
         </Fieldset>
         <Fieldset>
-          <Legend withMargins>Overskrift for gruppe</Legend>
+          <Legend withMargins typographyType="headingMedium">
+            Overskrift for gruppe
+          </Legend>
           <FieldsetGroup>
             <TextInput label="Ledetekst" />
             <NativeSelect label="Ledetekst">
@@ -445,7 +464,7 @@ export const FormWithStepsCustomGrid = () => {
           </FieldsetGroup>
         </Fieldset>
         <HStack gap="x1.5" paddingBlock="x1 0">
-          <Button>Neste</Button>
+          <Button>Send inn</Button>
           <Button purpose="tertiary">Avbryt og forkast</Button>
         </HStack>
       </form>
@@ -476,9 +495,6 @@ export const FormWithStepsCustomGrid = () => {
               <span className="required-mark">*</span>.
             </Paragraph>
             <VStack gap="x1">
-              <Button purpose="secondary" icon={ArrowLeftIcon}>
-                Forrige steg
-              </Button>
               <ShowHide showBelow="sm">
                 <DrawerGroup
                   isOpen={progressTrackerDrawerOpen}
@@ -501,6 +517,11 @@ export const FormWithStepsCustomGrid = () => {
                   </Drawer>
                 </DrawerGroup>
               </ShowHide>
+              {activeStep > 0 && (
+                <Button purpose="secondary" icon={ArrowLeftIcon}>
+                  Forrige steg
+                </Button>
+              )}
             </VStack>
             {formSteps[activeStep]}
           </VStack>


### PR DESCRIPTION
## Beskrivelse

Ny prop i `<Legend>`: `typoghraphyType`. Den støtter typografistilier for overskrifter. Brukes når komponenten trenger størrelsen tilpasset etter overskriftshierarki ellers på siden.

Fjerner også fast spacing på bunnen i `<Legend>` ved bruk av `withMargins` prop; den arver nå spacing fra valgt typografistil.

Fikser Form pattern til å bruke `typoghraphyType` i `<Legend>`.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
