### PR TITLE
ELSA1-616 Feil border farge i `<SplitButton>`

### DIFF
--- a/.changeset/proud-tigers-fix.md
+++ b/.changeset/proud-tigers-fix.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug deg border mellom knappene i `<SplitButton>` fikk feil farge på hover.

--- a/packages/dds-components/src/components/SplitButton/SplitButton.module.css
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.module.css
@@ -25,5 +25,5 @@
 
 .option--primary,
 .option--primary:hover {
-  border-left: 1px solid var(--dds-color-border-on-action);
+  border-left: 1px solid var(--dds-color-border-on-action) !important;
 }


### PR DESCRIPTION
## Beskrivelse

Fikser bug deg border mellom knappene i `<SplitButton>` fikk feil farge på hover. Fikser med `!important`, da styling er der, men hover-styling fra `<Button>` er mer spesifikk og overskriver; tenker det går fint her.



## Sjekkliste

### Generelt

- [ ] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [ ] I commits
  - [ ] I PR-tittelen
- [ ] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
