### PR TITLE
ELSA1-603 Fikser uforutsigbar test i `<FileUploader>`

### DIFF
--- a/packages/dds-components/src/components/FileUploader/FileUploader.spec.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { type ComponentProps, useState } from 'react';
 import { describe, expect, it } from 'vitest';
@@ -20,14 +20,18 @@ describe('<FileUploader>', () => {
     render(<FileUploaderTest />);
     const fileInput = screen.getByTestId('file-uploader-input');
     await userEvent.upload(fileInput, file);
-    expect(screen.getByText('hello.png', {})).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('hello.png', {})).toBeInTheDocument();
+    });
   });
 
   it('accepts uploading files with accept prop', async () => {
     render(<FileUploaderTest accept={['image/png']} />);
     const fileInput = screen.getByTestId('file-uploader-input');
     await userEvent.upload(fileInput, file);
-    expect(screen.getByText('hello.png', {})).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('hello.png', {})).toBeInTheDocument();
+    });
   });
 
   it('should render label', () => {


### PR DESCRIPTION
## Beskrivelse
Noen tester failet i PRer som ikke rørte testkoden. Fikser slik at det blir konsekvent oppførsel.


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [ ] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
