### PR TITLE
ELSA1-636 `<DatePicker>` blir ikke påvirket av `width` prop

### DIFF
--- a/.changeset/happy-lines-add.md
+++ b/.changeset/happy-lines-add.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<DatePicker>` ikke ble påvirket av `width` prop.

--- a/packages/dds-components/src/components/TextInput/TextInput.module.css
+++ b/packages/dds-components/src/components/TextInput/TextInput.module.css
@@ -10,10 +10,6 @@
   color: var(--dds-color-text-subtle);
 }
 
-.input-width {
-  width: var(--dds-textinput-width);
-}
-
 .input {
   &.with-icon--medium {
     padding-left: calc(

--- a/packages/dds-components/src/components/date-inputs/common/DateInput.module.css
+++ b/packages/dds-components/src/components/date-inputs/common/DateInput.module.css
@@ -3,7 +3,6 @@
   flex-direction: row;
   align-items: center;
   gap: var(--dds-spacing-x0-25);
-  width: var(--dds-date-input-width);
 }
 
 .date-input--medium {


### PR DESCRIPTION
## Beskrivelse

Fjerner CSS som overskriver propen. Fjerner også ubrukt width-relatert kode  i `<TextInput>` CSS.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
