### PR TITLE
ELSA1-611 Manglende layout styling i `<RadioButton>`

### DIFF
--- a/.changeset/tangy-points-beg.md
+++ b/.changeset/tangy-points-beg.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<RadioButton>` ikke fikk layout styling.

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../../utils';
 import focusStyles from '../../helpers/styling/focus.module.css';
 import utilStyles from '../../helpers/styling/utilStyles.module.css';
-import { Box } from '../../layout';
 import { Typography } from '../../Typography';
 import { Label, SelectionControl } from '../SelectionControl.styles';
 import { selectionControlTypographyProps } from '../SelectionControl.utils';
@@ -44,13 +43,7 @@ export const Checkbox = ({
   const isDisabled = disabled || checkboxGroup?.disabled;
 
   return (
-    <Box
-      position="relative"
-      display="flex"
-      alignItems="center"
-      width="fit-content"
-      paddingInline="calc(18px + var(--dds-spacing-x0-5)) 0"
-      as={Label}
+    <Label
       hasError={hasError}
       disabled={isDisabled}
       readOnly={isReadOnly}
@@ -95,7 +88,7 @@ export const Checkbox = ({
       ) : hasLabel ? (
         <Typography {...selectionControlTypographyProps}>{label}</Typography>
       ) : null}
-    </Box>
+    </Label>
   );
 };
 

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.tsx
@@ -8,14 +8,12 @@ import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../../types';
-import { RequiredMarker, cn, derivativeIdGenerator } from '../../../utils';
-import { Icon } from '../../Icon';
-import { LockIcon } from '../../Icon/icons';
+import { cn, derivativeIdGenerator } from '../../../utils';
 import { renderInputMessage } from '../../InputMessage';
-import { Typography } from '../../Typography';
-import labelStyles from '../../Typography/Label/Label.module.css';
 import { type SelectionControlGroupCommonProps } from '../common/SelectionControl.types';
 import styles from '../SelectionControl.module.css';
+import { GroupLabel } from '../SelectionControl.styles';
+import { convertBooleanishToBoolean } from '../../../types/Booleanish';
 
 export type CheckboxGroupProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
@@ -47,7 +45,8 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
   const generatedId = useId();
   const uniqueGroupId = groupId ?? `${generatedId}-checkboxGroup`;
   const hasErrorMessage = !!errorMessage;
-  const showRequiredMarker = required || ariaRequired;
+  const showRequiredMarker =
+    required || convertBooleanishToBoolean(ariaRequired);
 
   const errorMessageId = derivativeIdGenerator(uniqueGroupId, 'errorMessage');
   const tipId = derivativeIdGenerator(uniqueGroupId, 'tip');
@@ -71,17 +70,13 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
       )}
     >
       {label !== undefined ? (
-        <Typography
-          as="span"
-          typographyType="labelMedium"
+        <GroupLabel
           id={uniqueGroupId}
-          className={readOnly ? labelStyles['read-only'] : undefined}
+          readOnly={readOnly}
+          showRequiredMarker={showRequiredMarker}
         >
-          {readOnly && (
-            <Icon icon={LockIcon} className={labelStyles['read-only__icon']} />
-          )}
-          {label} {showRequiredMarker && <RequiredMarker />}
-        </Typography>
+          {label}
+        </GroupLabel>
       ) : null}
       {renderInputMessage(tip, tipId)}
       <CheckboxGroupContext value={{ ...contextProps }}>

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.tsx
@@ -8,12 +8,12 @@ import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../../types';
+import { convertBooleanishToBoolean } from '../../../types/Booleanish';
 import { cn, derivativeIdGenerator } from '../../../utils';
 import { renderInputMessage } from '../../InputMessage';
 import { type SelectionControlGroupCommonProps } from '../common/SelectionControl.types';
 import styles from '../SelectionControl.module.css';
 import { GroupLabel } from '../SelectionControl.styles';
-import { convertBooleanishToBoolean } from '../../../types/Booleanish';
 
 export type CheckboxGroupProps = BaseComponentPropsWithChildren<
   HTMLDivElement,

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.tsx
@@ -8,12 +8,12 @@ import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../../types';
+import { convertBooleanishToBoolean } from '../../../types/Booleanish';
 import { cn } from '../../../utils';
 import { renderInputMessage } from '../../InputMessage';
 import { type SelectionControlGroupCommonProps } from '../common/SelectionControl.types';
 import styles from '../SelectionControl.module.css';
 import { GroupLabel } from '../SelectionControl.styles';
-import { convertBooleanishToBoolean } from '../../../types/Booleanish';
 
 export type RadioButtonGroupProps<T extends string | number> =
   BaseComponentPropsWithChildren<

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.tsx
@@ -8,14 +8,12 @@ import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../../types';
-import { RequiredMarker, cn } from '../../../utils';
-import { Icon } from '../../Icon';
-import { LockIcon } from '../../Icon/icons';
+import { cn } from '../../../utils';
 import { renderInputMessage } from '../../InputMessage';
-import { Typography } from '../../Typography';
-import labelStyles from '../../Typography/Label/Label.module.css';
 import { type SelectionControlGroupCommonProps } from '../common/SelectionControl.types';
 import styles from '../SelectionControl.module.css';
+import { GroupLabel } from '../SelectionControl.styles';
+import { convertBooleanishToBoolean } from '../../../types/Booleanish';
 
 export type RadioButtonGroupProps<T extends string | number> =
   BaseComponentPropsWithChildren<
@@ -80,7 +78,8 @@ export const RadioButtonGroup = <T extends string | number = string>({
   };
 
   const hasErrorMessage = !!errorMessage;
-  const showRequiredMarker = required || ariaRequired;
+  const showRequiredMarker =
+    required || convertBooleanishToBoolean(ariaRequired);
 
   const tipId = tip && `${uniqueGroupId}-tip`;
   const errorMessageId = errorMessage && `${uniqueGroupId}-errorMessage`;
@@ -106,17 +105,15 @@ export const RadioButtonGroup = <T extends string | number = string>({
         rest,
       )}
     >
-      <Typography
-        as="span"
-        typographyType="labelMedium"
-        id={uniqueGroupId}
-        className={readOnly ? labelStyles['read-only'] : undefined}
-      >
-        {readOnly && (
-          <Icon icon={LockIcon} className={labelStyles['read-only__icon']} />
-        )}
-        {label} {showRequiredMarker && <RequiredMarker />}
-      </Typography>
+      {label !== undefined ? (
+        <GroupLabel
+          id={uniqueGroupId}
+          readOnly={readOnly}
+          showRequiredMarker={showRequiredMarker}
+        >
+          {label}
+        </GroupLabel>
+      ) : null}
       {renderInputMessage(tip, tipId)}
       <RadioButtonGroupContext value={{ ...contextProps }}>
         <div

--- a/packages/dds-components/src/components/SelectionControl/SelectionControl.styles.tsx
+++ b/packages/dds-components/src/components/SelectionControl/SelectionControl.styles.tsx
@@ -1,14 +1,13 @@
 import { type HTMLAttributes, type LabelHTMLAttributes } from 'react';
 
 import styles from './SelectionControl.module.css';
-import { cn, RequiredMarker } from '../../utils';
-import typographyStyles from '../Typography/typographyStyles.module.css';
-import { Box } from '../layout';
-import { Typography } from '../Typography';
+import { RequiredMarker, cn } from '../../utils';
 import { Icon } from '../Icon';
 import { LockIcon } from '../Icon/icons';
-
+import { Box } from '../layout';
+import { Typography } from '../Typography';
 import labelStyles from '../Typography/Label/Label.module.css';
+import typographyStyles from '../Typography/typographyStyles.module.css';
 type SelectionControlType = 'radio' | 'checkbox';
 
 type SelectionControlProps = {
@@ -71,12 +70,12 @@ export const Label = ({
   );
 };
 
-type SelectionControlGroupLabelProps = {
+interface SelectionControlGroupLabelProps {
   id?: string;
   showRequiredMarker?: boolean;
   readOnly?: boolean;
   children?: string;
-};
+}
 
 export const GroupLabel = ({
   id,

--- a/packages/dds-components/src/components/SelectionControl/SelectionControl.styles.tsx
+++ b/packages/dds-components/src/components/SelectionControl/SelectionControl.styles.tsx
@@ -1,9 +1,14 @@
 import { type HTMLAttributes, type LabelHTMLAttributes } from 'react';
 
 import styles from './SelectionControl.module.css';
-import { cn } from '../../utils';
+import { cn, RequiredMarker } from '../../utils';
 import typographyStyles from '../Typography/typographyStyles.module.css';
+import { Box } from '../layout';
+import { Typography } from '../Typography';
+import { Icon } from '../Icon';
+import { LockIcon } from '../Icon/icons';
 
+import labelStyles from '../Typography/Label/Label.module.css';
 type SelectionControlType = 'radio' | 'checkbox';
 
 type SelectionControlProps = {
@@ -43,7 +48,13 @@ export const Label = ({
   ...rest
 }: SelectionControlLabelProps) => {
   return (
-    <label
+    <Box
+      as="label"
+      position="relative"
+      display="flex"
+      alignItems="center"
+      width="fit-content"
+      paddingInline="calc(18px + var(--dds-spacing-x0-5)) 0"
       className={cn(
         className,
         styles.label,
@@ -57,5 +68,37 @@ export const Label = ({
       )}
       {...rest}
     />
+  );
+};
+
+type SelectionControlGroupLabelProps = {
+  id?: string;
+  showRequiredMarker?: boolean;
+  readOnly?: boolean;
+  children?: string;
+};
+
+export const GroupLabel = ({
+  id,
+  showRequiredMarker,
+  readOnly,
+  children,
+}: SelectionControlGroupLabelProps) => {
+  return (
+    <Typography
+      as="span"
+      typographyType="labelMedium"
+      id={id}
+      className={readOnly ? labelStyles['read-only'] : undefined}
+    >
+      {readOnly && (
+        <Icon
+          icon={LockIcon}
+          className={labelStyles['read-only__icon']}
+          iconSize="small"
+        />
+      )}
+      {children} {showRequiredMarker && <RequiredMarker />}
+    </Typography>
   );
 };

--- a/packages/dds-components/src/types/Booleanish.ts
+++ b/packages/dds-components/src/types/Booleanish.ts
@@ -1,0 +1,13 @@
+export type Booleanish = boolean | 'true' | 'false';
+
+export function convertBooleanishToBoolean(
+  value?: Booleanish,
+): boolean | undefined {
+  if (value === 'true') {
+    return true;
+  } else if (value === 'false') {
+    return false;
+  } else {
+    return value;
+  }
+}


### PR DESCRIPTION
## Beskrivelse


Fikser bug der styling ikke ble satt.

Fikser også feil størrelse på readonly-ikon i gruppeledetekst, og standardiserer den via `<GroupLabel>` JSX element.




## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
