### PR TITLE
ELSA1-619 Polymorfi i `<VisuallyHidden>`

### DIFF
--- a/.changeset/violet-ads-grow.md
+++ b/.changeset/violet-ads-grow.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Utvider `<VisuallyHidden>` sin `as` prop til å støtte valgfritt element. Propen er ikke lenger påkrevd og komponenten returnerer `<span>` som default.

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,14 +1,11 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import {
-  htmlPropsArgType,
-  windowWidthDecorator,
-} from '../../storybook/helpers';
+import { commonArgTypes, windowWidthDecorator } from '../../storybook/helpers';
 import { StoryVStack } from '../layout/Stack/utils';
 
 import { Breadcrumb, Breadcrumbs } from '.';
 
-export default {
+const meta: Meta<typeof Breadcrumbs> = {
   title: 'dds-components/Components/Breadcrumbs',
   component: Breadcrumbs,
   parameters: {
@@ -18,9 +15,11 @@ export default {
     },
   },
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
-} satisfies Meta<typeof Breadcrumbs>;
+};
+
+export default meta;
 
 type Story = StoryObj<typeof Breadcrumbs>;
 

--- a/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectableGroup.stories.tsx
+++ b/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectableGroup.stories.tsx
@@ -130,9 +130,7 @@ export const GroupWithInvisibleLabel: Story = {
   render: args => {
     return (
       <>
-        <VisuallyHidden as="span" id="label-1">
-          Gruppeledetekst
-        </VisuallyHidden>
+        <VisuallyHidden id="label-1">Gruppeledetekst</VisuallyHidden>
         <CardSelectableGroup {...args} aria-labelledby="label-1">
           <CardSelectable children="alternativ 1" value={1} name="a" />
           <CardSelectable children="alternativ 2" value={2} name="a" />

--- a/packages/dds-components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.tsx
@@ -170,9 +170,7 @@ export const FileUploader = (props: FileUploaderProps) => {
             data-testid="file-uploader-input"
           />
           {dropAreaLabel}
-          <VisuallyHidden as="span">
-            velg fil med påfølgende knapp
-          </VisuallyHidden>
+          <VisuallyHidden>velg fil med påfølgende knapp</VisuallyHidden>
           {button}
         </VStack>
       ) : (

--- a/packages/dds-components/src/components/Footer/Footer.stories.tsx
+++ b/packages/dds-components/src/components/Footer/Footer.stories.tsx
@@ -45,7 +45,7 @@ const socials = (
             htmlProps={{ style: { display: 'block' } }}
           />
         </Link>
-        <VisuallyHidden as="span">Facebook</VisuallyHidden>
+        <VisuallyHidden>Facebook</VisuallyHidden>
       </li>
       <li>
         <Link
@@ -58,7 +58,7 @@ const socials = (
             icon={InstagramIcon}
             htmlProps={{ style: { display: 'block' } }}
           />
-          <VisuallyHidden as="span">Instagram</VisuallyHidden>
+          <VisuallyHidden>Instagram</VisuallyHidden>
         </Link>
       </li>
       <li>
@@ -72,7 +72,7 @@ const socials = (
             icon={LinkedInIcon}
             htmlProps={{ style: { display: 'block' } }}
           />
-          <VisuallyHidden as="span">LinkedIn</VisuallyHidden>
+          <VisuallyHidden>LinkedIn</VisuallyHidden>
         </Link>
       </li>
     </FooterSocialsList>

--- a/packages/dds-components/src/components/InlineButton/InlineButton.stories.tsx
+++ b/packages/dds-components/src/components/InlineButton/InlineButton.stories.tsx
@@ -47,8 +47,7 @@ export const Example: Story = {
               <span>
                 ...{' '}
                 <InlineButton onClick={toggle}>
-                  Vis flere{' '}
-                  <VisuallyHidden as="span">resultater</VisuallyHidden>
+                  Vis flere <VisuallyHidden>resultater</VisuallyHidden>
                 </InlineButton>
               </span>
             )}
@@ -64,7 +63,7 @@ export const Example: Story = {
         </ul>
         {isShown && (
           <InlineButton onClick={toggle}>
-            Vis færre <VisuallyHidden as="span">resultater</VisuallyHidden>
+            Vis færre <VisuallyHidden>resultater</VisuallyHidden>
           </InlineButton>
         )}
       </>

--- a/packages/dds-components/src/components/InlineEdit/InlineEdit.utils.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEdit.utils.tsx
@@ -1,7 +1,7 @@
 import { VisuallyHidden } from '../VisuallyHidden';
 
 export const inlineEditVisuallyHidden = (id: string, emptiable?: boolean) => (
-  <VisuallyHidden id={id} as="span">
+  <VisuallyHidden id={id}>
     Escape, Enter eller Tab for å lagre.{' '}
     {!emptiable && 'Inputfeltet er ikke tømmbar.'}
   </VisuallyHidden>

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTrackerItem.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTrackerItem.tsx
@@ -150,13 +150,9 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
           typographyStyles['body-medium'],
         )}
       >
-        <VisuallyHidden as="span">
-          {getVisuallyHiddenTextBefore(index)}
-        </VisuallyHidden>
+        <VisuallyHidden>{getVisuallyHiddenTextBefore(index)}</VisuallyHidden>
         {children}
-        <VisuallyHidden as="span">
-          {getVisuallyHiddenTextAfter(completed)}
-        </VisuallyHidden>
+        <VisuallyHidden>{getVisuallyHiddenTextAfter(completed)}</VisuallyHidden>
       </div>
     </>
   );

--- a/packages/dds-components/src/components/Search/Search.tsx
+++ b/packages/dds-components/src/components/Search/Search.tsx
@@ -183,7 +183,7 @@ export const Search = ({
             showSuggestions={context.showSuggestions}
             componentSize={componentSize}
           />
-          <VisuallyHidden id={suggestionsDescriptionId} as="span">
+          <VisuallyHidden id={suggestionsDescriptionId}>
             Bla i søkeforslag med piltaster når listen er utvidet.
           </VisuallyHidden>
         </>

--- a/packages/dds-components/src/components/Table/collapsible/CollapsibleRow.tsx
+++ b/packages/dds-components/src/components/Table/collapsible/CollapsibleRow.tsx
@@ -117,7 +117,7 @@ export const CollapsibleRow = ({
           {definingColumnCells}
           <Table.Cell type="head" layout="center">
             Utvid
-            <VisuallyHidden as="span">raden</VisuallyHidden>
+            <VisuallyHidden>raden</VisuallyHidden>
           </Table.Cell>
         </>
       </Row>

--- a/packages/dds-components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
+++ b/packages/dds-components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
@@ -345,16 +345,16 @@ export const ResposiveMultipleBreakpoints: Story = {
 const headers = [
   {
     key: 'fav',
-    content: <VisuallyHidden as="span">Velg som favoritt</VisuallyHidden>,
+    content: <VisuallyHidden>Velg som favoritt</VisuallyHidden>,
   },
   {
     key: 'Dokumenttype',
-    content: <VisuallyHidden as="span">Dokumenttype</VisuallyHidden>,
+    content: <VisuallyHidden>Dokumenttype</VisuallyHidden>,
   },
   { key: 'Nummer', content: 'Nr.' },
   {
     key: 'Lest status',
-    content: <VisuallyHidden as="span">Lest status</VisuallyHidden>,
+    content: <VisuallyHidden>Lest status</VisuallyHidden>,
   },
   { key: 'Dokumentnavn', content: 'Dokumentnavn' },
   { key: 'Avsender', content: 'Avsender' },

--- a/packages/dds-components/src/components/Toggle/Toggle.tsx
+++ b/packages/dds-components/src/components/Toggle/Toggle.tsx
@@ -138,9 +138,7 @@ export const Toggle = ({
           />
         )}
         {children}{' '}
-        {isLoading && (
-          <VisuallyHidden as="span">Innlastning pågår</VisuallyHidden>
-        )}
+        {isLoading && <VisuallyHidden>Innlastning pågår</VisuallyHidden>}
       </span>
     </label>
   );

--- a/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.spec.tsx
+++ b/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.spec.tsx
@@ -6,7 +6,11 @@ import { VisuallyHidden } from './VisuallyHidden';
 describe('<VisuallyHidden>', () => {
   it('should render children', () => {
     const text = 'text';
-    render(<VisuallyHidden as="span">{text}</VisuallyHidden>);
+    render(<VisuallyHidden>{text}</VisuallyHidden>);
     expect(screen.getByText(text)).toBeInTheDocument;
+  });
+  it('should render <p>', () => {
+    render(<VisuallyHidden as="p" />);
+    expect(screen.getByRole('paragraph')).toBeInTheDocument;
   });
 });

--- a/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { categoryHtml, commonArgTypes } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { Table } from '../Table/normal';
 import { Link, Paragraph } from '../Typography';
@@ -11,7 +11,9 @@ export default {
   title: 'dds-components/Components/VisuallyHidden',
   component: VisuallyHidden,
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
+    as: { control: 'text' },
+    style: { table: categoryHtml },
   },
   parameters: {
     docs: {
@@ -35,17 +37,14 @@ export const Default: Story = {
 export const WithLink: Story = {
   render: args => (
     <>
+      <Paragraph>Eksempeltekst på en nettside.</Paragraph>
       <Paragraph>
-        I foreldretvister kan du søke fri rettshjelp hvis du har lav inntekt og
-        formue.
-      </Paragraph>
-      <Paragraph>
-        På sivilrett.no finner du{' '}
+        Her finner du{' '}
         <Link href="/">
           mer informasjon og søknadsskjema
-          <VisuallyHidden {...args} as="span">
+          <VisuallyHidden {...args}>
             {' '}
-            i forbindelse med foreldretvister
+            i forbindelse med et spesifikt tema
           </VisuallyHidden>
         </Link>
         .
@@ -63,7 +62,7 @@ export const TableButtons: Story = {
           <Table.Row type="head">
             <Table.Cell type="head">Bruker</Table.Cell>
             <Table.Cell type="head">
-              <VisuallyHidden as="span">Aksjoner</VisuallyHidden>
+              <VisuallyHidden>Aksjoner</VisuallyHidden>
             </Table.Cell>
           </Table.Row>
         </Table.Head>
@@ -72,7 +71,7 @@ export const TableButtons: Story = {
             <Table.Cell>Ane Bjerke</Table.Cell>
             <Table.Cell layout="right">
               <Button size="small" purpose="danger">
-                Slett <VisuallyHidden as="span">Ane Bjerke</VisuallyHidden>
+                Slett <VisuallyHidden>Navn Navnesen</VisuallyHidden>
               </Button>
             </Table.Cell>
           </Table.Row>
@@ -80,8 +79,7 @@ export const TableButtons: Story = {
             <Table.Cell>Sandra Lovsetter</Table.Cell>
             <Table.Cell layout="right">
               <Button size="small" purpose="danger">
-                Slett{' '}
-                <VisuallyHidden as="span">Sandra Lovsetter</VisuallyHidden>
+                Slett <VisuallyHidden>Sandra Lovsetter</VisuallyHidden>
               </Button>
             </Table.Cell>
           </Table.Row>

--- a/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.tsx
@@ -1,36 +1,35 @@
+import { type ElementType } from 'react';
+
 import {
-  type BaseComponentPropsWithChildren,
+  type PolymorphicBaseComponentProps,
   getBaseHTMLProps,
 } from '../../types';
 import { cn } from '../../utils';
+import { ElementAs } from '../helpers';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
 
-type VisuallyHiddenDivProps = BaseComponentPropsWithChildren<
-  HTMLDivElement,
-  { as: 'div' }
->;
+export type VisuallyHiddenProps<T extends ElementType = 'span'> =
+  PolymorphicBaseComponentProps<T>;
 
-type VisuallyHiddenSpanProps = BaseComponentPropsWithChildren<
-  HTMLSpanElement,
-  {
-    /**Spesifiserer hvilken HTML tag skal returneres. */
-    as: 'span';
-  }
->;
-
-export type VisuallyHiddenProps =
-  | VisuallyHiddenSpanProps
-  | VisuallyHiddenDivProps;
-
-export const VisuallyHidden = (props: VisuallyHiddenProps) => {
-  const { id, className, htmlProps, as, ...rest } = props;
-
-  const cl = cn(className, utilStyles['visually-hidden']);
-
-  if (as === 'div') {
-    return <div {...getBaseHTMLProps(id, cl, htmlProps, rest)} />;
-  }
-  return <span {...getBaseHTMLProps(id, cl, htmlProps, rest)} />;
+export const VisuallyHidden = <T extends ElementType = 'span'>({
+  id,
+  as: asProp,
+  className,
+  htmlProps,
+  ...rest
+}: VisuallyHiddenProps<T>) => {
+  const as = asProp ?? 'span';
+  return (
+    <ElementAs
+      as={as}
+      {...getBaseHTMLProps(
+        id,
+        cn(className, utilStyles['visually-hidden']),
+        htmlProps,
+        rest,
+      )}
+    />
+  );
 };
 
 VisuallyHidden.displayName = 'VisuallyHidden';

--- a/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/CalendarGrid.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/CalendarGrid.tsx
@@ -60,7 +60,7 @@ export function CalendarGrid({ state, ...props }: CalendarGridProps) {
             <th
               className={cn(styles['calendar__grid-element'], ...typographyCn)}
             >
-              # <VisuallyHidden as="span">Ukenummer</VisuallyHidden>
+              # <VisuallyHidden>Ukenummer</VisuallyHidden>
             </th>
           )}
           {weekDays.map((day, index) => (

--- a/packages/dds-components/src/storybook/helpers.tsx
+++ b/packages/dds-components/src/storybook/helpers.tsx
@@ -24,6 +24,13 @@ export const htmlPropsArgType: Partial<ArgTypes> = {
   table: categoryHtml,
 };
 
+export const commonArgTypes: ArgTypes = {
+  id: { table: categoryHtml },
+  className: { table: categoryHtml },
+  htmlProps: htmlPropsArgType,
+  ref: { control: { disable: true } },
+};
+
 export const htmlEventArgType: Partial<ArgTypes> = {
   control: { disable: true },
   table: categoryHtml,

--- a/stories/Tokens/utils/ColorsGenerator.tsx
+++ b/stories/Tokens/utils/ColorsGenerator.tsx
@@ -68,7 +68,7 @@ export const ColorsGenerator = () => {
           <Table.Cell>Token</Table.Cell>
           <Table.Cell>Verdi</Table.Cell>
           <Table.Cell>
-            <VisuallyHidden as="span">Forhåndsvisning</VisuallyHidden>
+            <VisuallyHidden>Forhåndsvisning</VisuallyHidden>
           </Table.Cell>
           <Table.Cell>Kopier</Table.Cell>
           <Table.Cell>Beskrivelse</Table.Cell>
@@ -133,7 +133,7 @@ export const DataColorsGenerator = () => {
           <Table.Cell>Token</Table.Cell>
           <Table.Cell>Verdi</Table.Cell>
           <Table.Cell>
-            <VisuallyHidden as="span">Forhåndsvisning</VisuallyHidden>
+            <VisuallyHidden>Forhåndsvisning</VisuallyHidden>
           </Table.Cell>
           <Table.Cell>Kopier</Table.Cell>
           <Table.Cell>Beskrivelse</Table.Cell>

--- a/stories/Tokens/utils/ShadowsGenerator.tsx
+++ b/stories/Tokens/utils/ShadowsGenerator.tsx
@@ -82,7 +82,7 @@ export const ShadowsGenerator = () => {
           <Table.Cell>Token</Table.Cell>
           <Table.Cell>Verdi</Table.Cell>
           <Table.Cell>
-            <VisuallyHidden as="span">Forhåndsvisning</VisuallyHidden>
+            <VisuallyHidden>Forhåndsvisning</VisuallyHidden>
           </Table.Cell>
           <Table.Cell>Kopier</Table.Cell>
           <Table.Cell>Base-token</Table.Cell>


### PR DESCRIPTION
## Beskrivelse

Utvider `<VisuallyHidden>` sin `as` prop til å støtte valgfritt element. Propen er ikke lenger påkrevd og komponenten returnerer `<span>` som default.


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
