### PR TITLE
ELSA1-169 Intern i18n støtte

### DIFF
--- a/.changeset/curvy-pigs-rhyme.md
+++ b/.changeset/curvy-pigs-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Intern støtte for i18n i komponenter via ny provider. Gjelder statiske, hovedsakelig usynlige tekster for UU/skjermleser, men også noen synlige. Bruker `'nb'` som default inntil videre, og vil dermed ikke føre til noen endringer hos konsumenter i denne release. Default blir fjernet i neste major release, med påkrevd bruk av `<DdsProvider>`.

--- a/.changeset/early-buckets-like.md
+++ b/.changeset/early-buckets-like.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Ny komponent: `<DdsProvider>`. Slår sammen `<LanguageProvider>` og `<ThemeProvider>`. Blir påkrevd å bruke i neste major release istedenfor `<ThemeProvider>`; må ikke brukes enda grunnet default språk inntil videre.

--- a/.changeset/fresh-rockets-rush.md
+++ b/.changeset/fresh-rockets-rush.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Utbedrer noen statiske usynlige ledetekster og beskrivelser for UU/skjermleser.

--- a/packages/dds-components/src/DdsProvider/DdsProvider.tsx
+++ b/packages/dds-components/src/DdsProvider/DdsProvider.tsx
@@ -1,0 +1,13 @@
+import {
+  ThemeProvider,
+  type ThemeProviderProps,
+} from '../components/ThemeProvider';
+import { type LanguageContextProps, LanguageProvider } from '../i18n';
+
+export type DdsProviderProps = LanguageContextProps & ThemeProviderProps;
+
+export function DdsProvider({ language, theme, children }: DdsProviderProps) {
+  <LanguageProvider language={language}>
+    <ThemeProvider theme={theme}>{children}</ThemeProvider>
+  </LanguageProvider>;
+}

--- a/packages/dds-components/src/DdsProvider/index.ts
+++ b/packages/dds-components/src/DdsProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './DdsProvider';

--- a/packages/dds-components/src/components/BackLink/BackLink.stories.tsx
+++ b/packages/dds-components/src/components/BackLink/BackLink.stories.tsx
@@ -1,10 +1,11 @@
-import { type StoryObj } from '@storybook/react-vite';
+import { type Meta, type StoryObj } from '@storybook/react-vite';
 
+import { LanguageProvider } from '../../i18n';
 import { categoryHtml, htmlEventArgType } from '../../storybook/helpers';
 
 import { BackLink } from '.';
 
-export default {
+const meta: Meta<typeof BackLink> = {
   title: 'dds-components/Components/BackLink',
   component: BackLink,
   parameters: {
@@ -19,7 +20,16 @@ export default {
     },
     onClick: htmlEventArgType,
   },
+  decorators: [
+    Story => (
+      <LanguageProvider language="nb">
+        <Story />
+      </LanguageProvider>
+    ),
+  ],
 };
+
+export default meta;
 
 type Story = StoryObj<typeof BackLink>;
 

--- a/packages/dds-components/src/components/BackLink/BackLink.tsx
+++ b/packages/dds-components/src/components/BackLink/BackLink.tsx
@@ -1,6 +1,7 @@
 import { type ComponentPropsWithRef } from 'react';
 
 import styles from './BackLink.module.css';
+import { createTexts, useTranslation } from '../../i18n';
 import { Icon } from '../Icon';
 import { ArrowLeftIcon } from '../Icon/icons';
 import { Link } from '../Typography';
@@ -13,8 +14,9 @@ export type BackLinkProps = {
 } & Pick<ComponentPropsWithRef<'a'>, 'onClick' | 'href' | 'ref'>;
 
 export const BackLink = ({ label, ref, ...rest }: BackLinkProps) => {
+  const { t } = useTranslation();
   return (
-    <nav ref={ref} aria-label="Gå tilbake">
+    <nav ref={ref} aria-label={t(texts.goBack)}>
       <Link {...rest}>
         <Icon icon={ArrowLeftIcon} iconSize="inherit" className={styles.icon} />
         {label}
@@ -24,3 +26,12 @@ export const BackLink = ({ label, ref, ...rest }: BackLinkProps) => {
 };
 
 BackLink.displayName = 'BackLink';
+
+const texts = createTexts({
+  goBack: {
+    nb: 'Gå tilbake',
+    no: 'Gå tilbake',
+    nn: 'Gå tilbake',
+    en: 'Go back',
+  },
+});

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.spec.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.spec.tsx
@@ -35,7 +35,7 @@ describe('<Breadcrumbs>', () => {
   it('should have nav with accessible name', () => {
     render(<Breadcrumbs />);
     const breadcrumbs = screen.getByRole('navigation');
-    expect(breadcrumbs).toHaveAccessibleName('brødsmulesti');
+    expect(breadcrumbs).toHaveAccessibleName('Brødsmulesti');
   });
   it('should render 4 breadcrumbs', () => {
     render(<TestComponent />);
@@ -50,7 +50,7 @@ describe('<Breadcrumbs>', () => {
     it('should render button for truncated children', () => {
       render(<TestComponentSmallScreen />);
       const button = screen.getByRole('button');
-      expect(button).toHaveAccessibleName('Vis brødsmulesti brødsmule 2 til 3');
+      expect(button).toHaveAccessibleName('Vis brødsmule 2 til 3');
       expect(button).toHaveAttribute('aria-expanded', 'false');
     });
     it('should show menu on button click', async () => {

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
+import { LanguageProvider } from '../../i18n';
 import { commonArgTypes, windowWidthDecorator } from '../../storybook/helpers';
 import { StoryVStack } from '../layout/Stack/utils';
 
@@ -17,6 +18,13 @@ const meta: Meta<typeof Breadcrumbs> = {
   argTypes: {
     ...commonArgTypes,
   },
+  decorators: [
+    Story => (
+      <LanguageProvider language="nb">
+        <Story />
+      </LanguageProvider>
+    ),
+  ],
 };
 
 export default meta;
@@ -55,7 +63,7 @@ export const SmallScreen: Story = {
   },
 };
 
-export const responsive: Story = {
+export const Responsive: Story = {
   args: {
     children,
     smallScreenBreakpoint: 'sm',

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,7 @@
 import { Children, isValidElement } from 'react';
 
 import styles from './Breadcrumbs.module.css';
+import { createTexts, useTranslation } from '../../i18n';
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
@@ -46,7 +47,7 @@ export const Breadcrumbs = ({
       icon={ChevronRightIcon}
     />
   );
-
+  const { t } = useTranslation();
   const childrenArray = Children.toArray(children);
 
   const responsiveLiProps: HStackProps<'li'> = {
@@ -56,7 +57,7 @@ export const Breadcrumbs = ({
     padding: 'x0',
   };
 
-  const breadcrumbChildren = childrenArray.map((item, index) => {
+  const bChildren = childrenArray.map((item, index) => {
     return (
       <HStack
         key={`breadcrumb-${index}`}
@@ -69,7 +70,7 @@ export const Breadcrumbs = ({
     );
   });
 
-  const breadcrumbChildrenTruncated =
+  const bChildrenTruncated =
     childrenArray.length > 2
       ? childrenArray.slice(1, childrenArray.length - 1).map((item, index) => {
           if (isValidElement<BreadcrumbProps>(item)) {
@@ -89,10 +90,10 @@ export const Breadcrumbs = ({
         })
       : [];
 
-  const breadcrumbChildrenSmallScreen = (
+  const bChildrenSmallScreen = (
     <>
       <HStack {...responsiveLiProps}>{childrenArray[0]}</HStack>
-      {breadcrumbChildrenTruncated.length > 0 && (
+      {bChildrenTruncated.length > 0 && (
         <HStack {...responsiveLiProps}>
           {chevronIcon}
           <OverflowMenuGroup>
@@ -100,10 +101,14 @@ export const Breadcrumbs = ({
               size="xsmall"
               icon={MoreHorizontalIcon}
               purpose="tertiary"
-              aria-label={`Vis brødsmulesti brødsmule 2 ${breadcrumbChildrenTruncated.length > 1 && `til ${breadcrumbChildren.length - 1}`}`}
+              aria-label={
+                bChildrenTruncated.length > 1
+                  ? t(texts.showHiddenTo(bChildren.length - 1))
+                  : t(texts.showHidden)
+              }
             />
             <OverflowMenu>
-              <OverflowMenuList>{breadcrumbChildrenTruncated}</OverflowMenuList>
+              <OverflowMenuList>{bChildrenTruncated}</OverflowMenuList>
             </OverflowMenu>
           </OverflowMenuGroup>
         </HStack>
@@ -126,17 +131,17 @@ export const Breadcrumbs = ({
   return (
     <nav
       {...getBaseHTMLProps(id, className, htmlProps, rest)}
-      aria-label="brødsmulesti"
+      aria-label={t(texts.breadcrumbs)}
     >
       <HStack
         {...responsiveListProps}
         hideBelow={hasSmallScreenBreakpoint ? smallScreenBreakpoint : undefined}
       >
-        {breadcrumbChildren}
+        {bChildren}
       </HStack>
       {hasSmallScreenBreakpoint && (
         <HStack {...responsiveListProps} showBelow={smallScreenBreakpoint}>
-          {breadcrumbChildrenSmallScreen}
+          {bChildrenSmallScreen}
         </HStack>
       )}
     </nav>
@@ -144,3 +149,24 @@ export const Breadcrumbs = ({
 };
 
 Breadcrumbs.displayName = 'Breadcrumbs';
+
+const texts = createTexts({
+  breadcrumbs: {
+    nb: 'Brødsmulesti',
+    no: 'Brødsmulesti',
+    nn: 'Brødsmulesti',
+    en: 'Breadcrumbs',
+  },
+  showHiddenTo: to => ({
+    nb: `Vis brødsmule 2 til ${to}`,
+    no: `Vis brødsmule 2 til ${to}`,
+    nn: `Vis brødsmule 2 til ${to}`,
+    en: `Show breadcrumb 2 to ${to}`,
+  }),
+  showHidden: {
+    nb: 'Vis brødsmule 2',
+    no: 'Vis brødsmule 2',
+    nn: 'Vis brødsmule 2',
+    en: 'Show breadcrumb 2',
+  },
+});

--- a/packages/dds-components/src/components/Chip/Chip.tsx
+++ b/packages/dds-components/src/components/Chip/Chip.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import styles from './Chip.module.css';
+import { createTexts, useTranslation } from '../../i18n';
 import { type BaseComponentProps, getBaseHTMLProps } from '../../types';
 import { cn } from '../../utils/dom';
 import { Button } from '../Button';
@@ -26,6 +27,7 @@ export const Chip = ({
   htmlProps = {},
   ...rest
 }: ChipProps) => {
+  const { t } = useTranslation();
   const { 'aria-label': ariaLabel, ...restHTMLprops } = htmlProps;
 
   const [isOpen, setIsOpen] = useState(true);
@@ -52,10 +54,19 @@ export const Chip = ({
         icon={CloseSmallIcon}
         purpose="tertiary"
         onClick={onClick}
-        aria-label={ariaLabel ?? `Fjern ${text ? `chip ${text}` : 'chip'}`}
+        aria-label={ariaLabel ?? t(texts.removeChip) + (text ? ` ${text}` : '')}
       />
     </div>
   ) : null;
 };
 
 Chip.displayName = 'Chip';
+
+const texts = createTexts({
+  removeChip: {
+    nb: 'Fjern chip',
+    no: 'Fjern chip',
+    nn: 'Fjern chip',
+    en: 'Remove chip',
+  },
+});

--- a/packages/dds-components/src/components/Contrast/Contrast.stories.tsx
+++ b/packages/dds-components/src/components/Contrast/Contrast.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
+import { LanguageProvider } from '../../i18n';
 import { BackLink } from '../BackLink';
 import { Breadcrumb, Breadcrumbs } from '../Breadcrumbs';
 import {
@@ -9,12 +10,13 @@ import {
 } from '../DescriptionList';
 import { Icon } from '../Icon';
 import { ArrowLeftIcon } from '../Icon/icons';
+import { VStack } from '../layout';
 import { List, ListItem } from '../List';
 import { Link, Paragraph } from '../Typography';
 
 import { Contrast } from '.';
 
-export default {
+const meta: Meta<typeof Contrast> = {
   title: 'dds-components/Components/Contrast',
   component: Contrast,
   parameters: {
@@ -26,8 +28,16 @@ export default {
   argTypes: {
     as: { control: 'text' },
   },
-} satisfies Meta<typeof Contrast>;
+  decorators: [
+    Story => (
+      <LanguageProvider language="nb">
+        <Story />
+      </LanguageProvider>
+    ),
+  ],
+};
 
+export default meta;
 type Story = StoryObj<typeof Contrast>;
 
 export const Default: Story = {
@@ -42,31 +52,25 @@ export const Default: Story = {
 };
 export const Examples: Story = {
   render: args => (
-    <Contrast
-      {...args}
-      style={{
-        padding: 'var(--dds-spacing-x2)',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 'var(--dds-spacing-x1)',
-      }}
-    >
-      <Icon icon={ArrowLeftIcon} />
-      <Paragraph>Tekst</Paragraph>
-      <Link>Lenke</Link>
-      <Breadcrumbs>
-        <Breadcrumb href="/">Side 1</Breadcrumb>
-        <Breadcrumb>Side 2</Breadcrumb>
-      </Breadcrumbs>
-      <BackLink href="/" label="Forrige side" />
-      <DescriptionList>
-        <DescriptionListTerm>Tittel</DescriptionListTerm>
-        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-      </DescriptionList>
-      <List>
-        <ListItem>Listeelement</ListItem>
-        <ListItem>Listeelement</ListItem>
-      </List>
+    <Contrast {...args}>
+      <VStack padding="x2" gap="x1">
+        <Icon icon={ArrowLeftIcon} />
+        <Paragraph>Tekst</Paragraph>
+        <Link>Lenke</Link>
+        <Breadcrumbs>
+          <Breadcrumb href="/">Side 1</Breadcrumb>
+          <Breadcrumb>Side 2</Breadcrumb>
+        </Breadcrumbs>
+        <BackLink href="/" label="Forrige side" />
+        <DescriptionList>
+          <DescriptionListTerm>Tittel</DescriptionListTerm>
+          <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+        </DescriptionList>
+        <List>
+          <ListItem>Listeelement</ListItem>
+          <ListItem>Listeelement</ListItem>
+        </List>
+      </VStack>
     </Contrast>
   ),
 };

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.stories.tsx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import { CookieBanner } from './CookieBanner';
+import { LanguageProvider } from '../../i18n';
 import {
   categoryHtml,
   htmlPropsArgType,
@@ -14,7 +15,7 @@ import { Link } from '../Typography';
 const { position, left, right, top, bottom, maxHeight, width } =
   responsivePropsArgTypes;
 
-export default {
+const meta: Meta<typeof CookieBanner> = {
   title: 'dds-components/Components/CookieBanner',
   component: CookieBanner,
   argTypes: {
@@ -34,7 +35,16 @@ export default {
       canvas: { sourceState: 'shown' },
     },
   },
-} satisfies Meta<typeof CookieBanner>;
+  decorators: [
+    Story => (
+      <LanguageProvider language="nb">
+        <Story />
+      </LanguageProvider>
+    ),
+  ],
+};
+
+export default meta;
 
 type Story = StoryObj<typeof CookieBanner>;
 

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.tsx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useState } from 'react';
 
+import { createTexts, useTranslation } from '../../i18n';
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
@@ -50,13 +51,16 @@ export function CookieBanner({
   id,
   className,
   htmlProps,
-  'aria-label': ariaLabel = 'Samtykke for bruk av informasjonskapsler',
+  'aria-label': ariaLabel,
   maxHeight = 'calc(100vh - 100px)',
   width = 'fit-content',
   children,
   collapsedBreakpoint,
   ...rest
 }: CookieBannerProps) {
+  const { t } = useTranslation();
+  const tAriaLabel = ariaLabel ?? t(texts.consent);
+
   const hasBp = !!collapsedBreakpoint;
   const [isCollapsedOnBreakpoint, setIsCollapsedOnBreakpoint] = useState(hasBp);
   const heading = headerText ? (
@@ -75,7 +79,7 @@ export function CookieBanner({
         rest,
       )}
       role="region"
-      aria-label={ariaLabel}
+      aria-label={tAriaLabel}
       padding={applyResponsiveStyle('x1', 'sm', 'x1.5')}
       width={width}
       maxHeight={maxHeight}
@@ -89,7 +93,7 @@ export function CookieBanner({
             <ShowHide
               as={Button}
               showBelow={collapsedBreakpoint}
-              aria-label="Utvid samtykke for bruk av informasjonskapsler"
+              aria-label={t(texts.expandConsent)}
               purpose="tertiary"
               icon={ExpandIcon}
               onClick={() => setIsCollapsedOnBreakpoint(false)}
@@ -130,3 +134,18 @@ export function CookieBanner({
 }
 
 CookieBanner.displayName = 'CookieBanner';
+
+const texts = createTexts({
+  expandConsent: {
+    nb: 'Utvid samtykke for bruk av informasjonskapsler',
+    no: 'Utvid samtykke for bruk av informasjonskapsler',
+    nn: 'Utvid samtykke for bruk av informasjonskapslar',
+    en: 'Expand consent for the use of cookies',
+  },
+  consent: {
+    nb: 'Samtykke for bruk av informasjonskapsler',
+    no: 'Samtykke for bruk av informasjonskapsler',
+    nn: 'Samtykke for bruk av informasjonskapslar',
+    en: 'Consent for the use of cookies',
+  },
+});

--- a/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
@@ -2,6 +2,7 @@ import { type Story } from '@storybook/addon-docs/blocks';
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
+import { LanguageProvider } from '../../i18n';
 import { htmlPropsArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
@@ -26,9 +27,11 @@ const meta: Meta<typeof Drawer> = {
   },
   decorators: [
     Story => (
-      <StoryThemeProvider>
-        <Story />
-      </StoryThemeProvider>
+      <LanguageProvider language="en">
+        <StoryThemeProvider>
+          <Story />
+        </StoryThemeProvider>
+      </LanguageProvider>
     ),
   ],
 };
@@ -56,7 +59,7 @@ export const Default: Story = {
   ),
 };
 
-export const withBackdrop: Story = {
+export const WithBackdrop: Story = {
   args: { header: 'Tittel' },
   render: args => (
     <DrawerGroup>

--- a/packages/dds-components/src/components/Drawer/Drawer.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.tsx
@@ -14,6 +14,8 @@ import {
   useMountTransition,
   useOnClickOutside,
 } from '../../hooks';
+import { useTranslation } from '../../i18n';
+import { commonTexts } from '../../i18n/commonTexts';
 import {
   type BaseComponentPropsWithChildren,
   type Size,
@@ -89,6 +91,7 @@ export const Drawer = ({
   if (!themeContext) {
     throw new Error('Drawer must be used within a ThemeProvider');
   }
+  const { t } = useTranslation();
 
   const portalTarget = parentElement ?? themeContext?.el;
 
@@ -201,7 +204,7 @@ export const Drawer = ({
           size="small"
           purpose="tertiary"
           onClick={onClose}
-          aria-label="Lukk"
+          aria-label={t(commonTexts.close)}
           icon={CloseIcon}
         />
       </HStack>

--- a/packages/dds-components/src/components/FavStar/FavStar.tsx
+++ b/packages/dds-components/src/components/FavStar/FavStar.tsx
@@ -2,6 +2,7 @@ import { type HTMLAttributes, useId } from 'react';
 
 import styles from './FavStar.module.css';
 import { useControllableState } from '../../hooks/useControllableState';
+import { createTexts, useTranslation } from '../../i18n';
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
@@ -49,6 +50,7 @@ export const FavStar = ({
   htmlProps,
   ...rest
 }: FavStarProps) => {
+  const { t } = useTranslation();
   const { style, ...props } = getBaseHTMLProps(
     id,
     cn(className),
@@ -78,7 +80,7 @@ export const FavStar = ({
         checked={checked}
         onChange={e => setChecked(e.target.checked)}
         type="checkbox"
-        aria-label={props['aria-label'] ?? 'Favoriser'}
+        aria-label={props['aria-label'] ?? t(texts.favourite)}
         className={utilStyles['hide-input']}
       />
       <Icon iconSize={size} icon={StarIcon} className={styles.icon} />
@@ -92,3 +94,12 @@ export const FavStar = ({
 };
 
 FavStar.displayName = 'FavStar';
+
+const texts = createTexts({
+  favourite: {
+    nb: 'Favoriser',
+    no: 'Favoriser',
+    nn: 'Favoriser',
+    en: 'Favorite',
+  },
+});

--- a/packages/dds-components/src/components/Feedback/CommentComponent.tsx
+++ b/packages/dds-components/src/components/Feedback/CommentComponent.tsx
@@ -5,6 +5,7 @@ import { VStack } from '../layout';
 import { TextArea } from '../TextArea';
 import { Paragraph } from '../Typography';
 import { ThumbIcon } from './utils';
+import { createTexts, useTranslation } from '../../i18n';
 
 interface CommentComponentType {
   layout: Layout;
@@ -31,6 +32,7 @@ export const CommentComponent = ({
   handleSubmit,
   handleFeedbackTextChange,
 }: CommentComponentType) => {
+  const { t } = useTranslation();
   return (
     <VStack gap="x1">
       <span className={styles['rating-submitted-title']}>
@@ -54,8 +56,17 @@ export const CommentComponent = ({
         onClick={handleSubmit}
         loading={loading}
       >
-        Send inn
+        {t(texts.send)}
       </Button>
     </VStack>
   );
 };
+
+const texts = createTexts({
+  send: {
+    nb: 'Send inn',
+    no: 'Send inn',
+    nn: 'Send inn',
+    en: 'Send',
+  },
+});

--- a/packages/dds-components/src/components/Feedback/Feedback.tsx
+++ b/packages/dds-components/src/components/Feedback/Feedback.tsx
@@ -3,20 +3,21 @@ import { useEffect, useState } from 'react';
 import { CommentComponent } from './CommentComponent';
 import { type FeedbackProps, type Rating } from './Feedback.types';
 import { RatingComponent } from './RatingComponent';
+import { createTexts, useTranslation } from '../../i18n';
 import { Paragraph } from '../Typography';
 
 export const Feedback = ({
   layout = 'vertical',
-  ratingLabel = 'Hva syns du om tjenesten?',
-  positiveFeedbackLabel = 'Hva kan vi forbedre? (valgfritt)',
-  negativeFeedbackLabel = 'Hva kan vi forbedre? (valgfritt)',
-  ratingSubmittedTitle = 'Tusen takk! Tilbakemeldingen din hjelper oss å forbedre løsningen',
-  submittedTitle = 'Tusen takk! Tilbakemeldingen din hjelper oss å forbedre løsningen',
-  textAreaTip = 'Ikke send inn personopplysninger eller annen sensitiv informasjon',
+  ratingLabel,
+  positiveFeedbackLabel,
+  negativeFeedbackLabel,
+  ratingSubmittedTitle,
+  submittedTitle,
+  textAreaTip,
   ratingValue: ratingProp,
   feedbackTextValue: feedbackTextProp,
-  thumbUpTooltip = 'Bra',
-  thumbDownTooltip = 'Dårlig',
+  thumbUpTooltip,
+  thumbDownTooltip,
   feedbackTextAreaExcluded = false,
   loading = false,
   isSubmitted: isSubmittedProp,
@@ -24,10 +25,21 @@ export const Feedback = ({
   onFeedbackTextChange,
   onSubmit,
 }: FeedbackProps) => {
+  const { t } = useTranslation();
   const [rating, setRating] = useState<Rating | null>(null);
   const [feedbackText, setFeedbackText] = useState<string>();
   const [isFeedbackSubmitted, setIsFeedbackSubmitted] =
     useState<boolean>(false);
+  const tRatingLabel = ratingLabel ?? t(texts.improvalQuestion);
+  const tPositiveFeedbackLabel =
+    positiveFeedbackLabel ?? t(texts.improvalQuestion);
+  const tNegativeFeedbackLabel =
+    negativeFeedbackLabel ?? t(texts.improvalQuestion);
+  const tRatingSubmittedTitle = ratingSubmittedTitle ?? t(texts.thanks);
+  const tSubmittedTitle = submittedTitle ?? t(texts.thanks);
+  const tTextAreaTip = textAreaTip ?? t(texts.sensitiveInfo);
+  const tThumbUpTooltip = thumbUpTooltip ?? t(texts.good);
+  const tThumbDownTooltip = thumbDownTooltip ?? t(texts.bad);
 
   useEffect(() => {
     ratingProp !== undefined && setRating(ratingProp);
@@ -63,10 +75,10 @@ export const Feedback = ({
     return (
       <RatingComponent
         layout={layout}
-        ratingLabel={ratingLabel}
+        ratingLabel={tRatingLabel}
         loading={loading}
-        thumbUpTooltip={thumbUpTooltip}
-        thumbDownTooltip={thumbDownTooltip}
+        thumbUpTooltip={tThumbUpTooltip}
+        thumbDownTooltip={tThumbDownTooltip}
         handleRatingChange={handleRatingChange}
       />
     );
@@ -78,10 +90,10 @@ export const Feedback = ({
         layout={layout}
         rating={rating}
         feedbackText={feedbackText}
-        positiveFeedbackLabel={positiveFeedbackLabel}
-        negativeFeedbackLabel={negativeFeedbackLabel}
-        ratingSubmittedTitle={ratingSubmittedTitle}
-        textAreaTip={textAreaTip}
+        positiveFeedbackLabel={tPositiveFeedbackLabel}
+        negativeFeedbackLabel={tNegativeFeedbackLabel}
+        ratingSubmittedTitle={tRatingSubmittedTitle}
+        textAreaTip={tTextAreaTip}
         loading={loading}
         handleSubmit={handleSubmit}
         handleFeedbackTextChange={handleFeedbackTextChange}
@@ -89,5 +101,44 @@ export const Feedback = ({
     );
   }
 
-  return <Paragraph>{submittedTitle}</Paragraph>;
+  return <Paragraph>{tSubmittedTitle}</Paragraph>;
 };
+
+const texts = createTexts({
+  ratingQuestion: {
+    nb: 'Hva syns du om tjenesten?',
+    no: 'Hva syns du om tjenesten?',
+    nn: 'Kva synest du om tenesta?',
+    en: 'What do you think about the service?',
+  },
+  improvalQuestion: {
+    nb: 'Hva kan vi forbedre? (valgfritt)',
+    no: 'Hva kan vi forbedre? (valgfritt)',
+    nn: 'Kva kan vi forbetre? (valfritt)',
+    en: 'What can we improve? (optional)',
+  },
+  thanks: {
+    nb: 'Tusen takk! Tilbakemeldingen din hjelper oss å forbedre løsningen',
+    no: 'Tusen takk! Tilbakemeldingen din hjelper oss å forbedre løsningen',
+    nn: 'Tusen takk! Tilbakemeldinga di hjelper oss å forbetre løysinga',
+    en: 'Thank you! Your feedback helps us improve the solution',
+  },
+  sensitiveInfo: {
+    nb: 'Ikke send inn personopplysninger eller annen sensitiv informasjon',
+    no: 'Ikke send inn personopplysninger eller annen sensitiv informasjon',
+    nn: 'Ikkje send inn personopplysningar eller annan sensitiv informasjon',
+    en: 'Do not submit personal data or other sensitive information',
+  },
+  good: {
+    nb: 'Bra',
+    no: 'Bra',
+    nn: 'Bra',
+    en: 'Good',
+  },
+  bad: {
+    nb: 'Dårlig',
+    no: 'Dårlig',
+    nn: 'Dårleg',
+    en: 'Bad',
+  },
+});

--- a/packages/dds-components/src/components/Feedback/RatingComponent.tsx
+++ b/packages/dds-components/src/components/Feedback/RatingComponent.tsx
@@ -1,6 +1,7 @@
 import styles from './Feedback.module.css';
 import { type Layout, type Rating } from './Feedback.types';
 import { ThumbIcon } from './utils';
+import { createTexts, useTranslation } from '../../i18n';
 import { cn } from '../../utils';
 import { StylelessButton } from '../helpers';
 import { focusable } from '../helpers/styling/focus.module.css';
@@ -26,6 +27,7 @@ export const RatingComponent = ({
   thumbDownTooltip,
   handleRatingChange,
 }: RatingComponentType) => {
+  const { t } = useTranslation();
   const button = (rating: Rating, layout: Layout, tooltip: string) => (
     <StylelessButton
       aria-label={tooltip}
@@ -45,7 +47,7 @@ export const RatingComponent = ({
     >
       <h2 className={typographyStyles['label-medium']}>{ratingLabel}</h2>
       {loading ? (
-        <Spinner tooltip="Laster opp tilbakemelding ..." />
+        <Spinner tooltip={t(texts.uploadingFeedback)} />
       ) : (
         <HStack gap="x1">
           <Tooltip text={thumbUpTooltip}>
@@ -59,3 +61,12 @@ export const RatingComponent = ({
     </div>
   );
 };
+
+const texts = createTexts({
+  uploadingFeedback: {
+    nb: 'Laster opp tilbakemelding...',
+    no: 'Laster opp tilbakemelding...',
+    nn: 'Lastar opp tilbakemelding...',
+    en: 'Uploading feedback...',
+  },
+});

--- a/packages/dds-components/src/components/FileUploader/File.tsx
+++ b/packages/dds-components/src/components/FileUploader/File.tsx
@@ -1,6 +1,7 @@
 import { ErrorList } from './ErrorList';
 import styles from './FileUploader.module.css';
 import { type FileUploaderFile } from './fileUploaderReducer';
+import { createTexts, useTranslation } from '../../i18n';
 import {
   cn,
   derivativeIdGenerator,
@@ -21,6 +22,7 @@ interface FileProps {
 }
 
 export const File = (props: FileProps) => {
+  const { t } = useTranslation();
   const { parentId, index, file: stateFile, removeFile, isValid } = props;
 
   const errorsList = stateFile.errors.map((e, errorIndex) => ({
@@ -57,9 +59,9 @@ export const File = (props: FileProps) => {
           onClick={removeFile}
           icon={CloseIcon}
           htmlProps={{
-            'aria-label': `Fjern fil ${stateFile.file.name}`,
+            'aria-label': t(texts.removeFile(stateFile.file.name)),
             'aria-invalid': !isValid ? true : undefined,
-            'aria-errormessage': !isValid ? 'Ugyldig fil' : undefined,
+            'aria-errormessage': !isValid ? t(texts.invalidFile) : undefined,
             'aria-describedby': spaceSeparatedIdListGenerator(
               errorsList.map(e => e.id),
             ),
@@ -70,3 +72,18 @@ export const File = (props: FileProps) => {
     </li>
   );
 };
+
+const texts = createTexts({
+  removeFile: file => ({
+    nb: `Fjern fil ${file}`,
+    no: `Fjern fil ${file}`,
+    nn: `Fjern fil ${file}`,
+    en: `Remove file ${file}`,
+  }),
+  invalidFile: {
+    nb: 'Ugyldig fil',
+    no: 'Ugyldig fil',
+    nn: 'Ugyldig fil',
+    en: 'Invalid file',
+  },
+});

--- a/packages/dds-components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.tsx
@@ -5,6 +5,7 @@ import { File } from './File';
 import styles from './FileUploader.module.css';
 import { type FileList } from './types';
 import { type FileUploaderHookProps, useFileUploader } from './useFileUploader';
+import { createTexts, useTranslation } from '../../i18n';
 import {
   cn,
   derivativeIdGenerator,
@@ -52,7 +53,7 @@ export const FileUploader = (props: FileUploaderProps) => {
   const {
     id,
     label,
-    dropAreaLabel = 'Dra og slipp filer her eller',
+    dropAreaLabel,
     btnLabel = 'Velg fil',
     tip,
     required = false,
@@ -69,6 +70,9 @@ export const FileUploader = (props: FileUploaderProps) => {
     className,
     ...rest
   } = props;
+
+  const { t } = useTranslation();
+  const tDropAreaLabel = dropAreaLabel ?? t(texts.dragAndDropOr);
 
   const generatedId = useId();
   const uniqueId = id ?? `${generatedId}-fileUploader`;
@@ -169,8 +173,8 @@ export const FileUploader = (props: FileUploaderProps) => {
             id={inputId}
             data-testid="file-uploader-input"
           />
-          {dropAreaLabel}
-          <VisuallyHidden>velg fil med påfølgende knapp</VisuallyHidden>
+          {tDropAreaLabel}
+          <VisuallyHidden>{t(texts.uploadFileWithButton)}</VisuallyHidden>
           {button}
         </VStack>
       ) : (
@@ -186,3 +190,18 @@ export const FileUploader = (props: FileUploaderProps) => {
 };
 
 FileUploader.displayName = 'FileUploader';
+
+const texts = createTexts({
+  dragAndDropOr: {
+    nb: 'Dra og slipp filer her eller',
+    no: 'Dra og slipp filer her eller',
+    nn: 'Dra og slipp filer her eller',
+    en: 'Drag and drop files here or',
+  },
+  uploadFileWithButton: {
+    nb: 'last opp en fil med den påfølgende knappen',
+    no: 'last opp en fil med den påfølgende knappen',
+    nn: 'last opp ei fil med den påfølgjande knappen',
+    en: 'upload using the following button',
+  },
+});

--- a/packages/dds-components/src/components/GlobalMessage/GlobalMessage.tsx
+++ b/packages/dds-components/src/components/GlobalMessage/GlobalMessage.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 
 import styles from './GlobalMessage.module.css';
+import { useTranslation } from '../../i18n';
+import { commonTexts } from '../../i18n/commonTexts';
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
@@ -46,6 +48,7 @@ export const GlobalMessage = ({
   htmlProps,
   ...rest
 }: GlobalMessageProps) => {
+  const { t } = useTranslation();
   const [isClosed, setClosed] = useState(false);
 
   return !isClosed ? (
@@ -78,7 +81,7 @@ export const GlobalMessage = ({
             onClose && onClose();
           }}
           size="small"
-          aria-label="Lukk melding"
+          aria-label={t(commonTexts.closeMessage)}
         />
       )}
     </div>

--- a/packages/dds-components/src/components/InlineEdit/InlineEdit.utils.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEdit.utils.tsx
@@ -1,8 +1,27 @@
+import { createTexts, useTranslation } from '../../i18n';
 import { VisuallyHidden } from '../VisuallyHidden';
 
-export const inlineEditVisuallyHidden = (id: string, emptiable?: boolean) => (
-  <VisuallyHidden id={id}>
-    Escape, Enter eller Tab for å lagre.{' '}
-    {!emptiable && 'Inputfeltet er ikke tømmbar.'}
-  </VisuallyHidden>
-);
+export const inlineEditVisuallyHidden = (id: string, clearable?: boolean) => {
+  const { t } = useTranslation();
+  return (
+    <VisuallyHidden id={id}>
+      {t(texts.inlineEditInfo)}
+      {!clearable && t(texts.notClearable)}
+    </VisuallyHidden>
+  );
+};
+
+const texts = createTexts({
+  inlineEditInfo: {
+    nb: 'Escape, Enter eller Tab for å lagre.',
+    no: 'Escape, Enter eller Tab for å lagre.',
+    nn: 'Escape, Enter eller Tab for å lagre.',
+    en: 'Escape, Enter or Tab to save.',
+  },
+  notClearable: {
+    nb: ' Inputfeltet er ikke tømbart.',
+    no: ' Inputfeltet er ikke tømbart.',
+    nn: ' Inputfeltet er ikke tømbart.',
+    en: ' Input field cannot be cleared.',
+  },
+});

--- a/packages/dds-components/src/components/InputStepper/InputStepper.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.tsx
@@ -1,6 +1,14 @@
 import { useId } from 'react';
 
-import { Box, Label, MinusIcon, PlusIcon, getBaseHTMLProps } from '../..';
+import {
+  Box,
+  Label,
+  MinusIcon,
+  PlusIcon,
+  createTexts,
+  getBaseHTMLProps,
+  useTranslation,
+} from '../..';
 import { useControllableState } from '../../hooks/useControllableState';
 import { Button } from '../Button';
 import { StatefulInput, getInputWidth } from '../helpers';
@@ -46,6 +54,7 @@ export const InputStepper = ({
   ) {
     throw new Error('minValue, maxValue & step must be a non-negative integer');
   }
+  const { t } = useTranslation();
   const generatedId = useId();
   const uniqueId = id ?? `${generatedId}-inputStepper`;
   const [inputValue, setInputValue] = useControllableState<number>({
@@ -97,7 +106,7 @@ export const InputStepper = ({
       >
         {readOnly || disabled ? null : (
           <Button
-            aria-label={decreaseButtonLabel ?? `Trekk fra ${label}`}
+            aria-label={decreaseButtonLabel ?? `${t(texts.decrease)} ${label}`}
             purpose="secondary"
             size={componentSize}
             icon={MinusIcon}
@@ -129,7 +138,7 @@ export const InputStepper = ({
         />
         {readOnly || disabled ? null : (
           <Button
-            aria-label={increaseButtonLabel ?? `Legg til ${label}`}
+            aria-label={increaseButtonLabel ?? `${t(texts.increase)} ${label}`}
             purpose="secondary"
             size={componentSize}
             icon={PlusIcon}
@@ -146,3 +155,18 @@ export const InputStepper = ({
 };
 
 InputStepper.displayName = 'InputStepper';
+
+const texts = createTexts({
+  decrease: {
+    nb: 'Trekk fra',
+    no: 'Trekk fra',
+    nn: 'Trekk fra',
+    en: 'Decrease',
+  },
+  increase: {
+    nb: 'Legg til',
+    no: 'Legg til',
+    nn: 'Legg til',
+    en: 'Increase',
+  },
+});

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.stories.tsx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
+import { LanguageProvider } from '../../i18n';
 import {
   htmlPropsArgType,
   windowWidthDecorator,
@@ -9,7 +10,7 @@ import { StoryVStack } from '../layout/Stack/utils';
 
 import { InternalHeader } from '.';
 
-export default {
+const meta: Meta<typeof InternalHeader> = {
   title: 'dds-components/Components/InternalHeader',
   component: InternalHeader,
   argTypes: {
@@ -24,8 +25,16 @@ export default {
       canvas: { sourceState: 'hidden' },
     },
   },
-} satisfies Meta<typeof InternalHeader>;
+  decorators: [
+    Story => (
+      <LanguageProvider language="nb">
+        <Story />
+      </LanguageProvider>
+    ),
+  ],
+};
 
+export default meta;
 const navigationLink = {
   href: '#',
   children: 'navlenke',

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.tsx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import styles from './InternalHeader.module.css';
 import { type InternalHeaderProps } from './InternalHeader.types';
 import { NavigationItem } from './NavigationItem';
+import { createTexts, useTranslation } from '../../i18n/translation';
 import { getBaseHTMLProps } from '../../types';
 import { cn } from '../../utils';
 import { Button } from '../Button';
@@ -43,6 +44,8 @@ export const InternalHeader = (props: InternalHeaderProps) => {
     ...rest
   } = props;
 
+  const { t } = useTranslation();
+
   const [currentPage, setCurrentPage] = useState<string | undefined>(
     currentPageHref,
   );
@@ -59,7 +62,7 @@ export const InternalHeader = (props: InternalHeaderProps) => {
   const hasNavInContextMenu = hasSmallScreenBreakpoint && hasNavigationElements;
 
   const navigation = hasNavigationElements ? (
-    <nav aria-label="sidenavigasjon">
+    <nav aria-label={t(texts.siteNavigation)}>
       <ShowHide
         as={StylelessList}
         hideBelow={hasSmallScreenBreakpoint ? smallScreenBreakpoint : undefined}
@@ -137,7 +140,7 @@ export const InternalHeader = (props: InternalHeaderProps) => {
             <Button
               icon={hasNavInContextMenu ? MenuIcon : MoreVerticalIcon}
               purpose="tertiary"
-              aria-label="åpne meny"
+              aria-label={t(texts.openMenu)}
             />
             <OverflowMenu className={styles['context-menu']}>
               {user && (
@@ -152,7 +155,7 @@ export const InternalHeader = (props: InternalHeaderProps) => {
               {hasNavInContextMenu && (
                 <ShowHide
                   as="nav"
-                  aria-label="sidenavigasjon"
+                  aria-label={t(texts.siteNavigation)}
                   showBelow={smallScreenBreakpoint}
                 >
                   <OverflowMenuList>
@@ -190,3 +193,18 @@ export const InternalHeader = (props: InternalHeaderProps) => {
 };
 
 InternalHeader.displayName = 'InternalHeader';
+
+const texts = createTexts({
+  openMenu: {
+    nb: 'Åpne meny',
+    no: 'Åpne meny',
+    nn: 'Åpne meny',
+    en: 'Open menu',
+  },
+  siteNavigation: {
+    nb: 'Sidenavigasjon',
+    no: 'Sidenavigasjon',
+    nn: 'Sidenavigasjon',
+    en: 'Site navigation',
+  },
+});

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.tsx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 
 import styles from './LocalMessage.module.css';
+import { useTranslation } from '../../i18n';
+import { commonTexts } from '../../i18n/commonTexts';
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
@@ -69,6 +71,8 @@ export const LocalMessage = ({
   htmlProps,
   ...rest
 }: LocalMessageProps) => {
+  const { t } = useTranslation();
+
   const [isClosed, setClosed] = useState(false);
 
   if (isClosed) {
@@ -111,7 +115,7 @@ export const LocalMessage = ({
             onClose && onClose();
           }}
           size="xsmall"
-          aria-label="Lukk melding"
+          aria-label={t(commonTexts.closeMessage)}
           className={styles.container__button}
         />
       )}

--- a/packages/dds-components/src/components/Modal/Modal.tsx
+++ b/packages/dds-components/src/components/Modal/Modal.tsx
@@ -15,6 +15,8 @@ import {
   useMountTransition,
   useOnKeyDown,
 } from '../../hooks';
+import { useTranslation } from '../../i18n';
+import { commonTexts } from '../../i18n/commonTexts';
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
@@ -88,6 +90,8 @@ export const Modal = ({
   if (!themeContext) {
     throw new Error('Modal must be used within a ThemeProvider');
   }
+
+  const { t } = useTranslation();
 
   const portalTarget = parentElement ?? themeContext?.el;
 
@@ -170,7 +174,7 @@ export const Modal = ({
                   purpose="tertiary"
                   icon={CloseIcon}
                   onClick={handleClose}
-                  aria-label="Lukk dialog"
+                  aria-label={t(commonTexts.close)}
                   className={styles['close-button']}
                 />
               )}

--- a/packages/dds-components/src/components/Pagination/Pagination.spec.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.spec.tsx
@@ -7,19 +7,19 @@ describe('<Pagination>', () => {
   it('has aria label', () => {
     render(<Pagination itemsAmount={10} />);
     const pagination = screen.getByRole('navigation');
-    expect(pagination).toHaveAccessibleName('paginering');
+    expect(pagination).toHaveAccessibleName('Paginering');
   });
   it('has aria label on each page', () => {
     render(<Pagination itemsAmount={100} defaultActivePage={3} />);
     expect(
       within(screen.getAllByRole('listitem')[0]).getByRole('button'),
-    ).toHaveAttribute('aria-label', 'Gå til forrige siden');
+    ).toHaveAttribute('aria-label', 'Forrige side');
     expect(
       within(screen.getAllByRole('listitem')[1]).getByRole('button'),
-    ).toHaveAttribute('aria-label', 'Gå til side 1');
+    ).toHaveAttribute('aria-label', 'Side 1');
     expect(
       within(screen.getAllByRole('listitem')[3]).getByRole('button'),
-    ).toHaveAttribute('aria-label', 'Nåværende side (side 3)');
+    ).toHaveAttribute('aria-label', 'Nåværende side (3)');
   });
   it('should render correct number of pages', () => {
     const itemsAmount = 6;
@@ -52,7 +52,7 @@ describe('<Pagination>', () => {
     it('has aria label', () => {
       render(<Pagination itemsAmount={10} smallScreenBreakpoint="sm" />);
       const pagination = screen.getByRole('navigation');
-      expect(pagination).toHaveAccessibleName('paginering');
+      expect(pagination).toHaveAccessibleName('Paginering');
     });
     it('should render correct number of pages', () => {
       const itemsAmount = 6;

--- a/packages/dds-components/src/components/Pagination/Pagination.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.tsx
@@ -2,6 +2,7 @@ import { type HTMLAttributes, useState } from 'react';
 
 import styles from './Pagination.module.css';
 import { PaginationGenerator } from './paginationGenerator';
+import { createTexts, useTranslation } from '../../i18n';
 import { type BaseComponentProps, getBaseHTMLProps } from '../../types';
 import { cn } from '../../utils';
 import { Button } from '../Button';
@@ -88,6 +89,8 @@ export const Pagination = ({
   ref,
   ...rest
 }: PaginationProps) => {
+  const { t } = useTranslation();
+
   const [activePage, setActivePage] = useState(defaultActivePage);
   const [itemsPerPage, setItemsPerPage] = useState(defaultItemsPerPage);
 
@@ -129,9 +132,7 @@ export const Pagination = ({
                     onPageChange(event, item);
                   }}
                   aria-label={
-                    isActive
-                      ? `Nåværende side (side ${item})`
-                      : `Gå til side ${item}`
+                    isActive ? t(texts.currentPage(item)) : t(texts.page(item))
                   }
                 >
                   {item}
@@ -155,7 +156,7 @@ export const Pagination = ({
       onClick={event => {
         onPageChange(event, activePage - 1);
       }}
-      aria-label="Gå til forrige siden"
+      aria-label={t(texts.previousPage)}
     />
   );
 
@@ -167,7 +168,7 @@ export const Pagination = ({
       onClick={event => {
         onPageChange(event, activePage + 1);
       }}
-      aria-label="Gå til neste siden"
+      aria-label={t(texts.nextPage)}
     />
   );
 
@@ -178,7 +179,7 @@ export const Pagination = ({
     <Box
       as="nav"
       ref={ref}
-      aria-label="paginering"
+      aria-label={t(texts.pagination)}
       display="flex"
       alignItems="center"
       {...(!withSelect &&
@@ -231,7 +232,7 @@ export const Pagination = ({
               onClick={event => {
                 onPageChange(event, 1);
               }}
-              aria-label="Gå til første siden"
+              aria-label={t(texts.firstPage)}
             />
           </li>
           <li
@@ -276,7 +277,7 @@ export const Pagination = ({
               onClick={event => {
                 onPageChange(event, pagesLength);
               }}
-              aria-label="Gå til siste siden"
+              aria-label={t(texts.lastPage)}
             />
           </li>
         </ShowHide>
@@ -315,12 +316,18 @@ export const Pagination = ({
             isClearable={false}
             onChange={handleSelectChange}
             componentSize="small"
-            aria-label="Antall elementer per side"
+            aria-label={t(texts.itemsPerPage)}
           />
         )}
         {withCounter && (
           <Paragraph>
-            Viser {activePageFirstItem}-{activePageLastItem} av {itemsAmount}
+            {t(
+              texts.showsAmountOfTotalItems(
+                activePageFirstItem,
+                activePageLastItem,
+                itemsAmount,
+              ),
+            )}
           </Paragraph>
         )}
       </div>
@@ -330,3 +337,60 @@ export const Pagination = ({
 };
 
 Pagination.displayName = 'Pagination';
+
+const texts = createTexts({
+  pagination: {
+    nb: 'Paginering',
+    no: 'Paginering',
+    nn: 'Paginering',
+    en: 'Pagination',
+  },
+  itemsPerPage: {
+    nb: 'Antall elementer per side',
+    no: 'Antall elementer per side',
+    nn: 'Antall element per side',
+    en: 'Items per page',
+  },
+  nextPage: {
+    nb: 'Neste side',
+    no: 'Neste side',
+    nn: 'Neste side',
+    en: 'Next page',
+  },
+  previousPage: {
+    nb: 'Forrige side',
+    no: 'Forrige side',
+    nn: 'Førre side',
+    en: 'Previous page',
+  },
+  firstPage: {
+    nb: 'Første side',
+    no: 'Første side',
+    nn: 'Fyrste side',
+    en: 'First page',
+  },
+  lastPage: {
+    nb: 'Siste side',
+    no: 'Siste side',
+    nn: 'Siste side',
+    en: 'Last page',
+  },
+  currentPage: page => ({
+    nb: `Nåværende side (${page})`,
+    no: `Nåværende side (${page})`,
+    nn: `Nåværende side (${page})`,
+    en: `Current page (${page})`,
+  }),
+  page: page => ({
+    nb: `Side ${page}`,
+    no: `Side ${page}`,
+    nn: `Side ${page}`,
+    en: `Page ${page}`,
+  }),
+  showsAmountOfTotalItems: (first, last, total) => ({
+    nb: `Viser ${first}-${last} av ${total}`,
+    no: `Viser ${first}-${last} av ${total}`,
+    nn: `Viser ${first}-${last} av ${total}`,
+    en: `Shows ${first}-${last} of ${total}`,
+  }),
+});

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.tsx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.tsx
@@ -12,6 +12,7 @@ import {
 import { COUNTRIES, type Country, type ISOCountryCode } from './constants';
 import styles from './PhoneInput.module.css';
 import { useCombinedRef } from '../../hooks';
+import { createTexts, useTranslation } from '../../i18n';
 import {
   cn,
   derivativeIdGenerator,
@@ -155,6 +156,9 @@ export const PhoneInput = ({
   ref,
   ...props
 }: PhoneInputProps) => {
+  const { t } = useTranslation();
+  const tGroupLabel = groupLabel ?? t(texts.countryCodeAndPhoneNumber);
+  const tSelectLabel = selectLabel ?? t(texts.countryCode);
   const generatedId = useId();
   const uniqueId = props.id ?? generatedId;
   const phoneInputId = `${uniqueId}-phone-input`;
@@ -278,10 +282,10 @@ export const PhoneInput = ({
         )}
         width={getInputWidth(width, widthDefault)}
         role="group"
-        aria-label={groupLabel}
+        aria-label={tGroupLabel}
       >
         <label className={utilStyles['visually-hidden']} htmlFor={selectId}>
-          {selectLabel}
+          {tSelectLabel}
         </label>
         <NativeSelect
           width={applyResponsiveStyle(
@@ -356,3 +360,18 @@ PhoneInput.displayName = 'PhoneInput';
 
 const getCallingCode = (s: string): string =>
   s.substring(s.indexOf('+'), s.length) ?? '';
+
+const texts = createTexts({
+  countryCode: {
+    nb: 'Landskode',
+    no: 'Landskode',
+    nn: 'Landskode',
+    en: 'Country code',
+  },
+  countryCodeAndPhoneNumber: {
+    nb: 'Landskode og telefonnummer',
+    no: 'Landskode og telefonnummer',
+    nn: 'Landskode og telefonnummer',
+    en: 'Country code and phone number',
+  },
+});

--- a/packages/dds-components/src/components/Popover/Popover.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.tsx
@@ -17,6 +17,8 @@ import {
   useOnKeyDown,
   useReturnFocusOnBlur,
 } from '../../hooks';
+import { useTranslation } from '../../i18n';
+import { commonTexts } from '../../i18n/commonTexts';
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
@@ -117,6 +119,8 @@ export const Popover = ({
     isOpen: contextIsOpen,
     anchorEl: contextAnchorEl,
   } = context;
+
+  const { t } = useTranslation();
 
   const hasContext = !isEmpty(context);
   const generatedId = useId();
@@ -237,7 +241,7 @@ export const Popover = ({
           purpose="tertiary"
           size="small"
           onClick={onClose}
-          aria-label="Lukk"
+          aria-label={t(commonTexts.close)}
           className={styles['close-button']}
         />
       )}

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.tsx
@@ -13,6 +13,7 @@ import {
 import { ProgressTrackerContext } from './ProgressTracker.context';
 import styles from './ProgressTracker.module.css';
 import { ProgressTrackerItem } from './ProgressTrackerItem';
+import { createTexts, useTranslation } from '../../i18n';
 import {
   type BaseComponentPropsWithChildren,
   type Direction,
@@ -53,6 +54,7 @@ export const ProgressTracker: ProgressTrackerComponent = (() => {
     htmlProps = {},
     ...rest
   }: ProgressTrackerProps) => {
+    const { t } = useTranslation();
     const [thisActiveStep, setActiveStep] = useState(activeStep);
 
     const handleChange = (step: number) => {
@@ -85,7 +87,7 @@ export const ProgressTracker: ProgressTrackerComponent = (() => {
         }}
       >
         <nav
-          aria-label={ariaLabel ?? 'stegprogresjon'}
+          aria-label={ariaLabel ?? t(texts.stepProgression)}
           {...getBaseHTMLProps(id, className, htmlProps, rest)}
         >
           <Box
@@ -125,3 +127,12 @@ function passIndexPropToProgressTrackerItem<TProps extends object>(
     }),
   );
 }
+
+const texts = createTexts({
+  stepProgression: {
+    nb: 'Stegprogresjon',
+    no: 'Stegprogresjon',
+    nn: 'Stegprogresjon',
+    en: 'Step progression',
+  },
+});

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTrackerItem.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTrackerItem.tsx
@@ -2,6 +2,7 @@ import { type ComponentPropsWithRef, useMemo } from 'react';
 
 import { useProgressTrackerContext } from './ProgressTracker.context';
 import styles from './ProgressTracker.module.css';
+import { createTexts, useTranslation } from '../../i18n';
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
@@ -85,11 +86,6 @@ export type ProgressTrackerItemProps =
       }
     >;
 
-const getVisuallyHiddenTextBefore = (index: number) => `${index + 1}. trinn, `;
-
-const getVisuallyHiddenTextAfter = (completed: boolean) =>
-  `, ${completed ? 'ferdig' : 'ikke ferdig'}`;
-
 export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
   const {
     id,
@@ -103,6 +99,8 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
     children,
     ...rest
   } = props;
+
+  const { t } = useTranslation();
 
   const { activeStep, handleStepChange, direction } =
     useProgressTrackerContext();
@@ -150,9 +148,11 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
           typographyStyles['body-medium'],
         )}
       >
-        <VisuallyHidden>{getVisuallyHiddenTextBefore(index)}</VisuallyHidden>
+        <VisuallyHidden>{t(texts.stepTextBefore(index + 1))}</VisuallyHidden>
         {children}
-        <VisuallyHidden>{getVisuallyHiddenTextAfter(completed)}</VisuallyHidden>
+        <VisuallyHidden>
+          {completed ? t(texts.completed) : t(texts.uncompleted)}
+        </VisuallyHidden>
       </div>
     </>
   );
@@ -194,3 +194,24 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
 };
 
 ProgressTrackerItem.displayName = 'ProgressTracker.Item';
+
+const texts = createTexts({
+  stepTextBefore: index => ({
+    nb: `${index}. trinn, `,
+    no: `${index}. trinn, `,
+    nn: `${index}. trinn, `,
+    en: `${index}. step, `,
+  }),
+  uncompleted: {
+    nb: 'ikke ferdig',
+    no: 'ikke ferdig',
+    nn: 'ikke ferdig',
+    en: 'uncompleted',
+  },
+  completed: {
+    nb: 'ferdig',
+    no: 'ferdig',
+    nn: 'ferdig',
+    en: 'completed',
+  },
+});

--- a/packages/dds-components/src/components/Search/Search.tsx
+++ b/packages/dds-components/src/components/Search/Search.tsx
@@ -11,6 +11,7 @@ import { type SearchButtonProps, type SearchSize } from './Search.types';
 import { createEmptyChangeEvent, typographyTypes } from './Search.utils';
 import { SearchSuggestions } from './SearchSuggestions';
 import { useCombinedRef } from '../../hooks';
+import { createTexts, useTranslation } from '../../i18n';
 import {
   cn,
   derivativeIdGenerator,
@@ -102,6 +103,8 @@ export const Search = ({
     'suggestions-description',
   );
 
+  const { t } = useTranslation();
+
   const [hasValue, setHasValue] = useState(!!value);
 
   const context = useAutocompleteSearch();
@@ -184,7 +187,7 @@ export const Search = ({
             componentSize={componentSize}
           />
           <VisuallyHidden id={suggestionsDescriptionId}>
-            Bla i søkeforslag med piltaster når listen er utvidet.
+            {t(texts.useArrowKeys)}
           </VisuallyHidden>
         </>
       )}
@@ -193,7 +196,7 @@ export const Search = ({
           icon={CloseSmallIcon}
           size={componentSize === 'large' ? 'medium' : 'small'}
           purpose="tertiary"
-          aria-label="Tøm"
+          aria-label={t(texts.clearSearch)}
           onClick={clearInput}
           className={styles['clear-button']}
         />
@@ -233,3 +236,18 @@ export const Search = ({
 };
 
 Search.displayName = 'Search';
+
+const texts = createTexts({
+  clearSearch: {
+    nb: 'Tøm søk',
+    no: 'Tøm søk',
+    nn: 'Tøm søk',
+    en: 'Clear search',
+  },
+  useArrowKeys: {
+    nb: 'Bruk piltastene for å navigere i forslagene',
+    no: 'Bruk piltastene for å navigere i forslagene',
+    nn: 'Bruk piltastane for å navigere i forslaga',
+    en: 'Use the arrow keys to navigate suggestions',
+  },
+});

--- a/packages/dds-components/src/components/Spinner/Spinner.tsx
+++ b/packages/dds-components/src/components/Spinner/Spinner.tsx
@@ -2,6 +2,8 @@ import { type Property } from 'csstype';
 import { useId, useRef } from 'react';
 
 import styles from './Spinner.module.css';
+import { useTranslation } from '../../i18n';
+import { commonTexts } from '../../i18n/commonTexts';
 import { type BaseComponentProps, getBaseHTMLProps } from '../../types';
 import { type TextColor, cn, getTextColor } from '../../utils';
 
@@ -27,12 +29,14 @@ export function Spinner(props: SpinnerProps) {
   const {
     size = 'var(--dds-icon-size-medium)',
     color = 'iconActionResting',
-    tooltip = 'Innlasting pågår',
+    tooltip,
     id,
     className,
     htmlProps,
     ...rest
   } = props;
+
+  const { t } = useTranslation();
 
   const mountTime = useRef(Date.now());
   const outerAnimationDelay = -(mountTime.current % 2000);
@@ -54,7 +58,7 @@ export function Spinner(props: SpinnerProps) {
         height: size,
       }}
     >
-      <title id={uniqueId}>{tooltip}</title>
+      <title id={uniqueId}>{tooltip ?? t(commonTexts.loading)}</title>
       <circle
         className={cn(styles.circle)}
         style={{

--- a/packages/dds-components/src/components/SplitButton/SplitButton.spec.tsx
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.spec.tsx
@@ -28,7 +28,7 @@ describe('<SplitButton>', () => {
     render(<SplitButton primaryAction={primary} secondaryActions={item} />);
     const menu = screen.queryByRole('menu');
     expect(menu).not.toBeInTheDocument();
-    const menuButton = screen.getByLabelText('Åpne liste med flere valg');
+    const menuButton = screen.getByLabelText('Flere handlinger');
 
     await userEvent.click(menuButton!);
 
@@ -68,7 +68,7 @@ describe('<SplitButton>', () => {
 
   it('should hide menu after Esc keydown', async () => {
     render(<SplitButton secondaryActions={item} primaryAction={primary} />);
-    const menuButton = screen.getByLabelText('Åpne liste med flere valg');
+    const menuButton = screen.getByLabelText('Flere handlinger');
     fireEvent.click(menuButton!);
     const menuOpened = screen.getByRole('menu');
     expect(menuOpened).toHaveAttribute('aria-hidden', 'false');

--- a/packages/dds-components/src/components/SplitButton/SplitButton.tsx
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.tsx
@@ -1,6 +1,7 @@
 import { type ComponentPropsWithRef, useState } from 'react';
 
 import styles from './SplitButton.module.css';
+import { createTexts, useTranslation } from '../../i18n';
 import { type ExtractStrict } from '../../types';
 import { cn } from '../../utils';
 import { Button, type ButtonProps, type ButtonPurpose } from '../Button';
@@ -43,6 +44,7 @@ export const SplitButton = ({
   className,
   ...rest
 }: SplitButtonProps) => {
+  const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const buttonStyleProps: ButtonProps = {
     purpose,
@@ -61,7 +63,7 @@ export const SplitButton = ({
         <Button
           {...buttonStyleProps}
           icon={isOpen ? ChevronUpIcon : ChevronDownIcon}
-          aria-label="Åpne liste med flere valg"
+          aria-label={t(texts.moreActions)}
           purpose={purpose}
           className={cn(
             styles.option,
@@ -84,3 +86,12 @@ export const SplitButton = ({
 };
 
 SplitButton.displayName = 'SplitButton';
+
+const texts = createTexts({
+  moreActions: {
+    nb: 'Flere handlinger',
+    no: 'Flere handlinger',
+    nn: 'Fleire handlingar',
+    en: 'More actions',
+  },
+});

--- a/packages/dds-components/src/components/Table/collapsible/CollapsibleRow.tsx
+++ b/packages/dds-components/src/components/Table/collapsible/CollapsibleRow.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 
 import { useCollapsibleTableContext } from './Table.context';
+import { createTexts, useTranslation } from '../../../i18n';
 import {
   cn,
   derivativeIdGenerator,
@@ -33,6 +34,7 @@ export const CollapsibleRow = ({
   ref,
   ...rest
 }: TableRowProps) => {
+  const { t } = useTranslation();
   const isInHead = useIsInTableHead();
   const type = _type ?? (isInHead ? 'head' : 'body');
   const { isCollapsed, headerValues, definingColumnIndex } =
@@ -115,8 +117,8 @@ export const CollapsibleRow = ({
         <>
           {definingColumnCells}
           <Table.Cell type="head" layout="center">
-            Utvid
-            <VisuallyHidden>raden</VisuallyHidden>
+            {t(texts.expand)}
+            <VisuallyHidden>{t(texts.row)}</VisuallyHidden>
           </Table.Cell>
         </>
       </Row>
@@ -169,3 +171,18 @@ export const CollapsibleRow = ({
 };
 
 CollapsibleRow.displayName = 'CollapsibleTable.Row';
+
+const texts = createTexts({
+  expand: {
+    nb: 'Utvid',
+    no: 'Utvid',
+    nn: 'Utvid',
+    en: 'Expand',
+  },
+  row: {
+    nb: 'raden',
+    no: 'raden',
+    nn: 'raden',
+    en: 'row',
+  },
+});

--- a/packages/dds-components/src/components/Table/normal/SortCell.tsx
+++ b/packages/dds-components/src/components/Table/normal/SortCell.tsx
@@ -2,6 +2,7 @@ import { type MouseEvent } from 'react';
 
 import { Cell, type TableCellProps } from './Cell';
 import styles from './Table.module.css';
+import { createTexts, useTranslation } from '../../../i18n';
 import { cn } from '../../../utils';
 import { StylelessButton } from '../../helpers';
 import { focusable } from '../../helpers/styling/focus.module.css';
@@ -41,20 +42,32 @@ export const SortCell = ({
   onClick,
   children,
   ...rest
-}: TableSortCellProps) => (
-  <Cell
-    type="head"
-    aria-sort={isSorted && sortOrder ? sortOrder : undefined}
-    {...rest}
-  >
-    <StylelessButton
-      onClick={onClick}
-      aria-description="Aktiver for å endre sorteringsrekkefølge"
-      className={cn(styles['sort-button'], focusable)}
+}: TableSortCellProps) => {
+  const { t } = useTranslation();
+  return (
+    <Cell
+      type="head"
+      aria-sort={isSorted && sortOrder ? sortOrder : undefined}
+      {...rest}
     >
-      {children} {makeSortIcon(isSorted, sortOrder)}
-    </StylelessButton>
-  </Cell>
-);
+      <StylelessButton
+        onClick={onClick}
+        aria-description={t(texts.changeSort)}
+        className={cn(styles['sort-button'], focusable)}
+      >
+        {children} {makeSortIcon(isSorted, sortOrder)}
+      </StylelessButton>
+    </Cell>
+  );
+};
 
 SortCell.displayName = 'Table.SortCell';
+
+const texts = createTexts({
+  changeSort: {
+    nb: 'Aktiver for å endre sorteringsrekkefølge',
+    no: 'Aktiver for å endre sorteringsrekkefølge',
+    nn: 'Aktiver for å endre sorteringsrekkjefølgje',
+    en: 'Activate to change sort order',
+  },
+});

--- a/packages/dds-components/src/components/Toggle/Toggle.tsx
+++ b/packages/dds-components/src/components/Toggle/Toggle.tsx
@@ -2,6 +2,8 @@ import { type InputHTMLAttributes, type ReactNode, useId } from 'react';
 
 import styles from './Toggle.module.css';
 import { useControllableState } from '../../hooks/useControllableState';
+import { useTranslation } from '../../i18n';
+import { commonTexts } from '../../i18n/commonTexts';
 import {
   type BaseComponentProps,
   type Size,
@@ -71,6 +73,7 @@ export const Toggle = ({
   htmlProps = {},
   ...rest
 }: ToggleProps) => {
+  const { t } = useTranslation();
   const generatedId = useId();
   const uniqueId = id ?? `${generatedId}-toggle`;
   const iconSize = size === 'large' ? 'medium' : 'small';
@@ -138,7 +141,7 @@ export const Toggle = ({
           />
         )}
         {children}{' '}
-        {isLoading && <VisuallyHidden>Innlastning pågår</VisuallyHidden>}
+        {isLoading && <VisuallyHidden>{t(commonTexts.loading)}</VisuallyHidden>}
       </span>
     </label>
   );

--- a/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/Calendar.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/Calendar.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react';
 
 import { CalendarGrid } from './CalendarGrid';
+import { createTexts, useTranslation } from '../../../../i18n';
 import { Button } from '../../../Button';
 import { ArrowLeftIcon, ArrowRightIcon } from '../../../Icon/icons';
 import { HStack } from '../../../layout';
@@ -32,6 +33,7 @@ function createCalendar(identifier: string) {
 export type CalendarProps<T extends DateValue> = AriaCalendarProps<T>;
 
 export function Calendar<T extends DateValue>(props: CalendarProps<T>) {
+  const { t } = useTranslation();
   const { locale } = useLocale();
   const state = useCalendarState({
     ...props,
@@ -40,8 +42,8 @@ export function Calendar<T extends DateValue>(props: CalendarProps<T>) {
   });
   const {
     calendarProps,
-    prevButtonProps: { onPress: onPrev, 'aria-label': prevAriaLabel },
-    nextButtonProps: { onPress: onNext, 'aria-label': nextAriaLabel },
+    prevButtonProps: { onPress: onPrev },
+    nextButtonProps: { onPress: onNext },
     title,
   } = useCalendar(props, state);
 
@@ -62,7 +64,7 @@ export function Calendar<T extends DateValue>(props: CalendarProps<T>) {
       <HStack justifyContent="space-between" alignItems="center">
         <Button
           type="button"
-          aria-label={prevAriaLabel}
+          aria-label={t(texts.previousMonth)}
           onClick={e => onPrev?.(e as never)}
           size="small"
           purpose="tertiary"
@@ -79,7 +81,7 @@ export function Calendar<T extends DateValue>(props: CalendarProps<T>) {
         </Heading>
         <Button
           type="button"
-          aria-label={nextAriaLabel}
+          aria-label={t(texts.nextMonth)}
           onClick={e => onNext?.(e as never)}
           size="small"
           purpose="tertiary"
@@ -93,3 +95,18 @@ export function Calendar<T extends DateValue>(props: CalendarProps<T>) {
 }
 
 Calendar.displayName = 'Calendar';
+
+const texts = createTexts({
+  nextMonth: {
+    nb: 'Neste måned',
+    no: 'Neste måned',
+    nn: 'Neste månad',
+    en: 'Next month',
+  },
+  previousMonth: {
+    nb: 'Forrige måned',
+    no: 'Forrige måned',
+    nn: 'Førre månad',
+    en: 'Previous month',
+  },
+});

--- a/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/CalendarGrid.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/CalendarGrid.tsx
@@ -11,6 +11,7 @@ import {
 import { useContext } from 'react';
 
 import { CalendarCell } from './CalendarCell';
+import { createTexts, useTranslation } from '../../../../i18n';
 import { cn } from '../../../../utils';
 import typographyStyles from '../../../Typography/typographyStyles.module.css';
 import { VisuallyHidden } from '../../../VisuallyHidden';
@@ -23,6 +24,7 @@ interface CalendarGridProps extends AriaCalendarGridProps {
 }
 
 export function CalendarGrid({ state, ...props }: CalendarGridProps) {
+  const { t } = useTranslation();
   const { locale } = useLocale();
   const {
     gridProps: { onKeyDown, ...gridProps },
@@ -31,7 +33,15 @@ export function CalendarGrid({ state, ...props }: CalendarGridProps) {
 
   // Get the number of weeks in the month so we can render the proper number of rows.
   const weeksInMonth = getWeeksInMonth(state.visibleRange.start, locale);
-  const weekDays = ['Ma', 'Ti', 'On', 'To', 'Fr', 'Lø', 'Sø'];
+  const weekDays = [
+    { short: t(texts.mo), full: t(texts.monday) },
+    { short: t(texts.tu), full: t(texts.tuesday) },
+    { short: t(texts.we), full: t(texts.wednesday) },
+    { short: t(texts.th), full: t(texts.thursday) },
+    { short: t(texts.fr), full: t(texts.friday) },
+    { short: t(texts.sa), full: t(texts.saturday) },
+    { short: t(texts.su), full: t(texts.sunday) },
+  ];
 
   const { showWeekNumbers, onClose } = useContext(CalendarPopoverContext);
 
@@ -60,12 +70,14 @@ export function CalendarGrid({ state, ...props }: CalendarGridProps) {
             <th
               className={cn(styles['calendar__grid-element'], ...typographyCn)}
             >
-              # <VisuallyHidden>Ukenummer</VisuallyHidden>
+              <span aria-hidden>#</span>
+              <VisuallyHidden>{t(texts.weekNumber)}</VisuallyHidden>
             </th>
           )}
           {weekDays.map((day, index) => (
             <th key={index} className={cn(...typographyCn)}>
-              {day}
+              <span aria-hidden>{day.short}</span>
+              <VisuallyHidden>{day.full}</VisuallyHidden>
             </th>
           ))}
         </tr>
@@ -111,3 +123,96 @@ export function CalendarGrid({ state, ...props }: CalendarGridProps) {
 }
 
 CalendarGrid.displayName = 'CalendarGrid';
+
+const texts = createTexts({
+  weekNumber: {
+    nb: 'Ukenummer',
+    no: 'Ukenummer',
+    nn: 'Ukenummer',
+    en: 'Week number',
+  },
+  mo: {
+    nb: 'Ma',
+    no: 'Ma',
+    nn: 'Må',
+    en: 'Mo',
+  },
+  tu: {
+    nb: 'Ti',
+    no: 'Ty',
+    nn: 'Ti',
+    en: 'Tu',
+  },
+  we: {
+    nb: 'On',
+    no: 'On',
+    nn: 'On',
+    en: 'We',
+  },
+  th: {
+    nb: 'To',
+    no: 'To',
+    nn: 'To',
+    en: 'Th',
+  },
+  fr: {
+    nb: 'Fr',
+    no: 'Fr',
+    nn: 'Fr',
+    en: 'Fr',
+  },
+  sa: {
+    nb: 'Lø',
+    no: 'Lø',
+    nn: 'La',
+    en: 'Sa',
+  },
+  su: {
+    nb: 'Sø',
+    no: 'Sø',
+    nn: 'Su',
+    en: 'Su',
+  },
+  monday: {
+    nb: 'Mandag',
+    no: 'Mandag',
+    nn: 'Måndag',
+    en: 'Monday',
+  },
+  tuesday: {
+    nb: 'Tirsdag',
+    no: 'Tirsdag',
+    nn: 'Tysdag',
+    en: 'Tuesday',
+  },
+  wednesday: {
+    nb: 'Onsdag',
+    no: 'Onsdag',
+    nn: 'Onsdag',
+    en: 'Wednesday',
+  },
+  thursday: {
+    nb: 'Torsdag',
+    no: 'Torsdag',
+    nn: 'Torsdag',
+    en: 'Thursday',
+  },
+  friday: {
+    nb: 'Fredag',
+    no: 'Fredag',
+    nn: 'Fredag',
+    en: 'Friday',
+  },
+  saturday: {
+    nb: 'Lørdag',
+    no: 'Lørdag',
+    nn: 'Laurdag',
+    en: 'Saturday',
+  },
+  sunday: {
+    nb: 'Søndag',
+    no: 'Søndag',
+    nn: 'Sundag',
+    en: 'Sunday',
+  },
+});

--- a/packages/dds-components/src/components/date-inputs/DatePicker/CalendarPopover.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/CalendarPopover.tsx
@@ -18,6 +18,8 @@ import {
   useOnClickOutside,
   useOnKeyDown,
 } from '../../../hooks';
+import { useTranslation } from '../../../i18n';
+import { commonTexts } from '../../../i18n/commonTexts';
 import { cn } from '../../../utils';
 import { Button } from '../../Button';
 import {
@@ -120,6 +122,7 @@ export const CalendarPopoverContent = ({
   }
 
   const portalTarget = themeContext.el;
+  const { t } = useTranslation();
   const { isOpen, onClose, anchorRef, closeButtonRef } = useContext(
     CalendarPopoverContext,
   );
@@ -181,7 +184,7 @@ export const CalendarPopoverContent = ({
                     icon={CloseIcon}
                     size="small"
                     purpose="tertiary"
-                    aria-label="Lukk"
+                    aria-label={t(commonTexts.close)}
                     onClick={onClose}
                     htmlProps={{ onKeyDown: closeOnKeyboardBlurBack }}
                   />

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
@@ -9,6 +9,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useRef, useState } from 'react';
 
+import { LanguageProvider } from '../../../i18n';
 import { windowWidthDecorator } from '../../../storybook/helpers';
 import { Button } from '../../Button';
 import { StoryHStack, StoryVStack } from '../../layout/Stack/utils';
@@ -39,9 +40,11 @@ const meta: Meta<typeof DatePicker> = {
   },
   decorators: [
     Story => (
-      <StoryThemeProvider>
-        <Story />
-      </StoryThemeProvider>
+      <LanguageProvider language="nb">
+        <StoryThemeProvider>
+          <Story />
+        </StoryThemeProvider>
+      </LanguageProvider>
     ),
   ],
 };

--- a/packages/dds-components/src/components/helpers/Input/CharCounter.tsx
+++ b/packages/dds-components/src/components/helpers/Input/CharCounter.tsx
@@ -1,9 +1,11 @@
 import { useId } from 'react';
 
 import styles from './Input.module.css';
+import { createTexts, useTranslation } from '../../../i18n';
 import { type BaseComponentProps, getBaseHTMLProps } from '../../../types';
 import { cn } from '../../../utils';
 import { Typography } from '../../Typography';
+import { VisuallyHidden } from '../../VisuallyHidden';
 
 type Props = BaseComponentProps<
   HTMLElement,
@@ -14,6 +16,7 @@ type Props = BaseComponentProps<
 >;
 
 export function CharCounter(props: Props) {
+  const { t } = useTranslation();
   const { current, max, id, className, htmlProps, ...rest } = props;
 
   const generatedId = useId();
@@ -30,9 +33,13 @@ export function CharCounter(props: Props) {
       as="div"
       typographyType="bodyXsmall"
       color="textSubtle"
-      aria-label={`${current} av ${max} tegn skrevet`}
     >
-      {current}/{max}
+      <span aria-hidden>
+        {current}/{max}
+      </span>
+      <VisuallyHidden>
+        {t(texts.charsWritten(current, max, max - current))}
+      </VisuallyHidden>
     </Typography>
   );
 }
@@ -46,3 +53,12 @@ export const renderCharCounter = (
   if (!!maxLength && Number.isInteger(maxLength) && maxLength > 0 && isShown)
     return <CharCounter id={id} max={maxLength} current={textLength} />;
 };
+
+const texts = createTexts({
+  charsWritten: (current, max, remain) => ({
+    nb: `${current} av ${max} tegn skrevet. ${remain} igjen.`,
+    no: `${current} av ${max} tegn skrevet. ${remain} igjen.`,
+    nn: `${current} av ${max} tegn skrevet. ${remain} igjen.`,
+    en: `${current} of ${max} characters used. ${remain} remaining.`,
+  }),
+});

--- a/packages/dds-components/src/i18n/LanguageProvider.tsx
+++ b/packages/dds-components/src/i18n/LanguageProvider.tsx
@@ -1,0 +1,37 @@
+import { type ReactNode, createContext, useContext } from 'react';
+
+import { type Language } from './translation.types';
+
+export interface LanguageContextProps {
+  language: Language;
+}
+
+export const LanguageContext = createContext<LanguageContextProps | undefined>(
+  undefined,
+);
+
+export interface LanguageProviderProps {
+  language: Language;
+  children?: ReactNode;
+}
+
+export function LanguageProvider({
+  /**Språk på siden. */
+  language,
+  /**Selve applikasjonen. */
+  children,
+}: LanguageProviderProps) {
+  return <LanguageContext value={{ language }}>{children}</LanguageContext>;
+}
+
+export function useLanguage() {
+  const lang = useContext(LanguageContext)?.language;
+  if (!lang) {
+    return 'nb';
+  }
+  //TODO: ha med når LanguageProvider blir påkrevd
+  // if (!lang) {
+  //   throw new Error('useLangage must be used within LanguageProvider.');
+  // }
+  return lang;
+}

--- a/packages/dds-components/src/i18n/commonTexts.tsx
+++ b/packages/dds-components/src/i18n/commonTexts.tsx
@@ -1,0 +1,22 @@
+import { createTexts } from './translation';
+
+export const commonTexts = createTexts({
+  close: {
+    nb: 'Lukk',
+    no: 'Lukk',
+    nn: 'Lukk',
+    en: 'Close',
+  },
+  closeMessage: {
+    nb: 'Lukk melding',
+    no: 'Lukk melding',
+    nn: 'Lukk melding',
+    en: 'Close message',
+  },
+  loading: {
+    nb: 'Innlastning pågår',
+    no: 'Innlastning pågår',
+    nn: 'Innlastning pågår',
+    en: 'Loading',
+  },
+});

--- a/packages/dds-components/src/i18n/index.ts
+++ b/packages/dds-components/src/i18n/index.ts
@@ -1,0 +1,2 @@
+export * from './LanguageProvider';
+export * from './translation';

--- a/packages/dds-components/src/i18n/translation.tsx
+++ b/packages/dds-components/src/i18n/translation.tsx
@@ -1,0 +1,12 @@
+import { useLanguage } from './LanguageProvider';
+import { type TranslationObj, type Translations } from './translation.types';
+
+export function useTranslation() {
+  const lang = useLanguage();
+  const t = (text: TranslationObj) => text[lang] as string;
+  return { t, lang };
+}
+
+export function createTexts<T extends Translations>(texts: T) {
+  return texts;
+}

--- a/packages/dds-components/src/i18n/translation.types.tsx
+++ b/packages/dds-components/src/i18n/translation.types.tsx
@@ -1,0 +1,15 @@
+export type Language = 'nb' | 'nn' | 'no' | 'en';
+
+export type TranslationObj = {
+  [key in Language]: string | React.ReactElement;
+};
+
+export type TranslationFunction = (
+  ...args: Array<string | number>
+) => TranslationObj;
+
+export type Translation = TranslationObj | TranslationFunction;
+
+export interface Translations {
+  [key: string]: Translation | Translations;
+}

--- a/packages/dds-components/src/index.ts
+++ b/packages/dds-components/src/index.ts
@@ -7,6 +7,8 @@ export * as icons from './components/Icon/icons';
 export * from './hooks';
 export * from './types';
 export { cn } from './utils/dom';
+export * from './i18n';
+export * from './DdsProvider';
 
 export * from './components/Accordion';
 export * from './components/BackLink';


### PR DESCRIPTION
- Intern støtte for i18n i komponenter via ny provider `<LanguageProvider>`; den er ikke eksponert til konsumenter, istedet er den slått sammen med `<ThemeProvider>`, som til sammen blir `<DdsProvider>`. Inntil videre bruker vi `'nb'` som default språk, og vil dermed ikke føre til noen endringer hos konsumenter i denne release. Default blir fjernet i neste major release, med påkrevd bruk av `<DdsProvider>` og fjernet `<ThemeProvider>`.
- Utbedrer noen statiske usynlige ledetekster og beskrivelser for UU/skjermleser.

## Beskrivelse

_Denne PRen endrer..._

## Sjekkliste

### Generelt

- [ ] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [ ] I commits
  - [ ] I PR-tittelen
- [ ] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
