### PR TITLE
ELSA1-602 Støtte for responsiv `width` prop i `<Search>`

### DIFF
--- a/.changeset/shiny-loops-hunt.md
+++ b/.changeset/shiny-loops-hunt.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for responsiv `width` prop i `<Search>`.

--- a/packages/dds-components/src/components/Search/Search.module.css
+++ b/packages/dds-components/src/components/Search/Search.module.css
@@ -12,7 +12,6 @@
 .with-button-container {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: var(--dds-spacing-x0-5);
 }
 
 .input {

--- a/packages/dds-components/src/components/Search/Search.stories.tsx
+++ b/packages/dds-components/src/components/Search/Search.stories.tsx
@@ -1,5 +1,9 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
+import {
+  responsivePropsArgTypes,
+  windowWidthDecorator,
+} from '../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 import { Search } from '.';
@@ -9,6 +13,7 @@ export default {
   component: Search,
   argTypes: {
     buttonProps: { control: false },
+    width: responsivePropsArgTypes.width,
   },
   parameters: {
     docs: {
@@ -143,4 +148,18 @@ export const WithSuggestions: Story = {
       </div>
     </>
   ),
+};
+
+export const ResponsiveWidth: Story = {
+  decorators: [Story => windowWidthDecorator(<Story />)],
+  args: {
+    label: 'Label',
+    width: {
+      xs: '100%',
+      sm: '100%',
+      md: '20%',
+      lg: 'var(--dds-input-default-width)',
+      xl: 'var(--dds-input-default-width)',
+    },
+  },
 };

--- a/packages/dds-components/src/components/Search/Search.tsx
+++ b/packages/dds-components/src/components/Search/Search.tsx
@@ -22,6 +22,7 @@ import inputStyles from '../helpers/Input/Input.module.css';
 import { Icon, type IconSize } from '../Icon';
 import { CloseSmallIcon, SearchIcon } from '../Icon/icons';
 import { renderInputMessage } from '../InputMessage';
+import { Box } from '../layout';
 import { Label, getTypographyCn } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 import { VisuallyHidden } from '../VisuallyHidden';
@@ -42,7 +43,8 @@ export type SearchProps = Pick<InputProps, 'tip' | 'label'> & {
   componentSize?: SearchSize;
   /**Props for søkeknappen. */
   buttonProps?: SearchButtonProps;
-} & ComponentPropsWithRef<'input'>;
+} & Pick<InputProps, 'width'> &
+  Omit<ComponentPropsWithRef<'input'>, 'width'>;
 
 export const Search = ({
   componentSize = 'medium',
@@ -52,6 +54,7 @@ export const Search = ({
   tip,
   id,
   value,
+  width,
   onChange,
   className,
   style,
@@ -102,11 +105,13 @@ export const Search = ({
     <div className={styles.container}>
       {hasLabel && <Label htmlFor={uniqueId}>{label}</Label>}
       <div>
-        <div
+        <Box
           className={cn(
             className,
             showSearchButton && styles['with-button-container'],
           )}
+          width={width}
+          gap="x0.5"
           style={style}
         >
           <div className={styles['input-group']}>
@@ -180,7 +185,7 @@ export const Search = ({
               {buttonLabel ?? 'Søk'}
             </Button>
           )}
-        </div>
+        </Box>
         {renderInputMessage(tip, tipId)}
       </div>
     </div>


### PR DESCRIPTION
## Beskrivelse

Støtte for responsiv `width` til å begynne med, da den støttet bare HTML `width` attributt som egentlig ikke fungerer; og responsiv støtte som i alle andre inputkomponenter.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
