### PR TITLE
ELSA1-597 `smallScreenBreakpoint` prop i `<DetailList>`

### DIFF
--- a/.changeset/wicked-goats-warn.md
+++ b/.changeset/wicked-goats-warn.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Ny prop `smallScreenBreakpoint` i `<DetailList>`. Den gjør om rader (`<DetailListRow>`) til kolonner.

--- a/packages/dds-components/src/components/DetailList/DetailList.context.tsx
+++ b/packages/dds-components/src/components/DetailList/DetailList.context.tsx
@@ -1,0 +1,10 @@
+import { createContext, useContext } from 'react';
+
+import { type Breakpoint } from '../layout';
+
+interface DetailListContextProps {
+  smallScreenBreakpoint?: Breakpoint;
+}
+
+export const DetailListContext = createContext<DetailListContextProps>({});
+export const useDetailListContext = () => useContext(DetailListContext);

--- a/packages/dds-components/src/components/DetailList/DetailList.module.css
+++ b/packages/dds-components/src/components/DetailList/DetailList.module.css
@@ -13,13 +13,13 @@
 
 .list--striped {
   .row {
-    &:nth-of-type(4n-3),
-    &:nth-of-type(4n-2) {
+    &:nth-of-type(4n-1),
+    &:nth-of-type(4n) {
       background-color: var(--dds-color-surface-default);
     }
 
-    &:nth-of-type(4n-1),
-    &:nth-of-type(4n) {
+    &:nth-of-type(4n-3),
+    &:nth-of-type(4n-2) {
       background-color: var(--dds-color-surface-subtle);
     }
   }

--- a/packages/dds-components/src/components/DetailList/DetailList.module.css
+++ b/packages/dds-components/src/components/DetailList/DetailList.module.css
@@ -13,11 +13,13 @@
 
 .list--striped {
   .row {
-    &:nth-of-type(even) {
+    &:nth-of-type(4n-3),
+    &:nth-of-type(4n-2) {
       background-color: var(--dds-color-surface-default);
     }
 
-    &:nth-of-type(odd) {
+    &:nth-of-type(4n-1),
+    &:nth-of-type(4n) {
       background-color: var(--dds-color-surface-subtle);
     }
   }
@@ -48,8 +50,12 @@
   }
 }
 
-.row {
-  display: table-row;
+.column {
+  dt,
+  dd {
+    margin-inline-start: 0;
+    text-align: left;
+  }
 }
 
 .cell {

--- a/packages/dds-components/src/components/DetailList/DetailList.spec.tsx
+++ b/packages/dds-components/src/components/DetailList/DetailList.spec.tsx
@@ -14,9 +14,9 @@ describe('<DetailList>', () => {
         </DetailListRow>
       </DetailList>,
     );
-    const term = screen.getByRole('term');
-    expect(term).toBeInTheDocument();
-    expect(screen.getByText(termText)).toBeInTheDocument();
+    const terms = screen.getAllByRole('term');
+    expect(terms).toHaveLength(2);
+    expect(screen.getAllByText(termText)).toHaveLength(2);
   });
   it('should render description', () => {
     const descText = 'desc';
@@ -28,8 +28,8 @@ describe('<DetailList>', () => {
         </DetailListRow>
       </DetailList>,
     );
-    const desc = screen.getByRole('definition');
-    expect(desc).toBeInTheDocument();
-    expect(screen.getByText(descText)).toBeInTheDocument();
+    const descs = screen.getAllByRole('definition');
+    expect(descs).toHaveLength(2);
+    expect(screen.getAllByText(descText)).toHaveLength(2);
   });
 });

--- a/packages/dds-components/src/components/DetailList/DetailList.stories.tsx
+++ b/packages/dds-components/src/components/DetailList/DetailList.stories.tsx
@@ -1,6 +1,9 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import {
+  htmlPropsArgType,
+  windowWidthDecorator,
+} from '../../storybook/helpers';
 import { InlineButton } from '../InlineButton';
 
 import { DetailList, DetailListDesc, DetailListRow, DetailListTerm } from '.';
@@ -123,4 +126,19 @@ export const Large: Story = {
       {children}
     </DetailList>
   ),
+};
+
+export const Responsive: Story = {
+  decorators: [
+    Story =>
+      windowWidthDecorator(
+        <>
+          <Story />
+          <style>{styling}</style>
+        </>,
+        'Versjonen for liten skjerm vises ved sm brekkpunkt og nedover.',
+      ),
+  ],
+  args: { smallScreenBreakpoint: 'sm' },
+  render: args => <DetailList {...args}>{children}</DetailList>,
 };

--- a/packages/dds-components/src/components/DetailList/DetailList.tsx
+++ b/packages/dds-components/src/components/DetailList/DetailList.tsx
@@ -5,6 +5,8 @@ import {
   getBaseHTMLProps,
 } from '../../types';
 import { cn } from '../../utils';
+import { type Breakpoint } from '../layout';
+import { DetailListContext } from './DetailList.context';
 
 export type DetailListSize = Extract<Size, 'large' | 'medium' | 'small'>;
 
@@ -26,6 +28,8 @@ export type DetailListProps = BaseComponentPropsWithChildren<
      * @default true
      */
     striped?: boolean;
+    /**Brekkpunkt og nedover versjonen for små skjermer skal vises; den gjør om rader til kolonner. */
+    smallScreenBreakpoint?: Breakpoint;
   }
 >;
 
@@ -36,22 +40,25 @@ export const DetailList = ({
   withDividers = true,
   striped = true,
   size = 'medium',
+  smallScreenBreakpoint,
   ...rest
 }: DetailListProps) => (
-  <dl
-    {...getBaseHTMLProps(
-      id,
-      cn(
-        className,
-        styles.list,
-        styles[`list--${size}`],
-        withDividers && styles['list--with-dividers'],
-        striped && styles['list--striped'],
-      ),
-      htmlProps,
-      rest,
-    )}
-  />
+  <DetailListContext value={{ smallScreenBreakpoint }}>
+    <dl
+      {...getBaseHTMLProps(
+        id,
+        cn(
+          className,
+          styles.list,
+          styles[`list--${size}`],
+          withDividers && styles['list--with-dividers'],
+          striped && styles['list--striped'],
+        ),
+        htmlProps,
+        rest,
+      )}
+    />
+  </DetailListContext>
 );
 
 DetailList.displayName = 'DetailList';

--- a/packages/dds-components/src/components/DetailList/DetailListRow.tsx
+++ b/packages/dds-components/src/components/DetailList/DetailListRow.tsx
@@ -2,11 +2,31 @@ import { type ComponentPropsWithRef } from 'react';
 
 import styles from './DetailList.module.css';
 import { cn } from '../../utils';
+import { Box } from '../layout';
+import { useDetailListContext } from './DetailList.context';
 
 export type DetailListRowProps = ComponentPropsWithRef<'div'>;
 
-export const DetailListRow = ({ className, ...rest }: DetailListRowProps) => (
-  <div className={cn(className, styles.row)} {...rest} />
-);
+export const DetailListRow = ({ className, ...rest }: DetailListRowProps) => {
+  const { smallScreenBreakpoint: bp } = useDetailListContext();
+
+  return (
+    <>
+      <Box
+        display="table-row"
+        hideBelow={bp}
+        className={cn(className, styles.row)}
+        {...rest}
+      />
+      <Box
+        display="flex"
+        flexDirection="column"
+        showBelow={bp}
+        className={cn(className, styles.row, styles.column)}
+        {...rest}
+      />
+    </>
+  );
+};
 
 DetailListRow.displayName = 'DetailListRow';


### PR DESCRIPTION
## Beskrivelse

Propen gjør om rader (`<DetailListRow>`) til kolonner, slik at den er responsiv.

![image](https://github.com/user-attachments/assets/11d3be74-9934-43e5-9ed5-f3b4d002a559)


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [ ] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
