### PR TITLE
ELSA1-600 Støtte for å skjule ikon i `<Search>`

### DIFF
--- a/.changeset/cool-owls-take.md
+++ b/.changeset/cool-owls-take.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for å skjule søkeikon i `<Search>` via `showIcon` prop.

--- a/.changeset/thirty-shoes-type.md
+++ b/.changeset/thirty-shoes-type.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Fjerner unødvendig nøstet `<div>` i`<Search>` når søkeknappen ikke er der og justerer på avstander. Kan påvirke layout.

--- a/packages/dds-components/src/components/Search/Search.module.css
+++ b/packages/dds-components/src/components/Search/Search.module.css
@@ -1,56 +1,15 @@
-.container {
-  display: flex;
-  flex-direction: column;
-  gap: var(--dds-spacing-x0-125);
-}
-
-.input-group {
-  position: relative;
-  display: flex;
-}
-
 .with-button-container {
   display: grid;
   grid-template-columns: 1fr auto;
 }
 
 .input {
-  width: 100%;
-  padding-right: calc(
-    var(--dds-spacing-x1) + var(--dds-icon-size-medium) +
-      var(--dds-spacing-x0-25)
-  );
-
   &[type='search']::-webkit-search-decoration,
   &[type='search']::-webkit-search-cancel-button,
   &[type='search']::-webkit-search-results-button,
   &[type='search']::-webkit-search-results-decoration {
     -webkit-appearance: none;
   }
-}
-
-.input--small {
-  padding-block: var(--dds-spacing-x0-5);
-  padding-left: calc(
-    var(--dds-spacing-x0-75) + var(--dds-icon-size-small) +
-      var(--dds-spacing-x0-5)
-  );
-}
-
-.input--medium {
-  padding-block: var(--dds-spacing-x0-75);
-  padding-left: calc(
-    var(--dds-spacing-x0-75) + var(--dds-icon-size-medium) +
-      var(--dds-spacing-x0-5)
-  );
-}
-
-.input--large {
-  padding-block: var(--dds-spacing-x1);
-  padding-left: calc(
-    var(--dds-spacing-x0-75) + var(--dds-icon-size-medium) +
-      var(--dds-spacing-x0-5)
-  );
 }
 
 .search-icon {
@@ -68,15 +27,5 @@
 }
 
 .suggestions {
-  position: absolute;
-  top: 100%;
-  width: 100%;
-  max-height: 300px;
   z-index: var(--dds-zindex-dropdown);
-  overflow-y: scroll;
-  margin-top: var(--dds-spacing-x0-25);
-}
-
-.suggestions__header {
-  padding-left: var(--dds-spacing-x1);
 }

--- a/packages/dds-components/src/components/Search/Search.stories.tsx
+++ b/packages/dds-components/src/components/Search/Search.stories.tsx
@@ -48,17 +48,13 @@ export const Default: Story = {};
 export const Overview: Story = {
   render: args => (
     <StoryVStack>
-      <Search {...args} componentSize="medium" />
-      <Search {...args} componentSize="medium" tip="Dette er en hjelpetekst" />
+      <Search {...args} />
+      <Search {...args} tip="Dette er en hjelpetekst" />
       <Search {...args} label={args.label ?? 'Label'} />
+      <Search {...args} showIcon={false} />
+      <Search {...args} buttonProps={{ onClick: () => null, label: 'Søk' }} />
       <Search
         {...args}
-        componentSize="medium"
-        buttonProps={{ onClick: () => null, label: 'Søk' }}
-      />
-      <Search
-        {...args}
-        componentSize="medium"
         buttonProps={{
           onClick: () => null,
           purpose: 'secondary',
@@ -66,14 +62,9 @@ export const Overview: Story = {
       />
       <Search
         {...args}
-        componentSize="medium"
         buttonProps={{ onClick: () => null, label: 'Custom label' }}
       />
-      <Search
-        {...args}
-        componentSize="medium"
-        buttonProps={{ onClick: () => null, loading: true }}
-      />
+      <Search {...args} buttonProps={{ onClick: () => null, loading: true }} />
     </StoryVStack>
   ),
 };

--- a/packages/dds-components/src/components/Search/SearchSuggestions.tsx
+++ b/packages/dds-components/src/components/Search/SearchSuggestions.tsx
@@ -9,7 +9,7 @@ import { type BaseComponentProps, getBaseHTMLProps } from '../../types';
 import { cn, derivativeIdGenerator } from '../../utils';
 import { StylelessList } from '../helpers';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
-import { Paper } from '../layout';
+import { Box, Paper } from '../layout';
 import { getTypographyCn } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
@@ -70,16 +70,21 @@ export const SearchSuggestions = ({
       )}
       aria-hidden={!showSuggestions}
       border="border-default"
+      position="absolute"
+      top="100%"
+      width="100%"
+      maxHeight="300px"
+      overflowY="scroll"
+      marginBlock="x0.25 0"
     >
-      <span
+      <Box
+        as="h2"
+        paddingInline="0 x1"
         id={suggestionsHeaderId}
-        className={cn(
-          styles.suggestions__header,
-          typographyStyles['body-xsmall'],
-        )}
+        className={typographyStyles['body-xsmall']}
       >
         Søkeforslag
-      </span>
+      </Box>
       <StylelessList role="listbox" aria-labelledby={suggestionsHeaderId}>
         {suggestionsToRender.map((suggestion, index) => {
           return (


### PR DESCRIPTION

## Beskrivelse

Støtter prop `showIcon`. Fjerner i samme slengen unødvendig nøstet div når søkeknappen ikke er der, og migrerer relevante delkomponenter til layout primitives.

Justerer på avstander da de var feil.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
