### PR TITLE
ELSA1-607 Støtte for async funksjon i `<OverflowMenuButton>`

### DIFF
--- a/.changeset/ready-pandas-shine.md
+++ b/.changeset/ready-pandas-shine.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for async funksjonkall med `onClickAsync` prop i `<OverflowMenuButton>`, slik at menyen er fortsatt åpen under loading.

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -210,6 +210,33 @@ export const WithButtons: Story = {
   },
 };
 
+export const WithAsyncClick: Story = {
+  render: args => {
+    const [text, setText] = useState('Klikk på "Handling" i menyen');
+    const click = async () => {
+      setText('Jobber...');
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      setText('Ferdig!');
+    };
+    return (
+      <VStack>
+        <span>{text}</span>
+        <OverflowMenuGroup>
+          <Button icon={MenuIcon} aria-label="Åpne meny" />
+          <OverflowMenu {...args}>
+            <OverflowMenuList>
+              <OverflowMenuButton onClickAsync={click}>
+                Handling
+              </OverflowMenuButton>
+            </OverflowMenuList>
+            <OverflowMenuDivider />
+          </OverflowMenu>
+        </OverflowMenuGroup>
+      </VStack>
+    );
+  },
+};
+
 export const WithNavigation: Story = {
   parameters: { docs: { story: { height: '250px' } } },
   render: args => {

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.types.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.types.tsx
@@ -1,4 +1,4 @@
-import { type ComponentPropsWithRef } from 'react';
+import { type ComponentPropsWithRef, type MouseEventHandler } from 'react';
 
 import { type Placement } from '../../hooks';
 import { type BaseComponentPropsWithChildren } from '../../types';
@@ -15,7 +15,10 @@ export type OverflowMenuListItemBaseProps<T extends 'span' | 'button' | 'a'> = {
 } & ComponentPropsWithRef<T>;
 
 export type OverflowMenuButtonProps = OverflowMenuListItemBaseProps<'button'> &
-  Pick<ButtonProps, 'loading' | 'loadingTooltip'>;
+  Pick<ButtonProps, 'loading' | 'loadingTooltip'> & {
+    /**Asynkron `onClick` event; håndterer loading status, slik at menyen ikke lukker seg under loading. */
+    onClickAsync?: MouseEventHandler<HTMLButtonElement>;
+  };
 
 export type OverflowMenuLinkProps = OverflowMenuListItemBaseProps<'a'>;
 


### PR DESCRIPTION
## Beskrivelse

Støtte for async funksjonkall med `onClickAsync` prop i `<OverflowMenuButton>`, slik at menyen er fortsatt åpen under loading.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
