### PR TITLE
ELSA1-630 Feil styling ved `readOnly="false"` i selection control

### DIFF
--- a/.changeset/early-cobras-listen.md
+++ b/.changeset/early-cobras-listen.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<Toggle>`, `<RadioButton>` og `<Checkbox>` fikk read-only styling ved `readOnly="false"`.

--- a/packages/dds-components/src/components/Card/Card.module.css
+++ b/packages/dds-components/src/components/Card/Card.module.css
@@ -21,7 +21,9 @@
 }
 
 .container--navigation:hover,
-.container--selection-control:has(input:enabled:not([aria-readonly])):hover {
+.container--selection-control:has(
+    input:enabled:not([aria-readonly='true'])
+  ):hover {
   border-color: var(--dds-color-border-action-hover);
   box-shadow: inset 0 0 0 1px var(--dds-color-border-action-hover);
 }
@@ -38,7 +40,7 @@
   }
 
   input:disabled,
-  input[aria-readonly] {
+  input[aria-readonly='true'] {
     & ~ span {
       background-color: var(--dds-color-surface-field-disabled);
     }
@@ -56,7 +58,7 @@
   }
 
   &:has(input:disabled),
-  &:has(input[aria-readonly]) {
+  &:has(input[aria-readonly='true']) {
     box-shadow: none;
     background-color: var(--dds-color-surface-selected-default);
     background-color: var(--dds-color-surface-field-disabled);

--- a/packages/dds-components/src/components/SelectionControl/SelectionControl.module.css
+++ b/packages/dds-components/src/components/SelectionControl/SelectionControl.module.css
@@ -23,22 +23,22 @@
   user-select: none;
 
   &:not(:hover)
-    input[aria-invalid]:enabled:not([aria-readonly]):not(:focus-visible):not(
-      :checked
-    )
+    input[aria-invalid]:enabled:not([aria-readonly='true']):not(
+      :focus-visible
+    ):not(:checked)
     ~ .selection-control {
     background-color: var(--dds-color-surface-danger-default);
   }
 }
 
 .label:has(input:enabled) {
-  input[aria-invalid]:not([aria-readonly]):not(:focus-visible)
+  input[aria-invalid]:not([aria-readonly='true']):not(:focus-visible)
     ~ .selection-control {
     border-color: var(--dds-color-border-danger);
     box-shadow: inset 0 0 0 1px var(--dds-color-border-danger);
   }
 
-  &:hover input:not(:checked):not([aria-readonly]) ~ .selection-control {
+  &:hover input:not(:checked):not([aria-readonly='true']) ~ .selection-control {
     background-color: var(--dds-color-surface-hover-default);
     box-shadow: inset 0 0 0 1px var(--dds-color-border-action-hover);
     border-color: var(--dds-color-border-action-hover);
@@ -50,14 +50,14 @@
     background-color: var(--dds-color-surface-action-selected);
   }
 
-  input:checked[aria-readonly] ~ .selection-control,
-  input[data-indeterminate][aria-readonly] ~ .selection-control {
+  input:checked[aria-readonly='true'] ~ .selection-control,
+  input[data-indeterminate][aria-readonly='true'] ~ .selection-control {
     border-color: var(--dds-color-surface-action-selected-disabled);
     background-color: var(--dds-color-surface-action-selected-disabled);
   }
 
   &:hover {
-    input:enabled:not([aria-readonly]) {
+    input:enabled:not([aria-readonly='true']) {
       &:checked[type='checkbox'],
       &[data-indeterminate] {
         ~ .selection-control {
@@ -118,7 +118,7 @@ input[data-indeterminate] ~ .selection-control:after {
     background-color: var(--dds-color-surface-action-selected-disabled);
   }
 
-  .label:has(input[aria-readonly]) {
+  .label:has(input[aria-readonly='true']) {
     cursor: default;
     color: var(--dds-color-text-medium);
     input ~ .selection-control {

--- a/packages/dds-components/src/components/Toggle/Toggle.module.css
+++ b/packages/dds-components/src/components/Toggle/Toggle.module.css
@@ -66,13 +66,13 @@
     transform: translateX(1.25rem);
   }
 
-  input:checked:enabled:active:not([aria-disabled]):not([aria-readonly])
+  input:checked:enabled:active:not([aria-disabled]):not([aria-readonly='true'])
     ~ .track
     > .thumb {
     transform: translateX(var(--dds-spacing-x1));
   }
 
-  input:enabled:active:not([aria-disabled]):not([aria-readonly])
+  input:enabled:active:not([aria-disabled]):not([aria-readonly='true'])
     ~ .track
     > .thumb {
     width: 1.5rem;
@@ -95,13 +95,13 @@
     transform: translateX(var(--dds-spacing-x1));
   }
 
-  input:checked:enabled:active:not([aria-disabled]):not([aria-readonly])
+  input:checked:enabled:active:not([aria-disabled]):not([aria-readonly='true'])
     ~ .track
     > .thumb {
     transform: translateX(var(--dds-spacing-x0-75));
   }
 
-  input:enabled:active:not([aria-disabled]):not([aria-readonly])
+  input:enabled:active:not([aria-disabled]):not([aria-readonly='true'])
     ~ .track
     > .thumb {
     width: var(--dds-spacing-x2);
@@ -110,7 +110,7 @@
 
 .label,
 .label--is-loading {
-  input:checked:enabled:not([aria-readonly]) ~ .track {
+  input:checked:enabled:not([aria-readonly='true']) ~ .track {
     background-color: var(--dds-color-surface-action-selected);
     border-color: var(--dds-color-border-action-default);
 
@@ -128,7 +128,7 @@
   cursor: pointer;
 
   &:hover
-    input:enabled:checked:not([aria-disabled]):not([aria-readonly])
+    input:enabled:checked:not([aria-disabled]):not([aria-readonly='true'])
     ~ .track {
     background-color: var(--dds-color-surface-action-hover);
     border-color: var(--dds-color-border-action-hover);
@@ -137,7 +137,9 @@
       border-color: var(--dds-color-border-action-hover);
     }
   }
-  &:hover input:enabled:not([aria-disabled]):not([aria-readonly]) ~ .track {
+  &:hover
+    input:enabled:not([aria-disabled]):not([aria-readonly='true'])
+    ~ .track {
     background-color: var(--dds-color-surface-hover-default);
     border-color: var(--dds-color-border-action-hover);
 


### PR DESCRIPTION
## Beskrivelse

Fikser bug der `<Toggle>`, `<RadioButton>` og `<Checkbox>` fikk read-only styling ved `readOnly="false"`.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
