### PR TITLE
ELSA1-593 Støtte for horisontal `<ProgressTracker>`

### DIFF
--- a/.changeset/clear-pants-stick.md
+++ b/.changeset/clear-pants-stick.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for horisontal `<ProgressTracker>` via ny prop: `direction`. Komponenten er fortsatt vertikal som default.

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.module.css
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.module.css
@@ -1,28 +1,33 @@
 .list {
   --dds-progress-tracker-connector-width: 1px;
   --dds-progress-tracker-item-number-size: 1.75rem;
-
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--dds-spacing-x0-125);
-  margin: 0;
-  padding: 0;
 }
 
-.connector {
+.connector--column {
   border-right: var(--dds-progress-tracker-connector-width) solid
     var(--dds-color-border-default);
   width: 1px;
-  height: 18px;
+  height: 1.125rem;
   margin-left: calc(
     (var(--dds-progress-tracker-item-number-size) / 2) -
       (var(--dds-progress-tracker-connector-width) / 2)
   );
 }
 
+.connector--row {
+  flex: 0 0 auto;
+  border-top: var(--dds-progress-tracker-connector-width) solid
+    var(--dds-color-border-default);
+  height: 1px;
+  width: 1.875rem;
+  margin-top: calc(
+    (var(--dds-progress-tracker-item-number-size) / 2) -
+      (var(--dds-progress-tracker-connector-width) / 2)
+  );
+}
+
 .item {
-  flex: 1;
+  flex: 0 0 auto;
   position: relative;
   display: flex;
   justify-content: center;

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
@@ -149,6 +149,57 @@ export const WithIcons: Story = {
   },
 };
 
+export const Horisontal: Story = {
+  render: args => {
+    const numSteps = 3;
+
+    const [activeStep, setActiveStep] = useState(0);
+    const [completedSteps, setCompletedSteps] = useState(new Set());
+
+    return (
+      <VStack gap="x1.5">
+        <ProgressTracker
+          {...args}
+          direction="row"
+          activeStep={activeStep}
+          onStepChange={step => setActiveStep(step)}
+        >
+          <ProgressTracker.Item completed={completedSteps.has(0)}>
+            Parter
+          </ProgressTracker.Item>
+          <ProgressTracker.Item completed={completedSteps.has(1)}>
+            Slutning
+          </ProgressTracker.Item>
+          <ProgressTracker.Item completed={completedSteps.has(2)}>
+            Vedlegg
+          </ProgressTracker.Item>
+          <ProgressTracker.Item completed={completedSteps.has(3)} disabled>
+            Sammendrag
+          </ProgressTracker.Item>
+        </ProgressTracker>
+
+        <div>
+          {activeStep === 0 && <div>Steg 1</div>}
+          {activeStep === 1 && <div>Steg 2</div>}
+          {activeStep === 2 && <div>Steg 3</div>}
+          {activeStep === 3 && <div>Steg 4</div>}
+        </div>
+
+        <Button
+          onClick={() => {
+            setCompletedSteps(s => new Set([...s, activeStep]));
+            if (activeStep < numSteps - 1) {
+              setActiveStep(s => s + 1);
+            }
+          }}
+        >
+          Sett som ferdig
+        </Button>
+      </VStack>
+    );
+  },
+};
+
 export const FutureStepsDisabled: Story = {
   render: args => {
     const numSteps = 3;

--- a/packages/dds-components/src/components/helpers/StylelessList/StylelessList.tsx
+++ b/packages/dds-components/src/components/helpers/StylelessList/StylelessList.tsx
@@ -9,3 +9,10 @@ export type StylelessListProps<TProps extends object = object> = TProps &
 export const StylelessList = ({ className, ...rest }: StylelessListProps) => (
   <ul {...rest} className={cn(className, utilStyles['remove-list-styling'])} />
 );
+
+export type StylelessOListProps<TProps extends object = object> = TProps &
+  ComponentPropsWithRef<'ul'>;
+
+export const StylelessOList = ({ className, ...rest }: StylelessOListProps) => (
+  <ul {...rest} className={cn(className, utilStyles['remove-list-styling'])} />
+);


### PR DESCRIPTION
## Beskrivelse

Via ny prop: `direction`. Komponenten er fortsatt vertikal som default.

![image](https://github.com/user-attachments/assets/170e971d-8bec-41ec-a1f9-af647c9faac0)


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
