### PR TITLE
ELSA1-590 `<TextArea>` bli mindre når tekst fjernes

### DIFF
--- a/.changeset/eleven-paths-lay.md
+++ b/.changeset/eleven-paths-lay.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+`<TextArea>` bli mindre når brukeren fjerner tekst; før endret størrelsen seg kun når brukeren skrev mer tekst, nå endres størrelsen i begge tilfeller.

--- a/packages/dds-components/src/components/TextArea/TextArea.tsx
+++ b/packages/dds-components/src/components/TextArea/TextArea.tsx
@@ -59,9 +59,9 @@ export const TextArea = ({
 
   useEffect(() => {
     if (textAreaRef?.current) {
-      textAreaRef.current.style.height = `${
-        textAreaRef.current.scrollHeight + 2
-      }px`;
+      const el = textAreaRef.current;
+      el.style.height = 'auto';
+      el.style.height = `${el.scrollHeight + 2}px`;
     }
   }, [text]);
 


### PR DESCRIPTION
## Beskrivelse

`<TextArea>` blir nå mindre når brukeren fjerner tekst; før endret størrelsen seg kun når brukeren skrev mer tekst, nå endres størrelsen i begge tilfeller. Grunnen til gamle oppførselen var at høyden var alltid større enn `scrollHeight`; å nullstille til `'auto'` først tillater beregning basert på nåværende tekst.

https://github.com/user-attachments/assets/dd19ca70-c2fb-4bd1-a2fc-dfb90d672c0d



## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
