### PR TITLE
ELSA1-588 Responsive props relaterte til størrelse

### DIFF
--- a/.changeset/cold-chairs-warn.md
+++ b/.changeset/cold-chairs-warn.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Utvider `width` og `height` props til å støtte responsive verdier i `<Skeleton>`. Se detaljer i [migreringsguiden v20 til v21](https://design.domstol.no/987b33f71/p/88e4c8-v20-til-v21).

--- a/.changeset/fuzzy-facts-rush.md
+++ b/.changeset/fuzzy-facts-rush.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<NativeSelect>` ikke støttet prosentverdi for `width` prop.

--- a/.changeset/green-shirts-joke.md
+++ b/.changeset/green-shirts-joke.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Utvider `widthProps` prop til å støtte responsive verdier i `<Drawer>`. Se detaljer i [migreringsguiden v20 til v21](https://design.domstol.no/987b33f71/p/88e4c8-v20-til-v21).

--- a/.changeset/grumpy-guests-wish.md
+++ b/.changeset/grumpy-guests-wish.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': major
+---
+
+Endrer hvordan `width` prop fungerer i `<PhoneInput>` og `<InputStepper>`. Den setter bredde for hele input-gruppen, og ikke bare inputfeltet. Se detaljer i [migreringsguiden v20 til v21](https://design.domstol.no/987b33f71/p/88e4c8-v20-til-v21).

--- a/.changeset/khaki-mirrors-carry.md
+++ b/.changeset/khaki-mirrors-carry.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Utvider `width` prop til å støtte responsive verdier i følgende komponenter: `<FileUploader>`, `<TextInput>`, `<TextArea>`, `<NativeSelect>`, `<Select>`, `<ProgressBar>`, `<DatePicker>`, `<InlineEditInput>`, `<InlineEditTextArea>`, `<LocalMessage>`, `<ToggleBar>`, `<PhoneInput>`, `<InputStepper>`. Se detaljer i [migreringsguiden v20 til v21](https://design.domstol.no/987b33f71/p/88e4c8-v20-til-v21).

--- a/.changeset/smart-ducks-argue.md
+++ b/.changeset/smart-ducks-argue.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Utvider `sizeProps` prop til å støtte responsive verdier i `<Popover>`. Se detaljer i [migreringsguiden v20 til v21](https://design.domstol.no/987b33f71/p/88e4c8-v20-til-v21).

--- a/.changeset/smooth-owls-burn.md
+++ b/.changeset/smooth-owls-burn.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': major
+---
+
+Endrer hvordan enkelte props fungerer i `<NativeSelect>`; `className` og `style` settes nå på rotcontainer, mens `width` settes på kontainer for `<select>` og chevronikonet. På denne måten er det likt på tvers av inputkomponenter og fleksibelt.

--- a/packages/dds-components/src/components/Drawer/Drawer.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.tsx
@@ -1,4 +1,3 @@
-import { type Property } from 'csstype';
 import {
   type MouseEvent,
   type ReactNode,
@@ -33,15 +32,14 @@ import { CloseIcon } from '../Icon/icons';
 import { ThemeContext } from '../ThemeProvider';
 import { Heading } from '../Typography';
 import { useDrawerContext } from './Drawer.context';
-import { HStack, Paper, VStack } from '../layout';
+import { HStack, Paper, type ResponsiveProps, VStack } from '../layout';
 
 export type DrawerSize = Extract<Size, 'small' | 'medium' | 'large'>;
 export type DrawerPlacement = 'left' | 'right';
-export interface WidthProps {
-  minWidth?: Property.MinWidth;
-  maxWidth?: Property.MaxWidth;
-  width?: Property.Width;
-}
+export type WidthProps = Pick<
+  ResponsiveProps,
+  'minWidth' | 'maxWidth' | 'width'
+>;
 
 export type DrawerProps = Omit<
   BaseComponentPropsWithChildren<
@@ -62,7 +60,7 @@ export type DrawerProps = Omit<
        * @default themeProviderRef
        */
       parentElement?: HTMLElement;
-      /**Custom props for breddehåndtering ved behov. */
+      /**Custom props for breddehåndtering ved behov. Kan settes per brekkpunkt eller samme verdi for alle. */
       widthProps?: WidthProps;
       /**
        * Om `<Drawer>` skal vises med backdrop som gråer ut bakgrunnen.
@@ -81,7 +79,7 @@ export const Drawer = ({
   size = 'small',
   className,
   htmlProps,
-  widthProps,
+  widthProps = {},
   withBackdrop,
   ref,
   ...rest
@@ -95,6 +93,7 @@ export const Drawer = ({
   const portalTarget = parentElement ?? themeContext?.el;
 
   const { isOpen = false, onClose, drawerId, triggerEl } = useDrawerContext();
+  const { minWidth, maxWidth, width } = widthProps;
 
   const hasHeader = !!header;
   const headerId = hasHeader ? `${drawerId}-header` : undefined;
@@ -154,8 +153,9 @@ export const Drawer = ({
       position="fixed"
       top="0"
       height="100%"
-      minWidth="300px"
-      maxWidth={getMaxWidth(size)}
+      minWidth={minWidth ? minWidth : '300px'}
+      maxWidth={maxWidth ? maxWidth : getMaxWidth(size)}
+      width={width}
       display="flex"
       flexDirection="column"
       justifyContent="flex-start"
@@ -174,7 +174,6 @@ export const Drawer = ({
         rest,
       )}
       elevation={4}
-      style={{ ...htmlProps?.style, ...widthProps }}
       aria-labelledby={headerId}
     >
       <HStack

--- a/packages/dds-components/src/components/FileUploader/File.tsx
+++ b/packages/dds-components/src/components/FileUploader/File.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { CheckCircledIcon, CloseIcon, ErrorIcon } from '../Icon/icons';
+import { Paper } from '../layout';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 interface FileProps {
@@ -29,7 +30,17 @@ export const File = (props: FileProps) => {
 
   return (
     <li>
-      <div className={cn(styles.file, !isValid && styles['file--invalid'])}>
+      <Paper
+        display="flex"
+        alignItems="center"
+        justifyContent="space-between"
+        gap="x0.75"
+        marginBlock="x0.5 0"
+        padding="x0.5 x1"
+        border={isValid ? 'border-default' : 'border-danger'}
+        background="surface-subtle"
+        className={cn(!isValid && styles['file--invalid'])}
+      >
         <span
           className={cn(styles.file__name, typographyStyles['body-medium'])}
         >
@@ -54,7 +65,7 @@ export const File = (props: FileProps) => {
             ),
           }}
         />
-      </div>
+      </Paper>
       <ErrorList errors={errorsList} />
     </li>
   );

--- a/packages/dds-components/src/components/FileUploader/FileUploader.module.css
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.module.css
@@ -1,19 +1,9 @@
-.container {
-  width: var(--dds-input-default-width);
-}
-
 .input-container {
   box-sizing: border-box;
-  border: 2px solid;
-  border-style: dashed;
-  display: flex;
-  flex-direction: column;
-  gap: var(--dds-spacing-x1);
+  border: 2px dashed;
   border-color: var(--dds-color-border-default);
   background-color: var(--dds-color-surface-default);
   border-radius: var(--dds-border-radius-surface);
-  padding: var(--dds-spacing-x1-5) var(--dds-spacing-x1-5) var(--dds-spacing-x2)
-    var(--dds-spacing-x1-5);
 
   @media (prefers-reduced-motion: no-preference) {
     transition:
@@ -35,20 +25,7 @@
   padding: var(--dds-spacing-x0-5) 0;
 }
 
-.file {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--dds-spacing-x0-75);
-  padding: var(--dds-spacing-x0-5) var(--dds-spacing-x1);
-  margin-top: var(--dds-spacing-x0-5);
-  background-color: var(--dds-color-surface-subtle);
-  border-radius: var(--dds-border-radius-surface);
-  border: 1px solid var(--dds-color-border-default);
-}
-
 .file--invalid {
-  border: 1px solid var(--dds-color-border-danger);
   box-shadow: inset 0 0 0 1px var(--dds-color-border-danger);
 }
 

--- a/packages/dds-components/src/components/FileUploader/FileUploader.stories.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.stories.tsx
@@ -2,7 +2,11 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { FileUploader } from './FileUploader';
-import { categoryHtml } from '../../storybook/helpers';
+import {
+  categoryCss,
+  categoryHtml,
+  windowWidthDecorator,
+} from '../../storybook/helpers';
 import { StoryVStack } from '../layout/Stack/utils';
 import { Heading, Paragraph } from '../Typography';
 
@@ -10,7 +14,7 @@ export default {
   title: 'dds-components/Components/FileUploader',
   component: FileUploader,
   argTypes: {
-    width: { control: 'text' },
+    width: { control: 'text', table: categoryCss },
     id: { control: false, table: categoryHtml },
     initialFiles: { control: false },
     accept: { control: false },
@@ -143,5 +147,18 @@ export const CustomFileList: Story = {
         )}
       </>
     );
+  },
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '30%',
+      lg: 'var(--dds-input-default-width)',
+      xl: 'var(--dds-input-default-width)',
+    },
   },
 };

--- a/packages/dds-components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.tsx
@@ -1,4 +1,3 @@
-import { type Property } from 'csstype';
 import { type ComponentPropsWithRef, useId } from 'react';
 
 import { ErrorList } from './ErrorList';
@@ -15,6 +14,7 @@ import { Button } from '../Button';
 import { StylelessList } from '../helpers';
 import { UploadIcon } from '../Icon/icons';
 import { InputMessage } from '../InputMessage';
+import { Box, type ResponsiveProps, VStack } from '../layout';
 import { Label } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 import { VisuallyHidden } from '../VisuallyHidden';
@@ -38,15 +38,14 @@ export type FileUploaderProps = {
   required?: boolean;
   /**Callback for når fil-listen endres. */
   onChange: (newFiles: FileList) => void;
-  /**Bredde for filopplasteren. */
-  width?: Property.Width;
   /**Om drag-and-drop zone skal vises.
    * @default true
    */
   withDragAndDrop?: boolean;
   /**Om listen med opplastede filer skal skjules. Brukes kun hvis listen blir vist på egen måte. */
   hideFileList?: boolean;
-} & Partial<FileUploaderHookProps> &
+} & Pick<ResponsiveProps, 'width'> &
+  Partial<FileUploaderHookProps> &
   Omit<ComponentPropsWithRef<'div'>, 'onChange' | 'id'>;
 
 export const FileUploader = (props: FileUploaderProps) => {
@@ -64,10 +63,9 @@ export const FileUploader = (props: FileUploaderProps) => {
     maxFiles,
     disabled,
     onChange,
-    width,
+    width = 'var(--dds-input-default-width)',
     errorMessage,
     hideFileList,
-    style,
     className,
     ...rest
   } = props;
@@ -139,14 +137,10 @@ export const FileUploader = (props: FileUploaderProps) => {
   );
 
   return (
-    <div
+    <Box
       id={uniqueId}
-      className={cn(
-        className,
-        styles.container,
-        typographyStyles['body-medium'],
-      )}
-      style={{ ...style, width }}
+      className={cn(className, typographyStyles['body-medium'])}
+      width={width}
       {...rest}
     >
       {hasLabel && (
@@ -160,7 +154,9 @@ export const FileUploader = (props: FileUploaderProps) => {
       )}
       {hasTip && <InputMessage id={tipId} message={tip} messageType="tip" />}
       {withDragAndDrop ? (
-        <div
+        <VStack
+          gap="x1"
+          padding="x1.5 x1.5 x2 x1.5"
           {...getRootProps()}
           className={cn(
             styles['input-container'],
@@ -178,7 +174,7 @@ export const FileUploader = (props: FileUploaderProps) => {
             velg fil med påfølgende knapp
           </VisuallyHidden>
           {button}
-        </div>
+        </VStack>
       ) : (
         <div className={styles['input-container--no-drag-zone']}>
           <input {...getInputProps()} id={inputId} />
@@ -187,7 +183,7 @@ export const FileUploader = (props: FileUploaderProps) => {
       )}
       <ErrorList errors={rootErrorsList} />
       {!hideFileList && <StylelessList>{fileListElements}</StylelessList>}
-    </div>
+    </Box>
   );
 };
 

--- a/packages/dds-components/src/components/InlineEdit/InlineEdit.module.css
+++ b/packages/dds-components/src/components/InlineEdit/InlineEdit.module.css
@@ -1,7 +1,3 @@
-.container {
-  position: relative;
-}
-
 .inline-input {
   width: 100%;
   padding: var(--dds-spacing-x0-25);
@@ -29,10 +25,6 @@
 
 .inline-input--with-icon {
   padding-left: var(--dds-spacing-x2);
-}
-
-.inline-input--with-icon--is-editing {
-  padding-left: var(--dds-spacing-x0-25);
 }
 
 .inline-textarea {

--- a/packages/dds-components/src/components/InlineEdit/InlineEdit.types.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEdit.types.tsx
@@ -1,5 +1,6 @@
-import { type Property } from 'csstype';
 import { type ComponentPropsWithRef, type InputHTMLAttributes } from 'react';
+
+import { type ResponsiveProps } from '../layout';
 
 export type EditElement = HTMLInputElement | HTMLTextAreaElement;
 
@@ -11,7 +12,7 @@ export interface BaseInlineInputProps {
   /** Bredde på komponenten.
    * @default "140px"
    */
-  width?: Property.Width;
+  width?: ResponsiveProps['width'];
   /**Om redigeringsikonet skal vises. */
   hideIcon?: boolean;
 }

--- a/packages/dds-components/src/components/InlineEdit/InlineEditInput.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEditInput.stories.tsx
@@ -2,6 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { InlineEditInput } from './InlineEditInput';
+import { categoryCss, windowWidthDecorator } from '../../storybook/helpers';
 import { StoryVStack } from '../layout/Stack/utils';
 import { Table } from '../Table/normal';
 
@@ -9,7 +10,7 @@ export default {
   title: 'dds-components/Components/InlineEdit/InlineEditInput',
   component: InlineEditInput,
   argTypes: {
-    width: { control: { type: 'text' } },
+    width: { control: 'text', table: categoryCss },
   },
   parameters: {
     controls: {
@@ -103,5 +104,18 @@ export const InTable: Story = {
         </Table>
       </Table.Wrapper>
     );
+  },
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '20%',
+      lg: 'var(--dds-input-default-width)',
+      xl: 'var(--dds-input-default-width)',
+    },
   },
 };

--- a/packages/dds-components/src/components/InlineEdit/InlineEditTextArea.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEditTextArea.stories.tsx
@@ -2,6 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { InlineEditTextArea } from './InlineEditTextArea';
+import { categoryCss, windowWidthDecorator } from '../../storybook/helpers';
 import { StoryVStack } from '../layout/Stack/utils';
 import { Table } from '../Table/normal';
 
@@ -9,7 +10,7 @@ export default {
   title: 'dds-components/Components/InlineEdit/InlineEditTextArea',
   component: InlineEditTextArea,
   argTypes: {
-    width: { control: { type: 'text' } },
+    width: { control: 'text', table: categoryCss },
   },
   parameters: {
     controls: {
@@ -107,5 +108,18 @@ export const InTable: Story = {
         </Table>
       </Table.Wrapper>
     );
+  },
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '20%',
+      lg: 'var(--dds-input-default-width)',
+      xl: 'var(--dds-input-default-width)',
+    },
   },
 };

--- a/packages/dds-components/src/components/InlineEdit/InlineInput.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineInput.tsx
@@ -15,6 +15,7 @@ import { focusable } from '../helpers/styling/focus.module.css';
 import { Icon } from '../Icon';
 import { EditIcon } from '../Icon/icons';
 import { renderInputMessage } from '../InputMessage';
+import { Box } from '../layout';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 export const InlineInput = ({
@@ -42,7 +43,7 @@ export const InlineInput = ({
   const combinedRef = useCombinedRef(ref, inputRef);
 
   return (
-    <div className={styles.container} style={{ width }}>
+    <Box position="relative" width={width}>
       <div className={inputStyles['input-group']}>
         {!isEditing && !hideIcon && (
           <span
@@ -70,10 +71,7 @@ export const InlineInput = ({
           aria-invalid={hasErrorState}
           className={cn(
             styles['inline-input'],
-            !hideIcon && styles['inline-input--with-icon'],
-            !hideIcon &&
-              isEditing &&
-              styles['inline-input--with-icon--is-editing'],
+            !hideIcon && !isEditing && styles['inline-input--with-icon'],
             typographyStyles['body-medium'],
             hasErrorState && inputStyles['input--stateful-danger'],
             focusable,
@@ -82,7 +80,7 @@ export const InlineInput = ({
       </div>
       {inlineEditVisuallyHidden(descId, emptiable)}
       {renderInputMessage(undefined, undefined, errorMessage, errorMessageId)}
-    </div>
+    </Box>
   );
 };
 

--- a/packages/dds-components/src/components/InlineEdit/InlineTextArea.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineTextArea.tsx
@@ -16,6 +16,7 @@ import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { Icon } from '../Icon';
 import { EditIcon } from '../Icon/icons';
 import { renderInputMessage } from '../InputMessage';
+import { Box } from '../layout';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 export const InlineTextArea = ({
@@ -44,7 +45,7 @@ export const InlineTextArea = ({
   const combinedRef = useCombinedRef(ref, inputRef);
 
   return (
-    <div className={styles.container} style={{ width }}>
+    <Box position="relative" width={width}>
       <div className={inputStyles['input-group']}>
         {!isEditing && !hideIcon && (
           <span
@@ -71,10 +72,7 @@ export const InlineTextArea = ({
           ])}
           className={cn(
             styles['inline-input'],
-            !hideIcon && styles['inline-input--with-icon'],
-            !hideIcon &&
-              isEditing &&
-              styles['inline-input--with-icon--is-editing'],
+            !hideIcon && !isEditing && styles['inline-input--with-icon'],
             styles['inline-textarea'],
             inputStyles['input--stateful'],
             hasErrorState && inputStyles['input--stateful-danger'],
@@ -86,7 +84,7 @@ export const InlineTextArea = ({
       </div>
       {inlineEditVisuallyHidden(descId, emptiable)}
       {renderInputMessage(undefined, undefined, errorMessage, errorMessageId)}
-    </div>
+    </Box>
   );
 };
 

--- a/packages/dds-components/src/components/InputStepper/InputStepper.module.css
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.module.css
@@ -4,7 +4,6 @@
 .textInput {
   text-align: center;
   border-radius: 0;
-  width: var(--dds-input-stepper-width);
 }
 .stepButton {
   &:focus-visible {

--- a/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
@@ -2,7 +2,12 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
 import { InputStepper } from './InputStepper';
-import { categoryHtml, htmlPropsArgType } from '../../storybook/helpers';
+import {
+  categoryCss,
+  categoryHtml,
+  htmlPropsArgType,
+  windowWidthDecorator,
+} from '../../storybook/helpers';
 import { Button } from '../Button';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
@@ -14,6 +19,7 @@ export default {
     disabled: { table: categoryHtml },
     value: { control: 'number', table: categoryHtml },
     htmlProps: htmlPropsArgType,
+    width: { control: 'text', table: categoryCss },
   },
 
   parameters: {
@@ -27,82 +33,52 @@ export default {
 type Story = StoryObj<typeof InputStepper>;
 
 export const Default: Story = {
-  args: {},
+  args: {
+    maxValue: 5,
+  },
   render: args => {
-    return <InputStepper {...args} label="Label" maxValue={10} />;
+    return <InputStepper {...args} label="Label" />;
   },
 };
 
 export const Sizes: Story = {
+  args: {
+    maxValue: 5,
+  },
   render: args => {
     return (
       <StoryHStack>
-        <InputStepper
-          {...args}
-          label="Medium"
-          step={1}
-          minValue={0}
-          maxValue={5}
-        />
-        <InputStepper
-          {...args}
-          label="Small"
-          step={1}
-          minValue={0}
-          maxValue={5}
-          componentSize="small"
-        />
+        <InputStepper {...args} label="Medium" />
+        <InputStepper {...args} label="Small" componentSize="small" />
       </StoryHStack>
     );
   },
 };
 
 export const Overview: Story = {
+  args: {
+    maxValue: 5,
+  },
   render: args => {
     return (
       <StoryHStack>
         <StoryVStack>
           <InputStepper {...args} label="Label" maxValue={5} />
-          <InputStepper
-            {...args}
-            label="Error"
-            step={1}
-            minValue={0}
-            maxValue={5}
-            errorMessage="Feilmelding"
-          />
-          <InputStepper
-            {...args}
-            label="Hjelpetekst"
-            step={1}
-            minValue={0}
-            maxValue={5}
-            tip="Hjelpetekst"
-          />
+          <InputStepper {...args} label="Error" errorMessage="Feilmelding" />
+          <InputStepper {...args} label="Hjelpetekst" tip="Hjelpetekst" />
         </StoryVStack>
         <StoryVStack>
-          <InputStepper
-            {...args}
-            label="ReadOnly"
-            step={1}
-            minValue={0}
-            maxValue={5}
-            readOnly
-          />
-          <InputStepper
-            {...args}
-            label="Disabled"
-            step={1}
-            minValue={0}
-            maxValue={5}
-            disabled
-          />
+          <InputStepper {...args} label="ReadOnly" readOnly />
+          <InputStepper {...args} label="Disabled" disabled />
         </StoryVStack>
       </StoryHStack>
     );
   },
 };
 export const Controlled: Story = {
+  args: {
+    maxValue: 5,
+  },
   render: args => {
     const [value, setValue] = useState(4);
 
@@ -111,9 +87,6 @@ export const Controlled: Story = {
         <InputStepper
           {...args}
           label="Label"
-          step={1}
-          minValue={0}
-          maxValue={5}
           value={value}
           onChange={e => {
             if (typeof e === 'number') {
@@ -132,5 +105,19 @@ export const Controlled: Story = {
         </Button>
       </StoryVStack>
     );
+  },
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '50%',
+      lg: '180px',
+      xl: '180px',
+    },
+    maxValue: 5,
   },
 };

--- a/packages/dds-components/src/components/InputStepper/InputStepper.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.tsx
@@ -1,10 +1,9 @@
-import { type Properties } from 'csstype';
 import { useId } from 'react';
 
-import { Label, MinusIcon, PlusIcon, getBaseHTMLProps } from '../..';
+import { Box, Label, MinusIcon, PlusIcon, getBaseHTMLProps } from '../..';
 import { useControllableState } from '../../hooks/useControllableState';
 import { Button } from '../Button';
-import { StatefulInput } from '../helpers';
+import { StatefulInput, getInputWidth } from '../helpers';
 import styles from './InputStepper.module.css';
 import {
   type InputStepperProps,
@@ -81,10 +80,6 @@ export const InputStepper = ({
     }
   };
 
-  const styleVariables: Properties = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ['--dds-input-stepper-width' as any]: width ? width : '85px',
-  };
   return (
     <div className={className}>
       <div>
@@ -96,7 +91,10 @@ export const InputStepper = ({
           {label}
         </Label>
       </div>
-      <div className={styles['input-container']}>
+      <Box
+        className={styles['input-container']}
+        width={getInputWidth(width, '180px')}
+      >
         {readOnly || disabled ? null : (
           <Button
             aria-label={decreaseButtonLabel ?? `Trekk fra ${label}`}
@@ -108,14 +106,16 @@ export const InputStepper = ({
             aria-controls={uniqueId}
           ></Button>
         )}
-        <StatefulInput
+        <Box
+          as={StatefulInput}
+          width="100%"
           type="text"
           disabled={disabled}
           readOnly={readOnly}
           inputMode="numeric"
           pattern="-?[0-9]+"
           id={uniqueId}
-          style={{ ...style, ...styleVariables }}
+          style={style}
           componentSize={componentSize}
           {...getBaseHTMLProps(uniqueId, styles.textInput, htmlProps, rest)}
           value={inputValue}
@@ -138,7 +138,7 @@ export const InputStepper = ({
             aria-controls={uniqueId}
           ></Button>
         )}
-      </div>
+      </Box>
       {hasMessage &&
         renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
     </div>

--- a/packages/dds-components/src/components/InputStepper/InputStepper.types.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.types.tsx
@@ -1,6 +1,7 @@
 import { type InputHTMLAttributes } from 'react';
 
 import { type BaseComponentProps, type Size } from '../../types';
+import { type InputProps } from '../helpers/Input';
 
 export type InputStepperSize = Extract<Size, 'small' | 'medium'>;
 
@@ -11,16 +12,10 @@ export function isPositiveInteger(n: number): n is number {
 export type InputStepperProps = BaseComponentProps<
   HTMLInputElement,
   {
-    /**Ledetekst */
-    label?: string;
     /**Ledetekst for minusknapp */
     decreaseButtonLabel?: string;
     /**Ledetekst for plussknapp */
     increaseButtonLabel?: string;
-    /**Størrelse.
-     * @default 'medium'
-     */
-    componentSize?: InputStepperSize;
     /**Minimumsverdi. Negative tall støttes ikke
      * @default 0
      */
@@ -36,22 +31,13 @@ export type InputStepperProps = BaseComponentProps<
      * @default 0
      */
     defaultValue?: number;
-    /**Disabled
-     * @default false
-     */
-    disabled?: boolean;
-    /**ReadOnly
-     * @default false
-     */
-    readOnly?: boolean;
     /**Verdi */
     value?: number;
     /** Funksjon for å håndtere onChange    */
     onChange?: (value: number) => void;
-    /**Feilmelding */
-    errorMessage?: string;
-    /**Hjelpetekst */
-    tip?: string;
-  } & InputHTMLAttributes<HTMLInputElement>,
-  Omit<InputHTMLAttributes<HTMLInputElement>, 'defaultValue' | 'onChange'>
+  } & InputProps,
+  Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    'defaultValue' | 'onChange' | 'width' | 'value'
+  >
 >;

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.module.css
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.module.css
@@ -1,11 +1,7 @@
 .container {
   border: 1px solid;
   box-sizing: border-box;
-  display: grid;
-  align-items: center;
   border-radius: var(--dds-border-radius-surface);
-  padding: var(--dds-spacing-x0-75);
-  gap: var(--dds-spacing-x0-5);
 }
 
 .container--info {

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
@@ -1,7 +1,11 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { LocalMessage } from './LocalMessage';
-import { htmlPropsArgType } from '../../storybook/helpers';
+import {
+  categoryCss,
+  htmlPropsArgType,
+  windowWidthDecorator,
+} from '../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { List, ListItem } from '../List';
 import { Heading, Paragraph } from '../Typography';
@@ -10,7 +14,7 @@ export default {
   title: 'dds-components/Components/LocalMessage',
   component: LocalMessage,
   argTypes: {
-    width: { control: 'text' },
+    width: { control: 'text', table: categoryCss },
     htmlProps: htmlPropsArgType,
   },
   parameters: {
@@ -59,6 +63,20 @@ export const Closable: Story = {
   args: {
     children: 'Dette er en lokal melding',
     closable: true,
+  },
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    children: 'Dette er en lokal melding',
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '20%',
+      lg: 'fit-content',
+      xl: 'fit-content',
+    },
   },
 };
 

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.tsx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.tsx
@@ -1,4 +1,3 @@
-import { type Property } from 'csstype';
 import { useState } from 'react';
 
 import styles from './LocalMessage.module.css';
@@ -17,6 +16,7 @@ import {
   TipIcon,
   WarningIcon,
 } from '../Icon/icons';
+import { Box, type ResponsiveProps } from '../layout';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 const icons: Record<LocalMessagePurpose, SvgIcon> = {
@@ -53,9 +53,7 @@ export type LocalMessageProps = BaseComponentPropsWithChildren<
      * @default "horisontal"
      */
     layout?: LocalMessageLayout;
-    /**Custom bredde ved behov. */
-    width?: Property.Width;
-  }
+  } & Pick<ResponsiveProps, 'width'>
 >;
 
 export const LocalMessage = ({
@@ -78,7 +76,7 @@ export const LocalMessage = ({
   }
 
   return (
-    <div
+    <Box
       {...getBaseHTMLProps(
         id,
         cn(
@@ -92,7 +90,11 @@ export const LocalMessage = ({
         htmlProps,
         rest,
       )}
-      style={{ ...htmlProps?.style, width }}
+      width={width}
+      display="grid"
+      alignItems="center"
+      padding="x0.75"
+      gap="x0.5"
     >
       <Icon
         icon={icons[purpose]}
@@ -114,7 +116,7 @@ export const LocalMessage = ({
           className={styles.container__button}
         />
       )}
-    </div>
+    </Box>
   );
 };
 

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.module.css
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.module.css
@@ -2,33 +2,26 @@
   .input {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
-    width: var(--dds-phone-input-width);
   }
-
-  .select {
-    width: 8rem;
+  select {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
-    margin-right: -1px;
   }
 
-  .select--xsmall {
-    width: 5rem;
+  .select > div {
+    margin-right: -1px;
   }
 }
 
 .inputs-container--small-screen-xs {
   @media only screen and (max-width: 600px) {
-    width: var(--dds-phone-input-width);
     .input {
       border-top-right-radius: 0;
-      width: 100%;
     }
 
-    .select {
+    select {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
-      width: 100%;
       margin-bottom: -1px;
     }
   }
@@ -36,16 +29,13 @@
 
 .inputs-container--small-screen-sm {
   @media only screen and (max-width: 960px) {
-    width: var(--dds-phone-input-width);
     .input {
       border-top-right-radius: 0;
-      width: 100%;
     }
 
-    .select {
+    select {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
-      width: 100%;
       margin-bottom: -1px;
     }
   }
@@ -53,16 +43,13 @@
 
 .inputs-container--small-screen-md {
   @media only screen and (max-width: 1280px) {
-    width: var(--dds-phone-input-width);
     .input {
       border-top-right-radius: 0;
-      width: 100%;
     }
 
-    .select {
+    select {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
-      width: 100%;
       margin-bottom: -1px;
     }
   }
@@ -70,38 +57,32 @@
 
 .inputs-container--small-screen-lg {
   @media only screen and (max-width: 1920px) {
-    width: var(--dds-phone-input-width);
     .input {
       border-top-right-radius: 0;
-      width: 100%;
     }
 
-    .select {
+    select {
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
-      width: 100%;
       margin-bottom: -1px;
     }
   }
 }
 
 .inputs-container--small-screen-xl {
-  width: var(--dds-phone-input-width);
   .input {
     border-top-right-radius: 0;
-    width: 100%;
   }
 
-  .select {
+  select {
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
-    width: 100%;
     margin-bottom: -1px;
   }
 }
 
-.select:focus-visible,
-.select:hover {
+select:focus-visible,
+select:hover {
   z-index: var(--dds-zindex-absolute-element);
   & ~ svg {
     z-index: var(--dds-zindex-absolute-element);

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.stories.tsx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.stories.tsx
@@ -1,7 +1,11 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
-import { categoryHtml, windowWidthDecorator } from '../../storybook/helpers';
+import {
+  categoryCss,
+  categoryHtml,
+  windowWidthDecorator,
+} from '../../storybook/helpers';
 import { Button } from '../Button';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
@@ -11,7 +15,7 @@ export default {
   title: 'dds-components/Components/PhoneInput',
   component: PhoneInput,
   argTypes: {
-    width: { control: 'text' },
+    width: { control: 'text', table: categoryCss },
     required: { control: 'boolean', table: categoryHtml },
     disabled: { control: 'boolean', table: categoryHtml },
     readOnly: { control: 'boolean' },
@@ -75,6 +79,19 @@ export const Responsive: Story = {
         'Versjonen for liten skjerm vises ved sm brekkpunkt.',
       ),
   ],
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '50%',
+      lg: 'var(--dds-input-default-width)',
+      xl: 'var(--dds-input-default-width)',
+    },
+  },
 };
 
 export const Controlled: Story = {

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.tsx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.tsx
@@ -1,4 +1,4 @@
-import { type Properties, type Property } from 'csstype';
+import { type Property } from 'csstype';
 import {
   type ChangeEvent,
   type ForwardedRef,
@@ -17,7 +17,7 @@ import {
   derivativeIdGenerator,
   spaceSeparatedIdListGenerator,
 } from '../../utils';
-import { type InputProps, StatefulInput } from '../helpers';
+import { type InputProps, StatefulInput, getInputWidth } from '../helpers';
 import inputStyles from '../helpers/Input/Input.module.css';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { renderInputMessage } from '../InputMessage';
@@ -195,15 +195,6 @@ export const PhoneInput = ({
       ? `calc(var(--dds-spacing-x1) + ${callingCodeWidth}px)`
       : undefined;
 
-  const styleVariables: Properties = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ['--dds-phone-input-width' as any]: width
-      ? width
-      : componentSize === 'xsmall'
-        ? '131px'
-        : '194px',
-  };
-
   const internalSelectRef = useRef<HTMLSelectElement>(null);
 
   const combinedSelectRef = useCombinedRef(selectRef, internalSelectRef);
@@ -263,6 +254,9 @@ export const PhoneInput = ({
 
   const bp = props.smallScreenBreakpoint;
 
+  const widthDefault =
+    componentSize === 'xsmall' && 'var(--dds-input-default-width-xsmall)';
+
   return (
     <div className={cn(className, inputStyles.container)} style={style}>
       {hasLabel && (
@@ -282,7 +276,7 @@ export const PhoneInput = ({
           styles['inputs-container'],
           !!bp && styles[`inputs-container--small-screen-${bp}`],
         )}
-        style={styleVariables}
+        width={getInputWidth(width, widthDefault)}
         role="group"
         aria-label={groupLabel}
       >
@@ -290,13 +284,15 @@ export const PhoneInput = ({
           {selectLabel}
         </label>
         <NativeSelect
+          width={applyResponsiveStyle(
+            '100%',
+            bp,
+            componentSize === 'xsmall' ? '5rem' : '8rem',
+          )}
           {...commonProps}
           ref={combinedSelectRef}
           id={selectId}
-          className={cn(
-            styles.select,
-            componentSize === 'xsmall' && styles['select--xsmall'],
-          )}
+          className={cn(styles.select)}
           onChange={handleCountryCodeChange}
           defaultValue={defaultValue?.countryCode}
           value={displayedValue?.countryCode || ''}
@@ -313,7 +309,7 @@ export const PhoneInput = ({
             </option>
           ))}
         </NativeSelect>
-        <div className={inputStyles['input-group']}>
+        <Box width="100%" className={inputStyles['input-group']}>
           <span
             className={cn(
               typographyStyles[`body-${componentSize}`],
@@ -325,7 +321,8 @@ export const PhoneInput = ({
             {callingCode}
           </span>
 
-          <StatefulInput
+          <Box
+            as={StatefulInput}
             ref={ref}
             type="tel"
             {...commonProps}
@@ -334,8 +331,8 @@ export const PhoneInput = ({
             defaultValue={defaultValue?.phoneNumber}
             name={`${name}-phone-number`}
             onChange={handlePhoneNumberChange}
+            width="100%"
             style={{
-              ...styleVariables,
               paddingInlineStart: callingCodeInlineStart,
             }}
             className={styles.input}
@@ -347,7 +344,7 @@ export const PhoneInput = ({
               ariaDescribedby,
             ])}
           />
-        </div>
+        </Box>
       </Box>
       {hasMessage &&
         renderInputMessage(tip, tipId, errorMessage, errorMessageId)}

--- a/packages/dds-components/src/components/Popover/Popover.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.tsx
@@ -1,4 +1,3 @@
-import { type Property } from 'csstype';
 import {
   type ReactNode,
   type RefObject,
@@ -27,19 +26,15 @@ import { Button } from '../Button';
 import focusStyles from '../helpers/styling/focus.module.css';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { CloseIcon } from '../Icon/icons';
-import { Paper } from '../layout';
+import { Paper, type ResponsiveProps } from '../layout';
 import { Heading } from '../Typography';
 import { usePopoverContext } from './Popover.context';
 import { ThemeContext } from '../ThemeProvider';
 
-export interface PopoverSizeProps {
-  width?: Property.Width;
-  height?: Property.Height;
-  minWidth?: Property.MinWidth;
-  minHeight?: Property.MinHeight;
-  maxWidth?: Property.MaxWidth;
-  maxHeight?: Property.MaxHeight;
-}
+export type PopoverSizeProps = Pick<
+  ResponsiveProps,
+  'width' | 'height' | 'minWidth' | 'minHeight' | 'maxWidth' | 'maxHeight'
+>;
 
 export type PopoverProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
@@ -93,7 +88,7 @@ export const Popover = ({
   parentElement,
   portal = false,
   offset = 8,
-  sizeProps,
+  sizeProps = {},
   returnFocusOnBlur = true,
   className,
   htmlProps = {},
@@ -107,6 +102,7 @@ export const Popover = ({
     offset,
     placement,
   });
+  const { maxHeight, maxWidth, minHeight, minWidth, height, width } = sizeProps;
 
   const context = usePopoverContext();
   const themeContext = useContext(ThemeContext);
@@ -201,10 +197,15 @@ export const Popover = ({
       )}
       ref={multiRef}
       tabIndex={-1}
+      height={height}
+      maxHeight={maxHeight}
+      minHeight={minHeight}
+      width={width}
+      maxWidth={maxWidth}
+      minWidth={minWidth}
       style={{
         ...htmlProps.style,
         ...floatStyling,
-        ...sizeProps,
       }}
       role="dialog"
       elevation={3}

--- a/packages/dds-components/src/components/ProgressBar/ProgressBar.module.css
+++ b/packages/dds-components/src/components/ProgressBar/ProgressBar.module.css
@@ -1,26 +1,10 @@
-.container {
-  width: 100%;
-}
-
 .progress {
-  width: var(--dds-progressbar-width);
-  height: 48px;
   background-color: var(--dds-color-surface-medium);
   border: 1px solid var(--dds-color-border-default);
   border-radius: var(--dds-border-radius-surface);
 }
 
-.progress--small {
-  height: var(--dds-spacing-x0-75);
-}
-
-.progress--medium {
-  height: var(--dds-spacing-x1-5);
-}
-
 .fill {
-  height: 100%;
-  width: var(--dds-progressbar-fill-width);
   background-color: var(--dds-color-surface-action-resting);
 
   @media (prefers-reduced-motion: no-preference) {
@@ -39,7 +23,6 @@
 }
 
 .fill--indeterminate {
-  width: 25%;
   animation: indeterminate 2s infinite linear;
 }
 

--- a/packages/dds-components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/dds-components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import { categoryCss, windowWidthDecorator } from '../../storybook/helpers';
 import { StoryVStack } from '../layout/Stack/utils';
 
 import { ProgressBar } from '.';
@@ -8,7 +9,7 @@ export default {
   title: 'dds-components/Components/ProgressBar',
   component: ProgressBar,
   argTypes: {
-    width: { control: 'text' },
+    width: { control: 'text', table: categoryCss },
   },
   parameters: {
     docs: {
@@ -51,4 +52,18 @@ export const Sizes: Story = {
       <ProgressBar {...args} size="small" />
     </StoryVStack>
   ),
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    label: 'Label',
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '20%',
+      lg: 'var(--dds-input-default-width)',
+      xl: 'var(--dds-input-default-width)',
+    },
+  },
 };

--- a/packages/dds-components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/dds-components/src/components/ProgressBar/ProgressBar.tsx
@@ -1,4 +1,3 @@
-import { type Properties } from 'csstype';
 import { type ComponentPropsWithRef, useId } from 'react';
 
 import { Label } from '../Typography';
@@ -9,8 +8,9 @@ import {
   derivativeIdGenerator,
   spaceSeparatedIdListGenerator,
 } from '../../utils';
-import { type CommonInputProps } from '../helpers';
+import { type CommonInputProps, getInputWidth } from '../helpers';
 import { renderInputMessage } from '../InputMessage';
+import { Box } from '../layout';
 
 export type ProgressBarSize = 'medium' | 'small';
 
@@ -69,21 +69,10 @@ export const ProgressBar = ({
   const tipId = derivativeIdGenerator(uniqueId, 'tip');
   const errorMessageId = derivativeIdGenerator(uniqueId, 'errorMessage');
 
-  const progressStyleVariables: Properties = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ['--dds-progressbar-width' as any]: width
-      ? width
-      : 'var(--dds-input-default-width)',
-  };
-
   const fillPrecentage = hasValidValue && (value / (max ?? 1)) * 100 + '%';
-  const fillStyleVariables: Properties = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ['--dds-progressbar-fill-width' as any]: fillPrecentage ?? 0,
-  };
-
+  const isIndeterminate = !hasValidValue && !hasErrorMessage;
   return (
-    <div className={cn(className, styles.container)} style={style}>
+    <Box width="100%" className={className} style={style}>
       {hasLabel ? <Label htmlFor={uniqueId}>{label}</Label> : undefined}
       <progress
         id={uniqueId}
@@ -99,22 +88,24 @@ export const ProgressBar = ({
       >
         {fillPrecentage}
       </progress>
-      <div
-        style={progressStyleVariables}
-        className={cn(styles.progress, styles[`progress--${size}`])}
+      <Box
+        width={getInputWidth(width)}
+        height={size === 'small' ? 'x0.75' : 'x1.5'}
+        className={cn(styles.progress)}
       >
-        <div
-          style={fillStyleVariables}
+        <Box
+          height="100%"
+          width={isIndeterminate ? '25%' : fillPrecentage ? fillPrecentage : 0}
           className={cn(
             styles.fill,
-            !hasValidValue && !hasErrorMessage && styles['fill--indeterminate'],
+            isIndeterminate && styles['fill--indeterminate'],
             fillPrecentage === '100%' && styles['fill--done'],
             errorMessage && styles['fill--error'],
           )}
         />
-      </div>
+      </Box>
       {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
-    </div>
+    </Box>
   );
 };
 

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.module.css
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.module.css
@@ -1,12 +1,7 @@
-.container {
-  position: relative;
-  width: fit-content;
-}
-
 .select {
   appearance: none;
-  width: var(--dds-native-select-width);
   text-overflow: ellipsis;
+  width: 100%;
 
   &:hover:not(:disabled):not(.select--readonly) {
     border-color: var(--dds-color-border-action-hover);

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.stories.tsx
@@ -1,6 +1,10 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import { categoryHtml } from '../../../storybook/helpers';
+import {
+  categoryCss,
+  categoryHtml,
+  windowWidthDecorator,
+} from '../../../storybook/helpers';
 import { StoryVStack } from '../../layout/Stack/utils';
 
 import { NativeSelect, NativeSelectPlaceholder } from '.';
@@ -18,7 +22,7 @@ export default {
     label: { control: 'text' },
     tip: { control: 'text' },
     errorMessage: { control: 'text' },
-    width: { control: 'text' },
+    width: { control: 'text', table: categoryCss },
     disabled: { control: 'boolean', table: categoryHtml },
     required: { control: 'boolean', table: categoryHtml },
     readOnly: { control: 'boolean' },
@@ -81,6 +85,20 @@ export const OverviewSizes: Story = {
       <NativeSelect {...args} componentSize="xsmall" />
     </StoryVStack>
   ),
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    label: 'Label',
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '20%',
+      lg: 'var(--dds-input-default-width)',
+      xl: 'var(--dds-input-default-width)',
+    },
+  },
 };
 
 export const Multi: Story = {

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.tsx
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.tsx
@@ -1,4 +1,3 @@
-import { type Properties } from 'csstype';
 import { useId } from 'react';
 import type { ComponentPropsWithRef } from 'react';
 
@@ -10,13 +9,18 @@ import {
   readOnlyMouseDownHandler,
   spaceSeparatedIdListGenerator,
 } from '../../../utils';
-import { type CommonInputProps, type InputProps } from '../../helpers';
+import {
+  type CommonInputProps,
+  type InputProps,
+  getInputWidth,
+} from '../../helpers';
 import inputStyles from '../../helpers/Input/Input.module.css';
 import { focusable } from '../../helpers/styling/focus.module.css';
 import { scrollbar } from '../../helpers/styling/utilStyles.module.css';
 import { Icon } from '../../Icon';
 import { ChevronDownIcon } from '../../Icon/icons';
 import { renderInputMessage } from '../../InputMessage';
+import { Box } from '../../layout';
 import { Label } from '../../Typography';
 import typographyStyles from '../../Typography/typographyStyles.module.css';
 
@@ -55,17 +59,13 @@ export const NativeSelect = ({
 
   const showRequiredStyling = !!(required || ariaRequired);
 
-  const styleVariables: Properties = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ['--dds-native-select-width' as any]: width
-      ? width
-      : componentSize === 'xsmall'
-        ? '210px'
-        : 'var(--dds-input-default-width)',
-  };
+  const inputWidth = getInputWidth(
+    width,
+    componentSize === 'xsmall' && 'var(--dds-input-default-width-xsmall)',
+  );
 
   return (
-    <div>
+    <div className={className} style={style}>
       {hasLabel && (
         <Label
           className={inputStyles.label}
@@ -76,12 +76,11 @@ export const NativeSelect = ({
           {label}
         </Label>
       )}
-      <div className={styles.container}>
+      <Box position="relative" width={inputWidth}>
         <select
           id={uniqueId}
           multiple={multiple}
           className={cn(
-            className,
             styles.select,
             readOnly && styles['select--readonly'],
             inputStyles.input,
@@ -93,7 +92,6 @@ export const NativeSelect = ({
             hasErrorMessage && inputStyles['input--stateful-danger'],
             multiple && styles['select--multiple'],
           )}
-          style={{ ...style, ...styleVariables }}
           aria-readonly={readOnly}
           aria-invalid={hasErrorMessage}
           aria-describedby={spaceSeparatedIdListGenerator([
@@ -115,7 +113,7 @@ export const NativeSelect = ({
             className={styles.icon}
           />
         )}
-      </div>
+      </Box>
       {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
     </div>
   );

--- a/packages/dds-components/src/components/Select/Select.module.css
+++ b/packages/dds-components/src/components/Select/Select.module.css
@@ -1,9 +1,3 @@
-.container {
-  margin: 0;
-  position: relative;
-  width: var(--dds-select-width);
-}
-
 .container--disabled {
   cursor: not-allowed;
 }

--- a/packages/dds-components/src/components/Select/Select.stories.tsx
+++ b/packages/dds-components/src/components/Select/Select.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
+import { categoryCss, windowWidthDecorator } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { Drawer, DrawerGroup } from '../Drawer';
 import { CourtIcon } from '../Icon/icons';
@@ -14,7 +15,7 @@ const meta: Meta<typeof Select> = {
   title: 'dds-components/Components/Select/Select',
   component: Select,
   argTypes: {
-    width: { control: 'text' },
+    width: { control: 'text', table: categoryCss },
     placeholder: { control: 'text' },
     isDisabled: { control: 'boolean' },
     isClearable: { control: 'boolean' },
@@ -147,6 +148,21 @@ export const WithValue: Story = {
     label: 'Label',
     options: options,
     value: options[0],
+  },
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    label: 'Label',
+    options: options,
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '20%',
+      lg: 'var(--dds-input-default-width)',
+      xl: 'var(--dds-input-default-width)',
+    },
   },
 };
 

--- a/packages/dds-components/src/components/Select/Select.tsx
+++ b/packages/dds-components/src/components/Select/Select.tsx
@@ -1,4 +1,3 @@
-import { type Properties, type Property } from 'csstype';
 import {
   type HTMLAttributes,
   type JSX,
@@ -36,10 +35,11 @@ import {
   spaceSeparatedIdListGenerator,
 } from '../../utils';
 import { readOnlyKeyDownHandler } from '../../utils/readonlyEventHandlers';
-import { type InputSize } from '../helpers';
+import { type InputSize, getInputWidth } from '../helpers';
 import inputStyles from '../helpers/Input/Input.module.css';
 import { type SvgIcon } from '../Icon/utils';
 import { renderInputMessage } from '../InputMessage';
+import { Box, type ResponsiveProps } from '../layout';
 import { ThemeContext } from '../ThemeProvider';
 import { Label } from '../Typography';
 
@@ -73,8 +73,6 @@ export type SelectProps<Option = unknown, IsMulti extends boolean = false> = {
   errorMessage?: string;
   /**Hjelpetekst. */
   tip?: string;
-  /**Custom bredde ved behov. */
-  width?: Property.Width;
   /** CSS klassenavn. */
   className?: string;
   /** Inline styling. */
@@ -92,6 +90,7 @@ export type SelectProps<Option = unknown, IsMulti extends boolean = false> = {
   /**Ref til komponenten. */
   ref?: SelectForwardRefType<Option, IsMulti>;
 } & Pick<HTMLAttributes<HTMLInputElement>, 'aria-required'> &
+  Pick<ResponsiveProps, 'width'> &
   WrappedReactSelectProps<Option, IsMulti, GroupBase<Option>>;
 
 export type SelectForwardRefType<Option, IsMulti extends boolean> = Ref<
@@ -148,14 +147,10 @@ export function Select<Option = unknown, IsMulti extends boolean = false>({
   const tipId = derivativeIdGenerator(uniqueId, 'tip');
   const errorMessageId = derivativeIdGenerator(uniqueId, 'errorMessage');
 
-  const styleVariables: Properties = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ['--dds-select-width' as any]: width
-      ? width
-      : componentSize === 'xsmall'
-        ? '210px'
-        : 'var(--dds-input-default-width)',
-  };
+  const inputWidth = getInputWidth(
+    width,
+    componentSize === 'xsmall' && 'var(--dds-input-default-width-xsmall)',
+  );
 
   const reactSelectProps: ReactSelectProps<
     Option,
@@ -227,14 +222,16 @@ export function Select<Option = unknown, IsMulti extends boolean = false>({
   };
 
   return (
-    <div
+    <Box
+      width={inputWidth}
+      position="relative"
+      margin="0"
       className={cn(
         className,
-        styles.container,
         isDisabled && styles['container--disabled'],
         readOnly && styles['container--readonly'],
       )}
-      style={{ ...style, ...styleVariables }}
+      style={style}
     >
       {hasLabel && (
         <Label
@@ -248,7 +245,7 @@ export function Select<Option = unknown, IsMulti extends boolean = false>({
       )}
       <ReactSelect {...reactSelectProps} ref={ref} />
       {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
-    </div>
+    </Box>
   );
 }
 

--- a/packages/dds-components/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/dds-components/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,14 +1,15 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { Skeleton } from './Skeleton';
+import { categoryCss, windowWidthDecorator } from '../../storybook/helpers';
 import { StoryVStack } from '../layout/Stack/utils';
 
 export default {
   title: 'dds-components/Components/Skeleton',
   component: Skeleton,
   argTypes: {
-    width: { control: 'text' },
-    height: { control: 'text' },
+    width: { control: 'text', table: categoryCss },
+    height: { control: 'text', table: categoryCss },
     borderRadius: { control: 'text' },
   },
   parameters: {
@@ -62,4 +63,24 @@ export const Example: Story = {
       />
     </StoryVStack>
   ),
+};
+
+export const Responsive: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '20%',
+      lg: 'var(--dds-input-default-width)',
+      xl: 'var(--dds-input-default-width)',
+    },
+    height: {
+      xs: '20px',
+      sm: '20px',
+      md: '30px',
+      lg: '50px',
+      xl: '50px',
+    },
+  },
 };

--- a/packages/dds-components/src/components/Skeleton/Skeleton.tsx
+++ b/packages/dds-components/src/components/Skeleton/Skeleton.tsx
@@ -3,19 +3,17 @@ import { type ComponentPropsWithRef } from 'react';
 
 import styles from './Skeleton.module.css';
 import { cn } from '../../utils';
+import { Box, type ResponsiveProps } from '../layout';
 
 export type SkeletonAppearance = 'circle' | 'rectangle';
 
 export type SkeletonProps = {
-  /** Bredde. */
-  width?: Property.Width;
-  /** Høyde. */
-  height?: Property.Height;
   /**CSS border radius.
    * @default "var(--dds-border-radius-surface)"
    */
   borderRadius?: Property.BorderRadius;
-} & ComponentPropsWithRef<'div'>;
+} & Pick<ResponsiveProps, 'width' | 'height'> &
+  ComponentPropsWithRef<'div'>;
 
 export const Skeleton = ({
   width,
@@ -27,12 +25,14 @@ export const Skeleton = ({
   ...rest
 }: SkeletonProps) => {
   return (
-    <div
+    <Box
+      width={width}
+      height={height}
       ref={ref}
       className={cn(className, styles.container)}
-      style={{ ...style, width, height, borderRadius }}
+      style={{ ...style, borderRadius }}
       {...rest}
-    ></div>
+    ></Box>
   );
 };
 

--- a/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
@@ -1,7 +1,11 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import {
+  categoryCss,
+  htmlPropsArgType,
+  windowWidthDecorator,
+} from '../../storybook/helpers';
 import { NotificationsIcon } from '../Icon/icons';
 import { StoryVStack } from '../layout/Stack/utils';
 import { TextArea } from '../TextArea';
@@ -13,7 +17,7 @@ export default {
   title: 'dds-components/Components/Tabs',
   component: Tabs,
   argTypes: {
-    width: { control: 'text' },
+    width: { control: 'text', table: categoryCss },
     htmlProps: htmlPropsArgType,
     addTabButtonProps: { control: false },
   },
@@ -228,6 +232,56 @@ export const WithWidth: Story = {
   ),
 };
 
+export const MaxContentWidth: Story = {
+  render: args => (
+    <>
+      <Paragraph withMargins>
+        Dette er et eksempel på hvordan du kan sette egne bredder på hver tab.
+        Her er alle tabs satt til å ha bredde "<code>max-content</code>".
+      </Paragraph>
+      <Tabs {...args} htmlProps={{ style: { width: '400px' } }}>
+        <TabList>
+          <Tab width="max-content">Aktører</Tab>
+          <Tab width="max-content">Restriksjoner</Tab>
+          <Tab width="max-content">Vedlegg</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>Innhold 1</TabPanel>
+          <TabPanel>Innhold 2</TabPanel>
+          <TabPanel>Innhold 3</TabPanel>
+        </TabPanels>
+      </Tabs>
+    </>
+  ),
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '20%',
+      lg: '500px',
+      xl: '1000px',
+    },
+  },
+  render: args => (
+    <Tabs {...args}>
+      <TabList>
+        <Tab>Tab 1</Tab>
+        <Tab>Tab 2</Tab>
+        <Tab>Tab 3</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>Innhold 1</TabPanel>
+        <TabPanel>Innhold 2</TabPanel>
+        <TabPanel>Innhold 3</TabPanel>
+      </TabPanels>
+    </Tabs>
+  ),
+};
+
 export const TabLongNames: Story = {
   render: args => (
     <Tabs {...args}>
@@ -273,28 +327,5 @@ export const ManyTabs: Story = {
         <TabPanel>Innhold 10</TabPanel>
       </TabPanels>
     </Tabs>
-  ),
-};
-
-export const MaxContentWidth: Story = {
-  render: args => (
-    <>
-      <Paragraph withMargins>
-        Dette er et eksempel på hvordan du kan sette egne bredder på hver tab.
-        Her er alle tabs satt til å ha bredde "<code>max-content</code>".
-      </Paragraph>
-      <Tabs {...args} htmlProps={{ style: { width: '400px' } }}>
-        <TabList>
-          <Tab width="max-content">Aktører</Tab>
-          <Tab width="max-content">Restriksjoner</Tab>
-          <Tab width="max-content">Vedlegg</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>Innhold 1</TabPanel>
-          <TabPanel>Innhold 2</TabPanel>
-          <TabPanel>Innhold 3</TabPanel>
-        </TabPanels>
-      </Tabs>
-    </>
   ),
 };

--- a/packages/dds-components/src/components/Tabs/Tabs.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,3 @@
-import { type Properties, type Property } from 'csstype';
 import { type HTMLAttributes, useEffect, useId, useRef, useState } from 'react';
 
 import { type AddTabButtonProps } from './AddTabButton';
@@ -11,6 +10,7 @@ import {
   getBaseHTMLProps,
 } from '../../types';
 import { cn } from '../../utils';
+import { Box, type ResponsiveProps } from '../layout';
 
 export type TabSize = Extract<Size, 'small' | 'medium'>;
 
@@ -27,11 +27,9 @@ export type TabsProps = BaseComponentPropsWithChildren<
      * @default "row"
      */
     tabContentDirection?: Direction;
-    /**Bredde for hele komponenten. */
-    width?: Property.Width;
     /** Props for "Legg til fane"-knapp. Støtter native HTML attributter og `width`. */
     addTabButtonProps?: Omit<AddTabButtonProps, 'index'>;
-  },
+  } & Pick<ResponsiveProps, 'width'>,
   Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>
 >;
 
@@ -67,11 +65,6 @@ export const Tabs = ({
     }
   }, [activeTab, thisActiveTab]);
 
-  const customWidth: Properties = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ['--dds-tabs-width' as any]: width,
-  };
-
   return (
     <TabsContext
       value={{
@@ -87,17 +80,17 @@ export const Tabs = ({
         addTabButtonProps,
       }}
     >
-      <div
+      <Box
         {...getBaseHTMLProps(
           uniqueId,
           cn(className, styles.tabs),
           htmlProps,
           rest,
         )}
-        style={{ ...htmlProps?.style, ...customWidth }}
+        width={width}
       >
         {children}
-      </div>
+      </Box>
     </TabsContext>
   );
 };

--- a/packages/dds-components/src/components/TextArea/TextArea.module.css
+++ b/packages/dds-components/src/components/TextArea/TextArea.module.css
@@ -1,12 +1,6 @@
 .textarea {
-  width: var(--dds-text-area-width);
   height: auto;
   resize: vertical;
   vertical-align: bottom;
   padding-bottom: var(--dds-spacing-x0-5);
-}
-
-.message-container {
-  display: flex;
-  justify-content: space-between;
 }

--- a/packages/dds-components/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/dds-components/src/components/TextArea/TextArea.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
 import { TextArea } from './TextArea';
-import { categoryHtml } from '../../storybook/helpers';
+import { categoryHtml, windowWidthDecorator } from '../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 export default {
@@ -58,4 +58,18 @@ export const Overview: Story = {
 
 export const WithCharacterCount: Story = {
   args: { label: 'Label', maxLength: 200 },
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    label: 'Label',
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '20%',
+      lg: 'var(--dds-input-default-width)',
+      xl: 'var(--dds-input-default-width)',
+    },
+  },
 };

--- a/packages/dds-components/src/components/TextArea/TextArea.tsx
+++ b/packages/dds-components/src/components/TextArea/TextArea.tsx
@@ -1,4 +1,3 @@
-import { type Properties } from 'csstype';
 import {
   type ComponentPropsWithRef,
   useEffect,
@@ -14,12 +13,13 @@ import {
   derivativeIdGenerator,
   spaceSeparatedIdListGenerator,
 } from '../../utils';
-import { getDefaultText, renderCharCounter } from '../helpers';
+import { getDefaultText, getInputWidth, renderCharCounter } from '../helpers';
 import { type CommonInputProps } from '../helpers';
 import inputStyles from '../helpers/Input/Input.module.css';
 import { focusable } from '../helpers/styling/focus.module.css';
 import { scrollbar } from '../helpers/styling/utilStyles.module.css';
 import { renderInputMessage } from '../InputMessage';
+import { Box } from '../layout';
 import { Label } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
@@ -86,11 +86,6 @@ export const TextArea = ({
 
   const showRequiredStyling = required || !!ariaRequired;
 
-  const styleVariables: Properties = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ['--dds-text-area-width' as any]: width ?? 'var(--dds-input-default-width)',
-  };
-
   return (
     <div className={cn(className, inputStyles.container)} style={{ ...style }}>
       {hasLabel && (
@@ -103,7 +98,9 @@ export const TextArea = ({
           {label}
         </Label>
       )}
-      <textarea
+      <Box
+        as="textarea"
+        width={getInputWidth(width)}
         ref={multiRef}
         id={uniqueId}
         onChange={onChangeHandler}
@@ -129,10 +126,9 @@ export const TextArea = ({
           typographyStyles['body-medium'],
           focusable,
         )}
-        style={styleVariables}
         {...rest}
       />
-      <div className={styles['message-container']}>
+      <Box display="flex" alignContent="space-between">
         {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
         {renderCharCounter(
           characterCounterId,
@@ -140,7 +136,7 @@ export const TextArea = ({
           text.length,
           maxLength,
         )}
-      </div>
+      </Box>
     </div>
   );
 };

--- a/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import { categoryHtml } from '../../storybook/helpers';
+import { categoryHtml, windowWidthDecorator } from '../../storybook/helpers';
 import { MailIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { LocalMessage } from '../LocalMessage';
@@ -117,4 +117,18 @@ export const WithCharacterCount: Story = {
 
 export const WithAriaRequired: Story = {
   args: { label: 'Label', 'aria-required': true },
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    label: 'Label',
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '20%',
+      lg: 'var(--dds-input-default-width)',
+      xl: 'var(--dds-input-default-width)',
+    },
+  },
 };

--- a/packages/dds-components/src/components/TextInput/TextInput.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.tsx
@@ -1,4 +1,4 @@
-import { type Properties, type Property } from 'csstype';
+import { type Property } from 'csstype';
 import React, { useId, useLayoutEffect, useRef, useState } from 'react';
 
 import styles from './TextInput.module.css';
@@ -9,7 +9,12 @@ import {
   spaceSeparatedIdListGenerator,
 } from '../../utils';
 import { getFormInputIconSize } from '../../utils/icon';
-import { StatefulInput, getDefaultText, renderCharCounter } from '../helpers';
+import {
+  StatefulInput,
+  getDefaultText,
+  getInputWidth,
+  renderCharCounter,
+} from '../helpers';
 import inputStyles from '../helpers/Input/Input.module.css';
 import { Icon } from '../Icon';
 import { renderInputMessage } from '../InputMessage';
@@ -84,14 +89,10 @@ export const TextInput = ({
   const tipId = derivativeIdGenerator(uniqueId, 'tip');
   const errorMessageId = derivativeIdGenerator(uniqueId, 'errorMessage');
 
-  const styleVariables: Properties = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ['--dds-textinput-width' as any]: width
-      ? width
-      : componentSize === 'xsmall'
-        ? '210px'
-        : 'var(--dds-input-default-width)',
-  };
+  const inputWidth = getInputWidth(
+    width,
+    componentSize === 'xsmall' && 'var(--dds-input-default-width-xsmall)',
+  );
 
   const generalInputProps = {
     ref,
@@ -134,10 +135,7 @@ export const TextInput = ({
 
   if (hasIcon) {
     extendedInput = (
-      <div
-        className={cn(styles['input-width'], inputStyles['input-group'])}
-        style={styleVariables}
-      >
+      <Box className={inputStyles['input-group']} width={inputWidth}>
         {
           <Icon
             icon={icon}
@@ -156,7 +154,7 @@ export const TextInput = ({
           )}
           {...generalInputProps}
         />
-      </div>
+      </Box>
     );
   } else if (hasAffix) {
     extendedInput = (
@@ -164,8 +162,7 @@ export const TextInput = ({
         position="relative"
         display="flex"
         alignItems="center"
-        className={styles['input-width']}
-        style={styleVariables}
+        width={inputWidth}
       >
         {prefix && (
           <span
@@ -230,11 +227,7 @@ export const TextInput = ({
       {extendedInput ? (
         extendedInput
       ) : (
-        <StatefulInput
-          style={styleVariables}
-          className={styles['input-width']}
-          {...generalInputProps}
-        />
+        <Box as={StatefulInput} width={inputWidth} {...generalInputProps} />
       )}
       {hasMessage && (
         <Box display="flex" justifyContent="space-between" gap="x0.5">

--- a/packages/dds-components/src/components/ThemeProvider/ThemeProvider.module.css
+++ b/packages/dds-components/src/components/ThemeProvider/ThemeProvider.module.css
@@ -18,6 +18,7 @@
 
   /*Other*/
   --dds-input-default-width: 320px;
+  --dds-input-default-width-xsmall: 210px;
   --dds-transition-duration-surface-move: 0.5s;
 }
 

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.module.css
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.module.css
@@ -1,9 +1,3 @@
-.container {
-  display: flex;
-  flex-direction: column;
-  gap: var(--dds-spacing-x0-125);
-}
-
 .bar {
   display: grid;
   grid-auto-flow: column;

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
@@ -1,7 +1,11 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 import { useState } from 'react';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import {
+  categoryCss,
+  htmlPropsArgType,
+  windowWidthDecorator,
+} from '../../storybook/helpers';
 import { PlusCircledIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
@@ -11,7 +15,7 @@ export default {
   title: 'dds-components/Components/ToggleBar',
   component: ToggleBar,
   argTypes: {
-    width: { control: 'text' },
+    width: { control: 'text', table: categoryCss },
     value: { control: false },
     htmlProps: htmlPropsArgType,
   },
@@ -247,21 +251,49 @@ export const WithWidth: Story = {
   render: args => {
     const [value, setValue] = useState<string | undefined>();
     return (
-      <>
-        <ToggleBar
-          {...args}
-          name="test"
-          value={value}
-          onChange={(_event, value) => {
-            setValue(value);
-          }}
-          width="320px"
-        >
-          <ToggleRadio value="alt1" label="Alt" />
-          <ToggleRadio value="alt2" label="Alt" />
-          <ToggleRadio value="alt3" label="Alt" />
-        </ToggleBar>
-      </>
+      <ToggleBar
+        {...args}
+        name="test"
+        value={value}
+        onChange={(_event, value) => {
+          setValue(value);
+        }}
+        width="320px"
+      >
+        <ToggleRadio value="alt1" label="Alt" />
+        <ToggleRadio value="alt2" label="Alt" />
+        <ToggleRadio value="alt3" label="Alt" />
+      </ToggleBar>
+    );
+  },
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '30%',
+      lg: '500px',
+      xl: '1000px',
+    },
+  },
+  render: args => {
+    const [value, setValue] = useState<string | undefined>();
+    return (
+      <ToggleBar
+        {...args}
+        name="test"
+        value={value}
+        onChange={(_event, value) => {
+          setValue(value);
+        }}
+      >
+        <ToggleRadio value="alt1" label="Alt" />
+        <ToggleRadio value="alt2" label="Alt" />
+        <ToggleRadio value="alt3" label="Alt" />
+      </ToggleBar>
     );
   },
 };

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.tsx
@@ -4,7 +4,8 @@ import { ToggleBarContext } from './ToggleBar.context';
 import styles from './ToggleBar.module.css';
 import { type ToggleBarProps, type ToggleBarValue } from './ToggleBar.types';
 import { getBaseHTMLProps } from '../../types';
-import { cn, combineHandlers } from '../../utils';
+import { combineHandlers } from '../../utils';
+import { VStack } from '../layout';
 import { Typography } from '../Typography';
 
 export const ToggleBar = <T extends string | number = string>(
@@ -45,14 +46,10 @@ export const ToggleBar = <T extends string | number = string>(
         value: groupValue,
       }}
     >
-      <div
-        {...getBaseHTMLProps(
-          id,
-          cn(className, styles.container),
-          htmlProps,
-          rest,
-        )}
-        style={{ ...htmlProps?.style, width }}
+      <VStack
+        {...getBaseHTMLProps(id, className, htmlProps, rest)}
+        width={width}
+        gap="x0.125"
         role="radiogroup"
         aria-labelledby={labelId ?? htmlProps?.['aria-labelledby']}
       >
@@ -62,7 +59,7 @@ export const ToggleBar = <T extends string | number = string>(
           </Typography>
         )}
         <div className={styles.bar}>{children}</div>
-      </div>
+      </VStack>
     </ToggleBarContext>
   );
 };

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.types.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.types.tsx
@@ -1,7 +1,7 @@
-import { type Property } from 'csstype';
 import { type ChangeEvent, type InputHTMLAttributes } from 'react';
 
 import { type BaseComponentPropsWithChildren, type Size } from '../../types';
+import { type ResponsiveProps } from '../layout';
 
 export type ToggleBarValue = string | number | null | undefined;
 export type ToggleBarSize = Extract<
@@ -26,7 +26,10 @@ export type ToggleBarProps<T extends string | number> =
       /** Gir alle barna samme `name` prop.*/
       name?: string;
       /**Bredden til komponenten. Bredden fordeles likt mellom barna.  */
-      width?: Property.Width;
+      width?: ResponsiveProps['width'];
     },
-    Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'size'>
+    Omit<
+      InputHTMLAttributes<HTMLInputElement>,
+      'value' | 'onChange' | 'size' | 'width'
+    >
   >;

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.tsx
@@ -3,7 +3,6 @@ import { useDatePicker } from '@react-aria/datepicker';
 import { I18nProvider } from '@react-aria/i18n';
 import { useDatePickerState } from '@react-stately/datepicker';
 import type { AriaDatePickerProps } from '@react-types/datepicker';
-import type * as CSS from 'csstype';
 import { type Ref, useRef } from 'react';
 
 import { Calendar } from './Calendar/Calendar';
@@ -16,6 +15,7 @@ import { locale } from './constants';
 import { DateField, type DateFieldProps } from './DateField/DateField';
 import { useCombinedRef } from '../../../hooks';
 import { type Breakpoint } from '../../layout';
+import { type ResponsiveProps } from '../../layout/common/Responsive.types';
 import {
   type FocusableRef,
   useFocusManagerRef,
@@ -23,7 +23,8 @@ import {
 
 export interface DatePickerProps
   extends Omit<AriaDatePickerProps<CalendarDate>, 'granularity'>,
-    Pick<DateFieldProps<CalendarDate>, 'componentSize' | 'tip' | 'style'> {
+    Pick<DateFieldProps<CalendarDate>, 'componentSize' | 'tip' | 'style'>,
+    Pick<ResponsiveProps, 'width'> {
   ref?: Ref<HTMLElement>;
   /**
    * Ledetekst.
@@ -37,10 +38,6 @@ export interface DatePickerProps
    * @default true
    */
   showWeekNumbers?: boolean;
-  /**
-   * Egendefinert bredde på komponenten.
-   */
-  width?: CSS.Properties['width'];
   /**
    * Brekkpunkt for å vise versjon for liten skjerm.
    */

--- a/packages/dds-components/src/components/date-inputs/common/DateInput.tsx
+++ b/packages/dds-components/src/components/date-inputs/common/DateInput.tsx
@@ -1,13 +1,13 @@
 import { type useDateField, type useDatePicker } from '@react-aria/datepicker';
-import { type Properties } from 'csstype';
 import { type ReactNode, type Ref, useContext } from 'react';
 
 import styles from './DateInput.module.css';
 import { cn } from '../../../utils';
-import { type InputProps } from '../../helpers';
+import { type InputProps, getInputWidth } from '../../helpers';
 import inputStyles from '../../helpers/Input/Input.module.css';
 import focusStyles from '../../helpers/styling/focus.module.css';
 import { InputMessage } from '../../InputMessage';
+import { Box } from '../../layout';
 import { Label } from '../../Typography';
 import { CalendarPopoverContext } from '../DatePicker/CalendarPopover';
 
@@ -61,11 +61,6 @@ export function DateInput({
 
   const { isOpen } = useContext(CalendarPopoverContext);
 
-  const styleVariables: Properties = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ['--dds-date-input-width' as any]: width ? width : 'fit-content',
-  };
-
   return (
     <div
       {...groupProps}
@@ -82,10 +77,11 @@ export function DateInput({
           {props.label}
         </Label>
       )}
-      <div
+      <Box
         {...fieldProps}
-        style={{ ...style, ...styleVariables }}
+        style={style}
         ref={internalRef}
+        width={getInputWidth(width, 'fit-content')}
         className={cn(
           inputStyles.input,
           inputStyles['input--stateful'],
@@ -105,7 +101,7 @@ export function DateInput({
       >
         {button}
         <div className={styles['date-segment-container']}>{children}</div>
-      </div>
+      </Box>
       {hasMessage && (
         <InputMessage
           messageType={hasErrorMessage ? 'error' : 'tip'}

--- a/packages/dds-components/src/components/helpers/Input/Input.types.tsx
+++ b/packages/dds-components/src/components/helpers/Input/Input.types.tsx
@@ -1,14 +1,14 @@
-import { type Property } from 'csstype';
 import { type ComponentPropsWithRef } from 'react';
 
 import { type Size } from '../../../types';
+import { type ResponsiveProps } from '../../layout/common/Responsive.types';
 import { type StaticTypographyType } from '../../Typography';
 
 export interface CommonInputProps {
   /**Ledetekst. */
   label?: string;
   /**Bredde for inputfeltet. */
-  width?: Property.Width;
+  width?: ResponsiveProps['width'];
   /**Hjelpetekst. */
   tip?: string;
   /**Feilmelding. Setter også error state. */
@@ -22,7 +22,7 @@ export type InputProps = CommonInputProps & {
    * @default "medium"
    */
   componentSize?: InputSize;
-} & ComponentPropsWithRef<'input'>;
+} & Omit<ComponentPropsWithRef<'input'>, 'width'>;
 
 export type StatefulInputProps = {
   hasErrorMessage: boolean;

--- a/packages/dds-components/src/components/helpers/Input/Input.utils.tsx
+++ b/packages/dds-components/src/components/helpers/Input/Input.utils.tsx
@@ -1,3 +1,5 @@
+import { type ResponsiveProps } from '../../layout';
+
 export function getDefaultText(
   value?: string | number | ReadonlyArray<string>,
   defaultValue?: string | number | ReadonlyArray<string>,
@@ -11,4 +13,11 @@ export function getDefaultText(
   }
 
   return '';
+}
+
+export function getInputWidth(
+  width?: ResponsiveProps['width'],
+  defaultW?: ResponsiveProps['width'] | false | null,
+): ResponsiveProps['width'] {
+  return width ? width : defaultW ? defaultW : 'var(--dds-input-default-width)';
 }


### PR DESCRIPTION
## Beskrivelse

Utvider props relaterte til størrelse (`width`, `height`, `minWidth` osv) på tvers av komponenter slik de de støtter responsiv prop (verdi per brekkpunkt). De fleste endringene er bare en utvidelse + stories for showcases.

`<PhoneInput>`, `<InputStepper>` ble i tillegg endret til å håndtere bredde på standsardisert måte, aka `width` påvirker hele inputgruppen, ikke bare den ene inputfeltet. `<NativeSelect>` ble tilpasset på samme måte + at `className` og `style` props settes på roten, slik det er i andre komponenter. Det kan føre til endringer i layout hos konsumentene, og oppfattes dermed som breaking change.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
