### PR TITLE
ELSA1-637 `<Checkbox>` indeterminate-styling bug

### DIFF
--- a/.changeset/real-moments-know.md
+++ b/.changeset/real-moments-know.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<Checkbox>` fikk indeterminate-styling selv om `indeterminate` prop var satt til `false`.

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.spec.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.spec.tsx
@@ -38,6 +38,11 @@ describe('<Checkbox>', () => {
     await userEvent.click(checkbox);
     expect(checkbox).not.toBeChecked();
   });
+  it('should be indeterminate', async () => {
+    render(<Checkbox indeterminate />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toHaveAttribute('aria-checked', 'mixed');
+  });
   describe('<CheckboxGroup>', () => {
     it('children of CheckboxGroup should have accessible description when tip provided', () => {
       const tip = 'tip';

--- a/packages/dds-components/src/components/SelectionControl/SelectionControl.module.css
+++ b/packages/dds-components/src/components/SelectionControl/SelectionControl.module.css
@@ -45,13 +45,13 @@
   }
 
   input:checked ~ .selection-control,
-  input[data-indeterminate] ~ .selection-control {
+  input[data-indeterminate='true'] ~ .selection-control {
     border-color: var(--dds-color-surface-action-selected);
     background-color: var(--dds-color-surface-action-selected);
   }
 
   input:checked[aria-readonly='true'] ~ .selection-control,
-  input[data-indeterminate][aria-readonly='true'] ~ .selection-control {
+  input[data-indeterminate='true'][aria-readonly='true'] ~ .selection-control {
     border-color: var(--dds-color-surface-action-selected-disabled);
     background-color: var(--dds-color-surface-action-selected-disabled);
   }
@@ -59,7 +59,7 @@
   &:hover {
     input:enabled:not([aria-readonly='true']) {
       &:checked[type='checkbox'],
-      &[data-indeterminate] {
+      &[data-indeterminate='true'] {
         ~ .selection-control {
           background-color: var(--dds-color-surface-action-hover);
           border-color: var(--dds-color-surface-action-hover);
@@ -70,7 +70,7 @@
 }
 
 input:checked ~ .selection-control:after,
-input[data-indeterminate] ~ .selection-control:after {
+input[data-indeterminate='true'] ~ .selection-control:after {
   display: block;
 }
 
@@ -85,7 +85,7 @@ input[data-indeterminate] ~ .selection-control:after {
     transform: rotate(45deg);
   }
 
-  input[data-indeterminate] ~ .selection-control:after {
+  input[data-indeterminate='true'] ~ .selection-control:after {
     border-width: 1px 0 0 0;
     left: 25%;
     top: 50%;
@@ -113,7 +113,7 @@ input[data-indeterminate] ~ .selection-control:after {
     border-color: var(--dds-color-border-subtle);
   }
   input:checked ~ .selection-control,
-  input[data-indeterminate] ~ .selection-control {
+  input[data-indeterminate='true'] ~ .selection-control {
     border-color: var(--dds-color-surface-action-selected-disabled);
     background-color: var(--dds-color-surface-action-selected-disabled);
   }
@@ -126,7 +126,7 @@ input[data-indeterminate] ~ .selection-control:after {
       background-color: var(--dds-color-surface-field-disabled);
     }
     input:checked ~ .selection-control,
-    input[data-indeterminate] ~ .selection-control {
+    input[data-indeterminate='true'] ~ .selection-control {
       border-color: var(--dds-color-surface-action-selected-disabled);
       background-color: var(--dds-color-surface-action-selected-disabled);
     }


### PR DESCRIPTION
## Beskrivelse

Fikser bug der `<Checkbox>` fikk indeterminate-styling selv om `indeterminate` prop var satt til `false`.

Slenger på en manglende test som sjekker om indeterminate-tilstand blir satt på `<input>`.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
