### PR TITLE
ELSA1-599 Legger tegnteller under inputfeltet

### DIFF
--- a/.changeset/major-news-taste.md
+++ b/.changeset/major-news-taste.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Tegnteller plasseres nå under inpufeltet til høyre i `<TextInput>` og `<TextArea>`. Hvis det blir for lite plass til feilmelding eller hjelpetekst vurder å gjøre inputfeltet bredere.

--- a/packages/dds-components/src/components/TextArea/TextArea.mdx
+++ b/packages/dds-components/src/components/TextArea/TextArea.mdx
@@ -30,6 +30,10 @@ Maks antall tegn i input bør ta utgangspunkt i konteksten til applikasjonen, s�
 
 Unngå å bruke `placeholder` attributtet. Hvis du bruker den istedenfor semantisk ledetekst ser brukeren ikke hva feltet ber om etter det blir fylt ut. I tillegg kan inputfeltet se ferdig fylt ut.
 
+### Tegnteller
+
+Tegnteller legger seg under inputfeltet til høyre. Hvis det blir for lite plass til feilmelding eller hjelpetekst vurder å gjøre inputfeltet bredere.
+
 ### Generelt
 
 - Bruk gjerne `autofocus` for å indikere hvor brukeren skal starte.

--- a/packages/dds-components/src/components/TextArea/TextArea.tsx
+++ b/packages/dds-components/src/components/TextArea/TextArea.tsx
@@ -76,6 +76,7 @@ export const TextArea = ({
   };
 
   const hasErrorMessage = !!errorMessage;
+  const hasMessage = hasErrorMessage || !!tip;
   const hasLabel = !!label;
   const tipId = derivativeIdGenerator(uniqueId, 'tip');
   const errorMessageId = derivativeIdGenerator(uniqueId, 'errorMessage');
@@ -85,6 +86,7 @@ export const TextArea = ({
   );
 
   const showRequiredStyling = required || !!ariaRequired;
+  const inputWidth = getInputWidth(width);
 
   return (
     <div className={cn(className, inputStyles.container)} style={{ ...style }}>
@@ -100,7 +102,7 @@ export const TextArea = ({
       )}
       <Box
         as="textarea"
-        width={getInputWidth(width)}
+        width={inputWidth}
         ref={multiRef}
         id={uniqueId}
         onChange={onChangeHandler}
@@ -128,7 +130,17 @@ export const TextArea = ({
         )}
         {...rest}
       />
-      <Box display="flex" alignContent="space-between">
+      <Box
+        display="flex"
+        justifyContent={
+          withCharacterCounter
+            ? hasMessage
+              ? 'space-between'
+              : 'flex-end'
+            : undefined
+        }
+        width={withCharacterCounter ? inputWidth : undefined}
+      >
         {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
         {renderCharCounter(
           characterCounterId,

--- a/packages/dds-components/src/components/TextInput/TextInput.mdx
+++ b/packages/dds-components/src/components/TextInput/TextInput.mdx
@@ -36,6 +36,10 @@ Maks antall tegn i input bør ta utgangspunkt i konteksten til applikasjonen, s�
 
 Unngå å bruke `placeholder` attributtet. Hvis du bruker den istedenfor semantisk ledetekst ser brukeren ikke hva feltet ber om etter det blir fylt ut. I tillegg kan inputfeltet se ferdig fylt ut.
 
+### Tegnteller
+
+Tegnteller legger seg under inputfeltet til høyre. Hvis det blir for lite plass til feilmelding eller hjelpetekst vurder å gjøre inputfeltet bredere.
+
 ### Affiks
 
 Prefix/suffix skal ikke være en erstatter for en beskrivende label. Den leses ikke av skjermleser, så label må beskrivende nok for formålet.

--- a/packages/dds-components/src/components/TextInput/TextInput.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.tsx
@@ -78,7 +78,8 @@ export const TextInput = ({
   const hasErrorMessage = !!errorMessage;
   const hasTip = !!tip;
   const hasLabel = !!label;
-  const hasMessage = hasErrorMessage || hasTip || !!maxLength;
+  const hasMessage = hasErrorMessage || hasTip;
+  const hasBottomContainer = hasErrorMessage || hasTip || !!maxLength;
   const hasIcon = !!icon;
   const hasAffix = !!(prefix ?? suffix);
 
@@ -229,8 +230,19 @@ export const TextInput = ({
       ) : (
         <Box as={StatefulInput} width={inputWidth} {...generalInputProps} />
       )}
-      {hasMessage && (
-        <Box display="flex" justifyContent="space-between" gap="x0.5">
+      {hasBottomContainer && (
+        <Box
+          display="flex"
+          justifyContent={
+            withCharacterCounter
+              ? hasMessage
+                ? 'space-between'
+                : 'flex-end'
+              : undefined
+          }
+          gap="x0.5"
+          width={withCharacterCounter ? inputWidth : undefined}
+        >
           {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
           {renderCharCounter(
             characterCounterId,


### PR DESCRIPTION
## Beskrivelse

Tegnteller havnet før helt ytterst; den plasseres nå under inpufeltet til høyre i `<TextInput>` og `<TextArea>`.

Før:
![image](https://github.com/user-attachments/assets/111da093-364e-4516-9b5c-476e9a44300a)

Etter:
![image](https://github.com/user-attachments/assets/3f10f42e-3704-4b6b-bcf7-827029411134)


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
