### PR TITLE
ELSA1-628 Ny prop i `<CookieBanner>`: `collapsedBreakpoint`.

### DIFF
--- a/.changeset/smart-times-smoke.md
+++ b/.changeset/smart-times-smoke.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Ny prop i `<CookieBanner>`: `collapsedBreakpoint`. Brukes til sammentrukket versjon på siden med detaljer om informasjonskapsler. Se detaljer i retningerlinjer.

--- a/packages/dds-components/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/dds-components/src/components/Accordion/AccordionHeader.tsx
@@ -6,11 +6,10 @@ import {
   getBaseHTMLProps,
 } from '../../types';
 import { cn } from '../../utils';
-import { AnimatedChevronUpDown } from '../helpers';
+import { AnimatedChevronUpDown, StylelessButton } from '../helpers';
 import { useAccordionContext } from '../helpers/AccordionBase';
 import baseStyles from '../helpers/AccordionBase/AccordionBase.module.css';
 import { focusable } from '../helpers/styling/focus.module.css';
-import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { Box } from '../layout';
 import { type StaticTypographyType, getTypographyCn } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
@@ -42,7 +41,7 @@ export const AccordionHeader = ({
 
   return (
     <Box
-      as="button"
+      as={StylelessButton}
       padding="x1 x1.5 x1 x1"
       {...getBaseHTMLProps(
         id,
@@ -50,8 +49,6 @@ export const AccordionHeader = ({
           className,
           styles['header-button'],
           baseStyles['header-button'],
-          utilStyles['normalize-button'],
-          utilStyles['remove-button-styling'],
           focusable,
           baseStyles['header-container'],
         ),

--- a/packages/dds-components/src/components/Card/CardExpandable/CardExpandableHeader.tsx
+++ b/packages/dds-components/src/components/Card/CardExpandable/CardExpandableHeader.tsx
@@ -7,11 +7,10 @@ import {
   getBaseHTMLProps,
 } from '../../../types';
 import { cn } from '../../../utils';
-import { AnimatedChevronUpDown } from '../../helpers';
+import { AnimatedChevronUpDown, StylelessButton } from '../../helpers';
 import { useAccordionContext } from '../../helpers/AccordionBase';
 import baseStyles from '../../helpers/AccordionBase/AccordionBase.module.css';
 import { focusable } from '../../helpers/styling/focus.module.css';
-import utilStyles from '../../helpers/styling/utilStyles.module.css';
 import { type StaticTypographyType, getTypographyCn } from '../../Typography';
 import typographyStyles from '../../Typography/typographyStyles.module.css';
 
@@ -52,15 +51,13 @@ export const CardExpandableHeader = ({
   const { id, ...restHeaderProps } = headerProps ?? {};
 
   return (
-    <button
+    <StylelessButton
       {...getBaseHTMLProps(
         id,
         cn(
           className,
           styles['header-button'],
           baseStyles['header-button'],
-          utilStyles['normalize-button'],
-          utilStyles['remove-button-styling'],
           focusable,
         ),
         htmlProps,
@@ -92,7 +89,7 @@ export const CardExpandableHeader = ({
           />
         </span>
       </div>
-    </button>
+    </StylelessButton>
   );
 };
 

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.mdx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.mdx
@@ -40,3 +40,13 @@ Banner bør ligge i nedre venstre hjørne, slik at den følger leserekkefølgen 
 Den kan gjerne plasseres med ulik avstand fra kanten av nettleservinduet for hvert brekkpunkt. <Link external href="https://domstolene.github.io/designsystem/iframe.html?args=&globals=&id=dds-components-components-cookiebanner--placement-with-checkboxes&viewMode=story"> Åpne eksempelet under i eget vindu for mer realistisk oppførsel</Link>.
 
 <Canvas of={CookieBannerStories.PlacementWithCheckboxes} />
+
+### På siden med detaljer om informasjonskapsler
+
+Dersom du følger eksempelet og inkluderer en lenke til en side med detaljer om informasjonskapsler, skal denne siden også vise `<CookieBanner>` så lenge brukeren ikke har tatt et valg.
+På små skjermer skal en sammentrukket versjon av banneret vises.
+Denne versjonen skal kunne utvides av brukeren, men ikke trekkes sammen igjen etter utvidelse.
+
+Dette møsteret implementeres ved å sette `collapsedBreakpoint` i komponenten for den spesifikke siden (endre vindusbredde for å se skaleringen):
+
+<Canvas of={CookieBannerStories.Collapsible} withToolbar />

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.spec.tsx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.spec.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
 
 import { CookieBanner } from '.';
@@ -45,5 +46,21 @@ describe('<CookieBanner>', () => {
     expect(screen.getByText(checkbox)).toBeInTheDocument();
     expect(screen.getByText(checkboxHeader)).toBeInTheDocument();
     expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+  it('Should render expand button', () => {
+    render(<CookieBanner collapsedBreakpoint="sm" />);
+    const button = screen.getByRole('button', {
+      name: 'Utvid samtykke for bruk av informasjonskapsler',
+    });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+  it('Should remove expand button after click', async () => {
+    render(<CookieBanner collapsedBreakpoint="sm" />);
+    const button = screen.getByRole('button', {
+      name: 'Utvid samtykke for bruk av informasjonskapsler',
+    });
+    await userEvent.click(button);
+    expect(button).not.toBeInTheDocument();
   });
 });

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.stories.tsx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.stories.tsx
@@ -261,3 +261,28 @@ export const PlacementWithCheckboxes: Story = {
     );
   },
 };
+
+export const Collapsible: Story = {
+  decorators: [
+    Story =>
+      windowWidthDecorator(
+        <Story />,
+        'Sammentrukket variant vises ved sm brekkpunkt.',
+      ),
+  ],
+  args: {
+    headerText: 'Tittel for banner',
+    collapsedBreakpoint: 'sm',
+    description: (
+      <>
+        Eksempeltekst for dette cookie-banneret. Fyll inn passende tekst om at
+        vi har noen valgfrie og noen nødvendige informasjonskapsler.{' '}
+        <Link href="/" color="text-default">
+          Se alle våre informasjonskapsler
+        </Link>
+        .
+      </>
+    ),
+    buttons: [{ children: 'Godkjenn alle' }, { children: 'Kun nødvendige' }],
+  },
+};

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.tsx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
 
 import {
   type BaseComponentPropsWithChildren,
@@ -6,7 +6,15 @@ import {
 } from '../../types';
 import { cn } from '../../utils';
 import { Button, type ButtonProps } from '../Button';
-import { HStack, Paper, type ResponsiveProps, VStack } from '../layout';
+import { ExpandIcon } from '../Icon/icons';
+import {
+  type Breakpoint,
+  HStack,
+  Paper,
+  type ResponsiveProps,
+  ShowHide,
+  VStack,
+} from '../layout';
 import { Heading } from '../Typography';
 import {
   CookieBannerCheckbox,
@@ -26,6 +34,8 @@ export type CookieBannerProps = BaseComponentPropsWithChildren<
     buttons?: Array<Omit<ButtonProps, 'purpose' | 'size'>>;
     /**Checkboxes for hver type informasjonskapsel som brukes på siden. Layout håndteres ut av boksen. */
     checkboxes?: Array<CookieBannerCheckboxProps>;
+    /**Brekkpunkt for sammentrukket variant; Brukes på siden med detaljer om informasjonskapsler. */
+    collapsedBreakpoint?: Breakpoint;
   } & Pick<
     ResponsiveProps,
     'position' | 'top' | 'bottom' | 'left' | 'right' | 'width' | 'maxHeight'
@@ -44,8 +54,18 @@ export function CookieBanner({
   maxHeight = 'calc(100vh - 100px)',
   width = 'fit-content',
   children,
+  collapsedBreakpoint,
   ...rest
 }: CookieBannerProps) {
+  const hasBp = !!collapsedBreakpoint;
+  const [isCollapsedOnBreakpoint, setIsCollapsedOnBreakpoint] = useState(hasBp);
+  const heading = headerText ? (
+    <Heading level={2} typographyType="headingMedium">
+      {headerText}
+    </Heading>
+  ) : (
+    ''
+  );
   return (
     <Paper
       {...getBaseHTMLProps(
@@ -63,31 +83,47 @@ export function CookieBanner({
       background="brand-tertiary-medium"
     >
       <VStack maxWidth="70ch" gap="x1">
-        {headerText && (
-          <Heading level={2} typographyType="headingMedium">
-            {headerText}
-          </Heading>
-        )}
-        {children}
-        {description && <div>{description}</div>}
-        {checkboxes && (
-          <VStack gap="x1">
-            {checkboxes.map(props => (
-              <CookieBannerCheckbox {...props} />
-            ))}
-          </VStack>
-        )}
-        {buttons && (
-          <HStack
-            gap={applyResponsiveStyle('x1', 'sm', 'x1.5')}
-            flexWrap="wrap"
-            paddingBlock="x0.25 0"
-          >
-            {buttons.map(props => (
-              <Button {...props} size="medium" purpose="secondary" />
-            ))}
+        {hasBp && isCollapsedOnBreakpoint ? (
+          <HStack alignItems="center" justifyContent="space-between" gap="x1">
+            {heading}
+            <ShowHide
+              as={Button}
+              showBelow={collapsedBreakpoint}
+              aria-label="Utvid samtykke for bruk av informasjonskapsler"
+              purpose="tertiary"
+              icon={ExpandIcon}
+              onClick={() => setIsCollapsedOnBreakpoint(false)}
+              aria-expanded="false"
+            />
           </HStack>
+        ) : (
+          heading
         )}
+        <VStack
+          gap="x1"
+          hideBelow={isCollapsedOnBreakpoint ? collapsedBreakpoint : undefined}
+        >
+          {children}
+          {description && <div>{description}</div>}
+          {checkboxes && (
+            <VStack gap="x1">
+              {checkboxes.map((props, index) => (
+                <CookieBannerCheckbox {...props} key={index} />
+              ))}
+            </VStack>
+          )}
+          {buttons && (
+            <HStack
+              gap={applyResponsiveStyle('x1', 'sm', 'x1.5')}
+              flexWrap="wrap"
+              paddingBlock="x0.25 0"
+            >
+              {buttons.map(props => (
+                <Button {...props} size="medium" purpose="secondary" />
+              ))}
+            </HStack>
+          )}
+        </VStack>
       </VStack>
     </Paper>
   );

--- a/packages/dds-components/src/components/Feedback/RatingComponent.tsx
+++ b/packages/dds-components/src/components/Feedback/RatingComponent.tsx
@@ -2,8 +2,8 @@ import styles from './Feedback.module.css';
 import { type Layout, type Rating } from './Feedback.types';
 import { ThumbIcon } from './utils';
 import { cn } from '../../utils';
+import { StylelessButton } from '../helpers';
 import { focusable } from '../helpers/styling/focus.module.css';
-import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { HStack } from '../layout';
 import { Spinner } from '../Spinner';
 import { Tooltip } from '../Tooltip';
@@ -27,18 +27,13 @@ export const RatingComponent = ({
   handleRatingChange,
 }: RatingComponentType) => {
   const button = (rating: Rating, layout: Layout, tooltip: string) => (
-    <button
+    <StylelessButton
       aria-label={tooltip}
       onClick={() => handleRatingChange(rating)}
-      className={cn(
-        utilStyles['remove-button-styling'],
-        styles.button,
-        styles[`button--${layout}`],
-        focusable,
-      )}
+      className={cn(styles.button, styles[`button--${layout}`], focusable)}
     >
       {ThumbIcon({ rating, layout, type: 'rating' })}
-    </button>
+    </StylelessButton>
   );
 
   return (

--- a/packages/dds-components/src/components/Icon/icons.stories.tsx
+++ b/packages/dds-components/src/components/Icon/icons.stories.tsx
@@ -4,10 +4,9 @@ import { Icon } from './Icon';
 import { CopyIcon } from './icons/copy';
 import styles from './IconStory.module.css';
 import { type SvgIcon, type SvgProps } from './utils';
-import { cn, icons } from '../..';
+import { StylelessButton, cn, icons } from '../..';
 import { Button } from '../Button';
 import { focusable } from '../helpers/styling/focus.module.css';
-import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { LocalMessage } from '../LocalMessage';
 import { Modal, ModalBody } from '../Modal';
 import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
@@ -67,21 +66,17 @@ export const Overview = () => {
     return Object.entries(iconsObject).map(([key, value]) => {
       const trimmedName = trim(key);
       return (
-        <button
+        <StylelessButton
           key={key}
           onClick={() => onIconClick(key, value)}
           title={trimmedName}
-          className={cn(
-            styles.card,
-            utilStyles['remove-button-styling'],
-            focusable,
-          )}
+          className={cn(styles.card, focusable)}
         >
           <Icon iconSize="large" icon={value} />
           <Typography typographyType="bodyXsmall" className={styles.card__name}>
             {trimmedName}
           </Typography>
-        </button>
+        </StylelessButton>
       );
     });
   };

--- a/packages/dds-components/src/components/InlineButton/InlineButton.tsx
+++ b/packages/dds-components/src/components/InlineButton/InlineButton.tsx
@@ -2,18 +2,16 @@ import { type ComponentPropsWithRef } from 'react';
 
 import styles from './InlineButton.module.css';
 import { cn } from '../../utils';
+import { StylelessButton } from '../helpers';
 import focusStyles from '../helpers/styling/focus.module.css';
-import utilStyles from '../helpers/styling/utilStyles.module.css';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 export type InlineButtonProps = ComponentPropsWithRef<'button'>;
 
 export const InlineButton = ({ className, ...rest }: InlineButtonProps) => (
-  <button
+  <StylelessButton
     className={cn(
       className,
-      utilStyles['normalize-button'],
-      utilStyles['remove-button-styling'],
       focusStyles.focusable,
       typographyStyles.a,
       styles.button,

--- a/packages/dds-components/src/components/Search/SearchSuggestionItem.tsx
+++ b/packages/dds-components/src/components/Search/SearchSuggestionItem.tsx
@@ -2,8 +2,8 @@ import { type ComponentPropsWithRef, useEffect, useRef } from 'react';
 
 import { useCombinedRef } from '../../hooks';
 import { cn } from '../../utils';
+import { StylelessButton } from '../helpers';
 import focusStyles from '../helpers/styling/focus.module.css';
-import utilStyles from '../helpers/styling/utilStyles.module.css';
 import styles from '../OverflowMenu/OverflowMenu.module.css';
 
 export type SearchSuggestionItemProps = {
@@ -27,14 +27,13 @@ export const SearchSuggestionItem = ({
   }, [focus]);
 
   return (
-    <button
+    <StylelessButton
       ref={combinedRef}
       className={cn(
         className,
         styles.list__item,
         styles['list__item--link'],
         focusStyles['focusable--inset'],
-        utilStyles['normalize-button'],
       )}
       {...rest}
       tabIndex={focus ? 0 : -1}

--- a/packages/dds-components/src/components/Table/collapsible/CollapsibleRow.tsx
+++ b/packages/dds-components/src/components/Table/collapsible/CollapsibleRow.tsx
@@ -14,7 +14,7 @@ import {
   spaceSeparatedIdListGenerator,
 } from '../../../utils';
 import { DescriptionList, DescriptionListTerm } from '../../DescriptionList';
-import { AnimatedChevronUpDown } from '../../helpers';
+import { AnimatedChevronUpDown, StylelessButton } from '../../helpers';
 import { focusable } from '../../helpers/styling/focus.module.css';
 import utilStyles from '../../helpers/styling/utilStyles.module.css';
 import { VisuallyHidden } from '../../VisuallyHidden';
@@ -133,23 +133,18 @@ export const CollapsibleRow = ({
       <Row ref={ref} {...rowProps(!childrenCollapsed && true)}>
         {definingColumnCells}
         <Table.Cell>
-          <button
+          <StylelessButton
             onClick={() => setChildrenCollapsed(!childrenCollapsed)}
             aria-expanded={!childrenCollapsed}
             aria-controls={idList}
-            className={cn(
-              styles['collapse-button'],
-              utilStyles['normalize-button'],
-              utilStyles['remove-button-styling'],
-              focusable,
-            )}
+            className={cn(styles['collapse-button'], focusable)}
           >
             <AnimatedChevronUpDown
               isUp={childrenCollapsed ? false : true}
               height="8px"
               width="12px"
             />
-          </button>
+          </StylelessButton>
         </Table.Cell>
       </Row>
     );

--- a/packages/dds-components/src/components/Table/collapsible/CollapsibleRow.tsx
+++ b/packages/dds-components/src/components/Table/collapsible/CollapsibleRow.tsx
@@ -16,7 +16,6 @@ import {
 import { DescriptionList, DescriptionListTerm } from '../../DescriptionList';
 import { AnimatedChevronUpDown, StylelessButton } from '../../helpers';
 import { focusable } from '../../helpers/styling/focus.module.css';
-import utilStyles from '../../helpers/styling/utilStyles.module.css';
 import { VisuallyHidden } from '../../VisuallyHidden';
 import { Table, type TableRowProps } from '../normal';
 import { Cell, type TableCellProps } from '../normal/Cell';

--- a/packages/dds-components/src/components/Table/normal/SortCell.tsx
+++ b/packages/dds-components/src/components/Table/normal/SortCell.tsx
@@ -5,7 +5,6 @@ import styles from './Table.module.css';
 import { cn } from '../../../utils';
 import { StylelessButton } from '../../helpers';
 import { focusable } from '../../helpers/styling/focus.module.css';
-import utilStyles from '../../helpers/styling/utilStyles.module.css';
 import { Icon } from '../../Icon';
 import {
   ChevronDownIcon,

--- a/packages/dds-components/src/components/Table/normal/SortCell.tsx
+++ b/packages/dds-components/src/components/Table/normal/SortCell.tsx
@@ -3,6 +3,7 @@ import { type MouseEvent } from 'react';
 import { Cell, type TableCellProps } from './Cell';
 import styles from './Table.module.css';
 import { cn } from '../../../utils';
+import { StylelessButton } from '../../helpers';
 import { focusable } from '../../helpers/styling/focus.module.css';
 import utilStyles from '../../helpers/styling/utilStyles.module.css';
 import { Icon } from '../../Icon';
@@ -47,18 +48,13 @@ export const SortCell = ({
     aria-sort={isSorted && sortOrder ? sortOrder : undefined}
     {...rest}
   >
-    <button
+    <StylelessButton
       onClick={onClick}
       aria-description="Aktiver for å endre sorteringsrekkefølge"
-      className={cn(
-        utilStyles['normalize-button'],
-        utilStyles['remove-button-styling'],
-        styles['sort-button'],
-        focusable,
-      )}
+      className={cn(styles['sort-button'], focusable)}
     >
       {children} {makeSortIcon(isSorted, sortOrder)}
-    </button>
+    </StylelessButton>
   </Cell>
 );
 

--- a/packages/dds-components/src/components/helpers/StylelessButton/StylelessButton.tsx
+++ b/packages/dds-components/src/components/helpers/StylelessButton/StylelessButton.tsx
@@ -1,0 +1,21 @@
+import { type ComponentPropsWithRef } from 'react';
+
+import { cn } from '../../../utils';
+import utilStyles from '../styling/utilStyles.module.css';
+
+export type StylelessButtonProps<TProps extends object = object> = TProps &
+  ComponentPropsWithRef<'button'>;
+
+export const StylelessButton = ({
+  className,
+  ...rest
+}: StylelessButtonProps) => (
+  <button
+    {...rest}
+    className={cn(
+      className,
+      utilStyles['remove-button-styling'],
+      utilStyles['normalize-button'],
+    )}
+  />
+);

--- a/packages/dds-components/src/components/helpers/StylelessButton/index.tsx
+++ b/packages/dds-components/src/components/helpers/StylelessButton/index.tsx
@@ -1,0 +1,1 @@
+export * from './StylelessButton';

--- a/packages/dds-components/src/components/helpers/index.ts
+++ b/packages/dds-components/src/components/helpers/index.ts
@@ -4,5 +4,6 @@ export * from './ElementAs';
 export * from './HiddenInput';
 export * from './Input';
 export * from './ScreenSize';
+export * from './StylelessButton';
 export * from './StylelessList';
 export * from './styling';


### PR DESCRIPTION
## Beskrivelse

Brukes til sammentrukket versjon av banneren på siden med detaljer om informasjonskapsler. Detaljer i retningerlinjer i mdx-fila.

![image](https://github.com/user-attachments/assets/95a03c46-e5a9-46fa-9d1c-bc019d7af838)


Lagde også StylelessButton da jeg trodde den var relevant; var ikke det likevel, men den er fortsatt nytting og jeg migrerte relevante knapper på tvers av biblioteket.


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
