### PR TITLE
ELSA1-610 `<Select>` lukker dropdown når options endrer seg dynamisk

### DIFF
--- a/.changeset/deep-actors-work.md
+++ b/.changeset/deep-actors-work.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser en bug der `<Select>` lukket dropdown når options endret seg dynamisk.

--- a/packages/dds-components/src/components/Select/Select.tsx
+++ b/packages/dds-components/src/components/Select/Select.tsx
@@ -207,8 +207,7 @@ export function Select<Option = unknown, IsMulti extends boolean = false>({
       ClearIndicator: props => DDSClearIndicator(props, componentSize),
       DropdownIndicator: props => DDSDropdownIndicator(props, componentSize),
       MultiValueRemove: DDSMultiValueRemove,
-      Control: props =>
-        DDSControl(props, componentSize, readOnly, icon, dataTestId),
+      Control: DDSControl(componentSize, readOnly, icon, dataTestId),
     },
     'aria-invalid': hasErrorMessage ? true : undefined,
     required,

--- a/packages/dds-components/src/components/Select/SelectComponents.tsx
+++ b/packages/dds-components/src/components/Select/SelectComponents.tsx
@@ -1,4 +1,4 @@
-import type { JSX } from 'react';
+import { type JSX, useMemo } from 'react';
 import {
   type ClearIndicatorProps,
   type ControlProps,
@@ -124,19 +124,31 @@ export const DDSInput = <TOption, IsMulti extends boolean>(
   />
 );
 
-export const DDSControl = <TValue, IsMulti extends boolean>(
-  props: ControlProps<TValue, IsMulti>,
+interface CustomInnerDDSControlProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  'data-testid'?: string;
+}
+
+export function createDDSControl(
   componentSize: InputSize,
   readOnly?: boolean,
   icon?: SvgIcon,
   dataTestId?: string,
-) => {
-  const { className, ...rest } = props;
+) {
+  return function DDSControlWrapper<TValue, IsMulti extends boolean>(
+    props: ControlProps<TValue, IsMulti>,
+  ) {
+    const { className, children, innerProps, ...rest } = props;
 
-  return (
-    <div data-testid={dataTestId ? dataTestId + '-control' : undefined}>
+    return (
       <Control
         {...rest}
+        innerProps={
+          {
+            ...innerProps,
+            'data-testid': dataTestId ? dataTestId + '-control' : undefined,
+          } as CustomInnerDDSControlProps
+        }
         className={cn(
           className,
           styles.control,
@@ -154,8 +166,19 @@ export const DDSControl = <TValue, IsMulti extends boolean>(
             )}
           />
         )}
-        {props.children}
+        {children}
       </Control>
-    </div>
+    );
+  };
+}
+
+export const DDSControl = (
+  componentSize: InputSize,
+  readOnly?: boolean,
+  icon?: SvgIcon,
+  dataTestId?: string,
+) =>
+  useMemo(
+    () => createDDSControl(componentSize, readOnly, icon, dataTestId),
+    [componentSize, readOnly, icon, dataTestId],
   );
-};


### PR DESCRIPTION
## Beskrivelse

Custom `<DDSControl>` delkomponent ble sendt inn slik i `<ReactSelect>`: `Control: props => DDSControl(props, componentSize, readOnly, icon, dataTestId)`. Det forvirret intern memoization og fokushåndtering. Fikser bugen ved å bruke memo og factory, så delkomponenten kan sendes inn slik: `Control: DDSControl(componentSize, readOnly, icon, dataTestId)`.


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
