### PR TITLE
Fix: logo i Footer får bredde og høyde

### DIFF
--- a/packages/dds-components/src/components/Footer/FooterLogo.tsx
+++ b/packages/dds-components/src/components/Footer/FooterLogo.tsx
@@ -13,13 +13,16 @@ export type FooterLogoProps = ComponentPropsWithRef<'img'> & {
 export const FooterLogo = ({ hideBreakpoint, ...rest }: FooterLogoProps) => {
   return (
     <Box
-      as="img"
       hideBelow={hideBreakpoint ? hideBreakpoint : undefined}
-      src={Logo}
-      height={80}
-      width={151}
-      alt="norges domstoler"
-      {...rest}
-    />
+      width="fit-content"
+    >
+      <img
+        height={80}
+        width={151}
+        alt="norges domstoler"
+        src={Logo}
+        {...rest}
+      />
+    </Box>
   );
 };


### PR DESCRIPTION
## Beskrivelse

Fikser bug introdusert i forrige PR, der props `height` og `width` ble tolket som CSS props.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [ ] I commits
  - [ ] I PR-tittelen
- [ ] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
