### PR TITLE
ELSA1-624 Styling-justeringer i `<CardSelectable>`

### DIFF
--- a/.changeset/big-donkeys-attend.md
+++ b/.changeset/big-donkeys-attend.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Hover styling overskriver nå error-styling i `Checkbox>` og `<RadioButton>`.

--- a/.changeset/calm-frogs-beg.md
+++ b/.changeset/calm-frogs-beg.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Små justeringer i styling i `<SelectableCard>`: selected-bakgrunn ved `checked`, ingen ramme ved `disabled`/`readOnly` kombinert med `checked`, disabled-bakgrunn i selection control ved `disabled`/`readOnly`.

--- a/packages/dds-components/src/components/Card/Card.module.css
+++ b/packages/dds-components/src/components/Card/Card.module.css
@@ -20,15 +20,10 @@
   border-color: var(--dds-color-border-subtle);
 }
 
-.container--navigation,
-.container--selection-control:not(.container--selection-control--disabled):not(
-    .container--selection-control--readonly
-  ) {
-  display: block;
-  &:hover {
-    border-color: var(--dds-color-border-action-hover);
-    box-shadow: inset 0 0 0 1px var(--dds-color-border-action-hover);
-  }
+.container--navigation:hover,
+.container--selection-control:has(input:enabled:not([aria-readonly])):hover {
+  border-color: var(--dds-color-border-action-hover);
+  box-shadow: inset 0 0 0 1px var(--dds-color-border-action-hover);
 }
 
 .container--selection-control {
@@ -40,31 +35,33 @@
   & > span {
     left: var(--dds-selection-control-card-control-left);
     top: var(--dds-selection-control-card-control-top);
+  }
 
-    &:focus-visible {
-      outline: none;
+  input:disabled,
+  input[aria-readonly] {
+    & ~ span {
+      background-color: var(--dds-color-surface-field-disabled);
     }
   }
 
   &:has(input:checked) {
     border-color: var(--dds-color-surface-action-selected);
     box-shadow: inset 0 0 0 1px var(--dds-color-surface-action-selected);
+    background-color: var(--dds-color-surface-selected-default);
   }
-}
 
-.container--selection-control--error {
-  border-color: var(--dds-color-border-danger);
-  box-shadow: 0 0 0 1px var(--dds-color-border-danger);
-}
+  &:has(input[aria-invalid]) {
+    border-color: var(--dds-color-border-danger);
+    box-shadow: inset 0 0 0 1px var(--dds-color-border-danger);
+  }
 
-.container--selection-control--disabled {
-  background-color: var(--dds-color-surface-field-disabled);
-  border-color: var(--dds-color-surface-field-disabled);
-}
-
-.container--selection-control--readonly {
-  background-color: var(--dds-color-surface-field-disabled);
-  border-color: var(--dds-color-surface-field-disabled);
+  &:has(input:disabled),
+  &:has(input[aria-readonly]) {
+    box-shadow: none;
+    background-color: var(--dds-color-surface-selected-default);
+    background-color: var(--dds-color-surface-field-disabled);
+    border-color: var(--dds-color-surface-field-disabled);
+  }
 }
 
 .container--navigation {

--- a/packages/dds-components/src/components/Card/Card.stories.tsx
+++ b/packages/dds-components/src/components/Card/Card.stories.tsx
@@ -16,6 +16,7 @@ import {
   CardExpandable,
   CardExpandableBody,
   CardExpandableHeader,
+  CardSelectable,
 } from '.';
 
 export default {
@@ -81,7 +82,7 @@ export const Overview: Story = {
         <Card {...args} cardType="info">
           <div className="story-container-padding">
             <Heading level={2} typographyType="headingLarge">
-              Title
+              Info
             </Heading>
             {body}
           </div>
@@ -89,23 +90,25 @@ export const Overview: Story = {
         <Card {...args} cardType="navigation" href="#">
           <div className="story-container-padding">
             <Heading level={2} typographyType="headingLarge">
-              Title
+              Navigation
             </Heading>
             {body}
           </div>
         </Card>
         <Card {...args} cardType="expandable">
           <CardExpandable>
-            <CardExpandableHeader> Title </CardExpandableHeader>
+            <CardExpandableHeader> Expandable </CardExpandableHeader>
             <CardExpandableBody>Content</CardExpandableBody>
           </CardExpandable>
         </Card>
+        <CardSelectable cardType="checkbox">Selectable checkbox</CardSelectable>
+        <CardSelectable cardType="radio">Selectable radio</CardSelectable>
       </StoryVStack>
       <StoryVStack>
         <Card {...args} cardType="info" appearance="border">
           <div className="story-container-padding">
             <Heading level={2} typographyType="headingLarge">
-              Title
+              Info
             </Heading>
             {body}
           </div>
@@ -113,17 +116,23 @@ export const Overview: Story = {
         <Card {...args} appearance="border" cardType="navigation" href="#">
           <div className="story-container-padding">
             <Heading level={2} typographyType="headingLarge">
-              Title
+              Navigation
             </Heading>
             {body}
           </div>
         </Card>
         <Card {...args} cardType="expandable" appearance="border">
           <CardExpandable>
-            <CardExpandableHeader> Title </CardExpandableHeader>
+            <CardExpandableHeader> Expandable </CardExpandableHeader>
             <CardExpandableBody>Content</CardExpandableBody>
           </CardExpandable>
         </Card>
+        <CardSelectable cardType="checkbox" appearance="border">
+          Selectable checkbox
+        </CardSelectable>
+        <CardSelectable cardType="radio" appearance="border">
+          Selectable radio
+        </CardSelectable>
       </StoryVStack>
     </StoryHStack>
   ),

--- a/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectable.stories.tsx
+++ b/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectable.stories.tsx
@@ -3,6 +3,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 
 import { CardSelectable } from './CardSelectable';
 import {
+  categoryHtml,
   htmlPropsArgType,
   responsivePropsArgTypes,
 } from '../../../storybook/helpers';
@@ -28,8 +29,8 @@ export default {
   },
   argTypes: {
     htmlProps: htmlPropsArgType,
-    checked: htmlPropsArgType,
-    disabled: htmlPropsArgType,
+    checked: { table: categoryHtml, control: 'boolean' },
+    disabled: { table: categoryHtml, control: 'boolean' },
     value: htmlPropsArgType,
     defaultValue: htmlPropsArgType,
     padding,

--- a/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectable.tsx
+++ b/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectable.tsx
@@ -33,6 +33,11 @@ export const CardSelectable = (props: CardSelectableProps) => {
   const cardType = cardTypeProp ?? cardTypeContext;
   const group = cardTypeContext === 'radio' ? radioGroup : checkboxGroup;
 
+  if (!cardType)
+    throw new Error(`
+Error: <CardSelectable> requires a \`cardType\` prop.
+Provide \`cardType\` either via a parent <CardSelectableGroup> or directly on the component.`);
+
   const {
     disabled = group?.disabled,
     readOnly = group?.readOnly,
@@ -48,9 +53,6 @@ export const CardSelectable = (props: CardSelectableProps) => {
     styles.container,
     styles[`container--${appearance}`],
     styles[`container--selection-control`],
-    readOnly && styles[`container--selection-control--readonly`],
-    disabled && styles[`container--selection-control--disabled`],
-    error && styles[`container--selection-control--error`],
     focusStyles['has-focusable-input'],
   );
 

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.tsx
@@ -44,9 +44,7 @@ export const Checkbox = ({
 
   return (
     <Label
-      hasError={hasError}
       disabled={isDisabled}
-      readOnly={isReadOnly}
       htmlFor={uniqueId}
       hasText={hasLabel || hasChildren}
       controlType="checkbox"

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.tsx
@@ -81,9 +81,7 @@ export const RadioButton = ({
 
   return (
     <Label
-      hasError={hasError}
       disabled={isDisabled}
-      readOnly={isReadOnly}
       style={style}
       className={cn(className, htmlPropsClassName)}
       hasText={hasLabel || hasChildren}

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
@@ -13,9 +13,9 @@ export default {
     label: { control: { type: 'text' } },
     errorMessage: { control: { type: 'text' } },
     tip: { control: { type: 'text' } },
-    disabled: { control: { type: 'boolean' } },
-    readOnly: { control: { type: 'boolean' } },
-    required: { control: { type: 'boolean' } },
+    disabled: { control: 'boolean' },
+    readOnly: { control: 'boolean' },
+    required: { control: 'boolean' },
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/SelectionControl/SelectionControl.module.css
+++ b/packages/dds-components/src/components/SelectionControl/SelectionControl.module.css
@@ -22,52 +22,56 @@
   cursor: pointer;
   user-select: none;
 
-  input ~ .selection-control {
-    @media (prefers-reduced-motion: no-preference) {
-      transition:
-        box-shadow 0.2s,
-        background-color 0.2s,
-        border 0.2s,
-        var(--dds-focus-transition);
-    }
+  &:not(:hover)
+    input[aria-invalid]:enabled:not([aria-readonly]):not(:focus-visible):not(
+      :checked
+    )
+    ~ .selection-control {
+    background-color: var(--dds-color-surface-danger-default);
+  }
+}
+
+.label:has(input:enabled) {
+  input[aria-invalid]:not([aria-readonly]):not(:focus-visible)
+    ~ .selection-control {
+    border-color: var(--dds-color-border-danger);
+    box-shadow: inset 0 0 0 1px var(--dds-color-border-danger);
   }
 
-  &:hover:not(.label--readonly)
-    input:enabled:not(:checked)
-    ~ .selection-control {
+  &:hover input:not(:checked):not([aria-readonly]) ~ .selection-control {
     background-color: var(--dds-color-surface-hover-default);
     box-shadow: inset 0 0 0 1px var(--dds-color-border-action-hover);
     border-color: var(--dds-color-border-action-hover);
   }
 
-  input:checked:enabled ~ .selection-control,
-  input:enabled[data-indeterminate='true'] ~ .selection-control {
+  input:checked ~ .selection-control,
+  input[data-indeterminate] ~ .selection-control {
     border-color: var(--dds-color-surface-action-selected);
     background-color: var(--dds-color-surface-action-selected);
   }
 
-  &.label--readonly input:checked:enabled ~ .selection-control,
-  &.label--readonly
-    input:enabled[data-indeterminate='true']
-    ~ .selection-control {
+  input:checked[aria-readonly] ~ .selection-control,
+  input[data-indeterminate][aria-readonly] ~ .selection-control {
     border-color: var(--dds-color-surface-action-selected-disabled);
     background-color: var(--dds-color-surface-action-selected-disabled);
   }
 
-  &:hover:not(.label--readonly)
-    input:checked:enabled[type='checkbox']
-    ~ .selection-control,
-  &:hover:not(.label--readonly)
-    input:enabled[data-indeterminate='true']
-    ~ .selection-control {
-    background-color: var(--dds-color-surface-action-hover);
-    border-color: var(--dds-color-surface-action-hover);
+  &:hover {
+    input:enabled:not([aria-readonly]) {
+      &:checked[type='checkbox'],
+      &[data-indeterminate] {
+        ~ .selection-control {
+          background-color: var(--dds-color-surface-action-hover);
+          border-color: var(--dds-color-surface-action-hover);
+        }
+      }
+    }
   }
+}
 
-  input:checked ~ .selection-control:after,
-  input[data-indeterminate='true'] ~ .selection-control:after {
-    display: block;
-  }
+input:checked ~ .selection-control:after,
+input[data-indeterminate] ~ .selection-control:after {
+  display: block;
 }
 
 .label--checkbox {
@@ -81,7 +85,7 @@
     transform: rotate(45deg);
   }
 
-  input[data-indeterminate='true'] ~ .selection-control:after {
+  input[data-indeterminate] ~ .selection-control:after {
     border-width: 1px 0 0 0;
     left: 25%;
     top: 50%;
@@ -103,47 +107,29 @@
   }
 }
 
-.label--disabled {
+.label:has(input:disabled) {
   cursor: not-allowed;
-  input:disabled ~ .selection-control {
+  input ~ .selection-control {
     border-color: var(--dds-color-border-subtle);
   }
-  input:checked:disabled ~ .selection-control,
-  input:disabled[data-indeterminate='true'] ~ .selection-control {
-    border-color: var(--dds-color-surface-action-selected-disabled);
-    background-color: var(--dds-color-surface-action-selected-disabled);
-  }
-}
-
-.label--readonly {
-  cursor: default;
-  color: var(--dds-color-text-medium);
-  input ~ .selection-control {
-    border-color: var(--dds-color-border-default);
-    background-color: var(--dds-color-surface-field-disabled);
-  }
   input:checked ~ .selection-control,
-  input[data-indeterminate='true'] ~ .selection-control {
+  input[data-indeterminate] ~ .selection-control {
     border-color: var(--dds-color-surface-action-selected-disabled);
     background-color: var(--dds-color-surface-action-selected-disabled);
   }
-}
 
-.label--error {
-  &:hover input:enabled:not(:focus-visible):not(:checked) ~ .selection-control {
-    background-color: var(--dds-color-surface-danger-default);
-    border-color: var(--dds-color-border-danger);
-    box-shadow: 0 0 0 1px var(--dds-c-tic-border-danger);
-  }
-
-  input:not(:focus-visible) ~ .selection-control,
-  input:checked:enabled:not(:focus-visible)
-    .selection-control
-    &:hover
-    input:checked:enabled:not(:focus-visible)
-    .selection-control {
-    border-color: var(--dds-color-border-danger);
-    box-shadow: 0 0 0 1px var(--dds-color-border-danger);
+  .label:has(input[aria-readonly]) {
+    cursor: default;
+    color: var(--dds-color-text-medium);
+    input ~ .selection-control {
+      border-color: var(--dds-color-border-default);
+      background-color: var(--dds-color-surface-field-disabled);
+    }
+    input:checked ~ .selection-control,
+    input[data-indeterminate] ~ .selection-control {
+      border-color: var(--dds-color-surface-action-selected-disabled);
+      background-color: var(--dds-color-surface-action-selected-disabled);
+    }
   }
 }
 
@@ -159,13 +145,21 @@
   border-color: var(--dds-color-border-default);
   background-color: var(--dds-color-surface-field-default);
   border-radius: var(--dds-border-radius-input);
-  height: 18px;
-  width: 18px;
+  height: var(--dds-selection-control-height);
+  width: var(--dds-selection-control-height);
   &:after {
     content: '';
     position: absolute;
     display: none;
     box-sizing: border-box;
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    transition:
+      box-shadow 0.2s,
+      background-color 0.2s,
+      border 0.2s,
+      border-color 0.2s,
+      var(--dds-focus-transition);
   }
 }
 

--- a/packages/dds-components/src/components/SelectionControl/SelectionControl.styles.tsx
+++ b/packages/dds-components/src/components/SelectionControl/SelectionControl.styles.tsx
@@ -31,16 +31,12 @@ export const SelectionControl = ({
 
 type SelectionControlLabelProps = {
   disabled?: boolean;
-  readOnly?: boolean;
-  hasError?: boolean;
   hasText?: boolean;
   controlType: SelectionControlType;
 } & LabelHTMLAttributes<HTMLLabelElement>;
 
 export const Label = ({
   disabled,
-  readOnly,
-  hasError,
   hasText,
   controlType,
   className,
@@ -60,10 +56,7 @@ export const Label = ({
         styles[`label--${controlType}`],
         !hasText && styles['label--no-text'],
         typographyStyles['text-color--default'],
-        disabled && styles['label--disabled'],
         disabled && typographyStyles['text-color--subtle'],
-        readOnly && styles['label--readonly'],
-        hasError && styles['label--error'],
       )}
       {...rest}
     />


### PR DESCRIPTION
## Beskrivelse

Små justeringer i styling i `<SelectableCard>`:
- selected-bakgrunn ved `checked`,
- ingen ramme ved `disabled`/`readOnly` kombinert med `checked`, 
- disabled-bakgrunn i selection control ved `disabled`/`readOnly`.
Generelt for selection control: Hover styling overskriver nå error-styling i `Checkbox>` og `<RadioButton>`.

Legger også til CardSelectable i overview-story og refaktorerer `SelectionControl.module.css`.
Før:

![image](https://github.com/user-attachments/assets/f444a50e-b814-49bf-9e95-900f455b6cd7)

Etter (subtile forskjeller):

![image](https://github.com/user-attachments/assets/1fb9a3b5-a0e0-4844-989b-8823c15052b6)

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
