### PR TITLE
ELSA1-574 Bedre UU i `<ProgressTracker>`

### DIFF
--- a/.changeset/bright-snakes-tickle.md
+++ b/.changeset/bright-snakes-tickle.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Bedre UU i `<ProgressTracker>`: `<nav>` wrapper for navigasjon, fikser bug der egen `aria-label` ikke var støttet, bedre default `aria-label`, bedre usynlig knappetekst for skjermleser, fikser ugyldig HTML.

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.context.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.context.tsx
@@ -1,13 +1,17 @@
 import { createContext, useContext } from 'react';
 
+import { type Direction } from '../../types';
+
 interface ProgressTrackerContextType {
   activeStep: number;
   handleStepChange?: (index: number) => void;
+  direction: Direction;
 }
 
 export const ProgressTrackerContext = createContext<ProgressTrackerContextType>(
   {
     activeStep: 0,
+    direction: 'column',
   },
 );
 

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.module.css
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.module.css
@@ -3,34 +3,33 @@
   --dds-progress-tracker-item-number-size: 1.75rem;
 }
 
-.connector--column {
+.list-item:not(:first-child)::before {
+  content: '';
+  display: block;
+}
+
+.list-item--column:not(:first-child)::before {
   border-right: var(--dds-progress-tracker-connector-width) solid
     var(--dds-color-border-default);
-  width: 1px;
+  width: var(--dds-progress-tracker-connector-width);
   height: 1.125rem;
   margin-left: calc(
     (var(--dds-progress-tracker-item-number-size) / 2) -
       (var(--dds-progress-tracker-connector-width) / 2)
   );
+  margin-bottom: var(--dds-spacing-x0-125);
 }
 
-.connector--row {
-  flex: 0 0 auto;
+.list-item--row:not(:first-child)::before {
   border-top: var(--dds-progress-tracker-connector-width) solid
     var(--dds-color-border-default);
-  height: 1px;
+  height: var(--dds-progress-tracker-connector-width);
   width: 1.875rem;
   margin-top: calc(
     (var(--dds-progress-tracker-item-number-size) / 2) -
       (var(--dds-progress-tracker-connector-width) / 2)
   );
-}
-
-.item {
-  flex: 0 0 auto;
-  position: relative;
-  display: flex;
-  justify-content: center;
+  margin-right: var(--dds-spacing-x0-5);
 }
 
 .item-button {
@@ -92,11 +91,8 @@
 
 .item-number {
   border-radius: var(--dds-border-radius-rounded);
-  display: flex;
-  align-items: center;
-  justify-content: center;
   z-index: var(--dds-zindex-absolute-element);
-  font-weight: 600;
+  font-weight: var(--dds-font-weight-bold);
   border: 2px solid;
   height: var(--dds-progress-tracker-item-number-size);
   width: var(--dds-progress-tracker-item-number-size);

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.spec.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.spec.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ProgressTracker } from './ProgressTracker';
+
+describe('<ProgressTracker>', () => {
+  it('should render navigation', () => {
+    render(<ProgressTracker />);
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+  });
+  it('should have accesible name', () => {
+    render(<ProgressTracker />);
+    expect(screen.getByRole('navigation')).toHaveAccessibleName(
+      'stegprogresjon',
+    );
+  });
+  describe('steps', () => {
+    it('should render step buttons', () => {
+      render(
+        <ProgressTracker>
+          <ProgressTracker.Item>Parter</ProgressTracker.Item>
+          <ProgressTracker.Item>Slutning</ProgressTracker.Item>
+        </ProgressTracker>,
+      );
+      const buttons = screen.getAllByRole('button');
+      expect(buttons).toHaveLength(2);
+    });
+    it('should render button labels', () => {
+      const text1 = 'a';
+      const text2 = 'b';
+      render(
+        <ProgressTracker>
+          <ProgressTracker.Item>{text1}</ProgressTracker.Item>
+          <ProgressTracker.Item>{text2}</ProgressTracker.Item>
+        </ProgressTracker>,
+      );
+
+      expect(screen.getByText(text1)).toBeInTheDocument();
+      expect(screen.getByText(text2)).toBeInTheDocument();
+    });
+    it('should render disabled button', () => {
+      const text1 = 'a';
+
+      render(
+        <ProgressTracker>
+          <ProgressTracker.Item disabled>{text1}</ProgressTracker.Item>
+        </ProgressTracker>,
+      );
+
+      const button = screen.getByRole('button');
+      expect(button).toBeDisabled();
+    });
+    it('should have accessible names', () => {
+      const text1 = 'a';
+      const text2 = 'b';
+      render(
+        <ProgressTracker>
+          <ProgressTracker.Item>{text1}</ProgressTracker.Item>
+          <ProgressTracker.Item>{text2}</ProgressTracker.Item>
+        </ProgressTracker>,
+      );
+      const buttons = screen.getAllByRole('button');
+      expect(buttons[0]).toHaveAccessibleName(
+        `1. trinn, ${text1} , ikke ferdig`,
+      );
+      expect(buttons[1]).toHaveAccessibleName(
+        `2. trinn, ${text2} , ikke ferdig`,
+      );
+    });
+    it('should have accessible completed name', () => {
+      const text1 = 'a';
+      const text2 = 'b';
+      render(
+        <ProgressTracker>
+          <ProgressTracker.Item>{text1}</ProgressTracker.Item>
+          <ProgressTracker.Item completed>{text2}</ProgressTracker.Item>
+        </ProgressTracker>,
+      );
+      const buttons = screen.getAllByRole('button');
+      expect(buttons[1]).toHaveAccessibleName(`2. trinn, ${text2} , ferdig`);
+    });
+  });
+});

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.tsx
@@ -1,7 +1,6 @@
 import {
   Children,
   type ForwardRefExoticComponent,
-  Fragment,
   type ReactElement,
   type ReactNode,
   cloneElement,
@@ -13,10 +12,7 @@ import {
 
 import { ProgressTrackerContext } from './ProgressTracker.context';
 import styles from './ProgressTracker.module.css';
-import {
-  ProgressTrackerItem,
-  type ProgressTrackerItemProps,
-} from './ProgressTrackerItem';
+import { ProgressTrackerItem } from './ProgressTrackerItem';
 import {
   type BaseComponentPropsWithChildren,
   type Direction,
@@ -54,7 +50,7 @@ export const ProgressTracker: ProgressTrackerComponent = (() => {
     direction = 'column',
     children,
     className,
-    htmlProps,
+    htmlProps = {},
     ...rest
   }: ProgressTrackerProps) => {
     const [thisActiveStep, setActiveStep] = useState(activeStep);
@@ -73,25 +69,23 @@ export const ProgressTracker: ProgressTrackerComponent = (() => {
     const steps = useMemo(() => {
       const validChildren = removeInvalidChildren(children);
       const itemsWithIndex = passIndexPropToProgressTrackerItem(validChildren);
-      const itemsWithConnectorsBetween = intersperseItemsWithConnector(
-        itemsWithIndex,
-        direction,
-      );
-      return itemsWithConnectorsBetween;
+      return itemsWithIndex;
     }, [children]);
 
     const isRow = direction === 'row';
+
+    const { 'aria-label': ariaLabel } = htmlProps;
 
     return (
       <ProgressTrackerContext
         value={{
           activeStep: thisActiveStep,
           handleStepChange: handleChange,
+          direction,
         }}
       >
-        <div
-          role="group"
-          aria-label="progress"
+        <nav
+          aria-label={ariaLabel ?? 'stegprogresjon'}
           {...getBaseHTMLProps(id, className, htmlProps, rest)}
         >
           <Box
@@ -107,7 +101,7 @@ export const ProgressTracker: ProgressTrackerComponent = (() => {
           >
             {steps}
           </Box>
-        </div>
+        </nav>
       </ProgressTrackerContext>
     );
   };
@@ -131,19 +125,3 @@ function passIndexPropToProgressTrackerItem<TProps extends object>(
     }),
   );
 }
-
-const intersperseItemsWithConnector = (
-  children: Array<ReactElement<ProgressTrackerItemProps>>,
-  direction: Direction,
-) =>
-  Children.map(children, (child, index) => {
-    if (index === 0) {
-      return child;
-    }
-    return (
-      <Fragment key={index}>
-        <div aria-hidden className={styles[`connector--${direction}`]} />
-        {child}
-      </Fragment>
-    );
-  });

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTrackerItem.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTrackerItem.tsx
@@ -11,6 +11,7 @@ import { focusable } from '../helpers/styling/focus.module.css';
 import { Icon } from '../Icon';
 import { CheckIcon } from '../Icon/icons';
 import { type SvgIcon } from '../Icon/utils';
+import { Box } from '../layout';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 import { VisuallyHidden } from '../VisuallyHidden';
 
@@ -84,14 +85,10 @@ export type ProgressTrackerItemProps =
       }
     >;
 
-const getVisuallyHiddenText = (
-  active: boolean,
-  completed: boolean,
-  index: number,
-) =>
-  `${index + 1}, ${active ? '' : 'Trinn, '}${
-    completed ? 'Ferdig, ' : 'Ikke ferdig, '
-  }`;
+const getVisuallyHiddenTextBefore = (index: number) => `${index + 1}. trinn, `;
+
+const getVisuallyHiddenTextAfter = (completed: boolean) =>
+  `, ${completed ? 'ferdig' : 'ikke ferdig'}`;
 
 export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
   const {
@@ -107,7 +104,8 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
     ...rest
   } = props;
 
-  const { activeStep, handleStepChange } = useProgressTrackerContext();
+  const { activeStep, handleStepChange, direction } =
+    useProgressTrackerContext();
   const active = activeStep === index;
   const itemState = toItemState(active, completed, disabled);
 
@@ -132,7 +130,10 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
 
   const stepContent = (
     <>
-      <div
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
         aria-hidden
         className={cn(
           styles['item-number'],
@@ -141,7 +142,7 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
         )}
       >
         {stepNumberContent}
-      </div>
+      </Box>
       <div
         className={cn(
           styles['item-text'],
@@ -150,15 +151,23 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
         )}
       >
         <VisuallyHidden as="span">
-          {getVisuallyHiddenText(active, completed, index)}
+          {getVisuallyHiddenTextBefore(index)}
         </VisuallyHidden>
         {children}
+        <VisuallyHidden as="span">
+          {getVisuallyHiddenTextAfter(completed)}
+        </VisuallyHidden>
       </div>
     </>
   );
 
   return (
-    <li aria-current={active ? 'step' : undefined} className={styles.item}>
+    <Box
+      as="li"
+      display={direction === 'row' ? 'flex' : undefined}
+      aria-current={active ? 'step' : undefined}
+      className={cn(styles['list-item'], styles[`list-item--${direction}`])}
+    >
       {handleStepChange ? (
         <button
           {...getBaseHTMLProps(
@@ -184,7 +193,7 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
           {stepContent}
         </div>
       )}
-    </li>
+    </Box>
   );
 };
 

--- a/packages/dds-components/src/components/helpers/StylelessList/StylelessList.tsx
+++ b/packages/dds-components/src/components/helpers/StylelessList/StylelessList.tsx
@@ -11,8 +11,8 @@ export const StylelessList = ({ className, ...rest }: StylelessListProps) => (
 );
 
 export type StylelessOListProps<TProps extends object = object> = TProps &
-  ComponentPropsWithRef<'ul'>;
+  ComponentPropsWithRef<'ol'>;
 
 export const StylelessOList = ({ className, ...rest }: StylelessOListProps) => (
-  <ul {...rest} className={cn(className, utilStyles['remove-list-styling'])} />
+  <ol {...rest} className={cn(className, utilStyles['remove-list-styling'])} />
 );


### PR DESCRIPTION
## Beskrivelse


- `<nav>` wrapper for navigasjon
- fikser bug der egen `aria-label` ikke var støttet
- bedre default `aria-label`
- bedre usynlig knappetekst for skjermleser
- fikser ugyldig HTML; tar i bruk `::after` for enkel connector istedenfor `<div>`




## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
