### PR TITLE
ELSA1-583 Ikon i `<LocalMessage>` alignet på toppen

### DIFF
--- a/.changeset/tired-spiders-rule.md
+++ b/.changeset/tired-spiders-rule.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Endrer layout i `LocalMessage` slik at ikon legger seg på toppen ved flere linjer med tekst. Fikser andre små feil som avstander og størrelse på lukkeknapp.

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.module.css
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.module.css
@@ -68,7 +68,6 @@
 
 .container__text {
   grid-area: text;
-  padding-right: var(--dds-spacing-x0-75);
 }
 
 .container__icon {
@@ -77,5 +76,4 @@
 
 .container__button {
   grid-area: closeButton;
-  margin: calc(0px - var(--dds-spacing-x0-75)) 0;
 }

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.tsx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.tsx
@@ -92,8 +92,7 @@ export const LocalMessage = ({
       )}
       width={width}
       display="grid"
-      alignItems="center"
-      padding="x0.75"
+      padding="x0.75 x0.75 x0.75 x0.5"
       gap="x0.5"
     >
       <Icon
@@ -111,7 +110,7 @@ export const LocalMessage = ({
             setClosed(true);
             onClose && onClose();
           }}
-          size="small"
+          size="xsmall"
           aria-label="Lukk melding"
           className={styles.container__button}
         />


### PR DESCRIPTION

## Beskrivelse

Endrer layout i `LocalMessage` slik at ikon legger seg på toppen ved flere linjer med tekst. Fikser andre små feil som avstander og størrelse på lukkeknapp.

Før:
![image](https://github.com/user-attachments/assets/f46684cf-b747-41af-9f70-9b6b04e85a9a)


Etter: 
![image](https://github.com/user-attachments/assets/bec961dd-1ab2-4077-aedd-3f686a71a68b)


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
