### PR TITLE
ELSA1-614 Buggy spacing i `<DatePicker>`

### DIFF
--- a/.changeset/eleven-planets-work.md
+++ b/.changeset/eleven-planets-work.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<DatePicker>` kalender manglet spacing og dager kunne bleede utover boksen. Justerer også på spacing over og under ukedager.

--- a/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/Calendar.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/Calendar.tsx
@@ -15,6 +15,7 @@ import {
 import { CalendarGrid } from './CalendarGrid';
 import { Button } from '../../../Button';
 import { ArrowLeftIcon, ArrowRightIcon } from '../../../Icon/icons';
+import { HStack } from '../../../layout';
 import { Heading } from '../../../Typography';
 import styles from '../../common/DateInput.module.css';
 import { CalendarPopoverContext } from '../CalendarPopover';
@@ -58,7 +59,7 @@ export function Calendar<T extends DateValue>(props: CalendarProps<T>) {
 
   return (
     <div {...calendarProps} className={styles.calendar}>
-      <div className={styles.calendar__header}>
+      <HStack justifyContent="space-between" alignItems="center">
         <Button
           type="button"
           aria-label={prevAriaLabel}
@@ -85,7 +86,7 @@ export function Calendar<T extends DateValue>(props: CalendarProps<T>) {
           icon={ArrowRightIcon}
           className={styles['calendar__month-button']}
         />
-      </div>
+      </HStack>
       <CalendarGrid state={state} />
     </div>
   );

--- a/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/CalendarCell.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/CalendarCell.tsx
@@ -58,6 +58,7 @@ export function CalendarCell({ date, state, onClose }: CalendarCellProps) {
         hidden={isOutsideVisibleRange}
         onKeyDown={closeOnKeyboardBlurForward}
         className={cn(
+          styles['calendar__grid-element'],
           styles['calendar__cell-button'],
           isToday(date, timezone) && styles['calendar__cell-button--today'],
           styles[`calendar__cell-button--${variant}`],

--- a/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/CalendarGrid.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/CalendarGrid.tsx
@@ -57,7 +57,9 @@ export function CalendarGrid({ state, ...props }: CalendarGridProps) {
       <thead {...headerProps}>
         <tr>
           {showWeekNumbers && (
-            <th className={cn(...typographyCn)}>
+            <th
+              className={cn(styles['calendar__grid-element'], ...typographyCn)}
+            >
               # <VisuallyHidden as="span">Ukenummer</VisuallyHidden>
             </th>
           )}
@@ -80,6 +82,7 @@ export function CalendarGrid({ state, ...props }: CalendarGridProps) {
               {showWeekNumbers && (
                 <td
                   className={cn(
+                    styles['calendar__grid-element'],
                     styles['calendar__week-number'],
                     ...typographyCn,
                   )}

--- a/packages/dds-components/src/components/date-inputs/DatePicker/CalendarPopover.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/CalendarPopover.tsx
@@ -29,7 +29,7 @@ import { CloseIcon } from '../../Icon/icons';
 import { ThemeContext } from '../../ThemeProvider';
 import styles from '../common/DateInput.module.css';
 import { type DateField } from './DateField/DateField';
-import { type Breakpoint, ShowHide } from '../../layout';
+import { type Breakpoint, type PaperProps, ShowHide } from '../../layout';
 import { Paper } from '../../layout';
 
 /**------------------------------------------------------------------------
@@ -157,6 +157,12 @@ export const CalendarPopoverContent = ({
 
   if (!isOpen) return null;
 
+  const paperStyleProps: PaperProps = {
+    elevation: 2,
+    border: 'border-default',
+    padding: 'x0.75',
+  };
+
   return (
     <>
       {portalTarget &&
@@ -167,9 +173,7 @@ export const CalendarPopoverContent = ({
               <Paper
                 ref={modalRef}
                 className={cn(styles.popover, className)}
-                elevation={2}
-                border="border-default"
-                padding="x0.5"
+                {...paperStyleProps}
               >
                 <div className={styles['modal-close-button-wrapper']}>
                   <Button
@@ -193,8 +197,7 @@ export const CalendarPopoverContent = ({
         hideBelow={hasBreakpoint ? smallScreenBreakpoint : undefined}
         className={cn(styles.popover, className)}
         style={floatingStyles.floating}
-        elevation={2}
-        border="border-default"
+        {...paperStyleProps}
       >
         {children}
       </Paper>

--- a/packages/dds-components/src/components/date-inputs/common/DateInput.module.css
+++ b/packages/dds-components/src/components/date-inputs/common/DateInput.module.css
@@ -95,7 +95,6 @@
   transition: 0.2s;
   background: transparent;
   border-radius: var(--dds-border-radius-button);
-  color: var(--dds-color-icon-default);
 
   &:not(:disabled):not(.disabled):hover,
   &:not(:disabled):not(.disabled):active {
@@ -127,14 +126,8 @@
 .calendar {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  height: 327px;
-}
-
-.calendar__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+  gap: var(--dds-spacing-x0-25);
+  height: 337px;
 }
 
 .calendar__header__month {
@@ -145,17 +138,18 @@
   user-select: none;
 }
 
-.calendar__week-number {
+.calendar__grid-element {
   width: 40px;
   height: 40px;
+}
+
+.calendar__week-number {
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .calendar__cell-button {
-  width: 40px;
-  height: 40px;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
## Beskrivelse

Fikser bug der `<DatePicker>` kalender manglet spacing og dager kunne bleede utover boksen, spesielt i Public tema.

 Justerer også på spacing over og under ukedager + litt refaktorering.

Før:
![image](https://github.com/user-attachments/assets/36d7545a-77cc-4b3c-bfdf-9dc8ea234995)


Etter:
![image](https://github.com/user-attachments/assets/c099441e-7884-4a9b-9122-8120071e4f11)


## Sjekkliste

### Generelt

- [ ] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [ ] I commits
  - [ ] I PR-tittelen
- [ ] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
