### PR TITLE
ELSA1-635 Fikser størrelse på spinner i `<Button>`ved loading

### DIFF
--- a/.changeset/chubby-buckets-pay.md
+++ b/.changeset/chubby-buckets-pay.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser størrelse på spinner i `<Button>` ved loading-tilstand.

--- a/packages/dds-components/src/components/Button/Button.tsx
+++ b/packages/dds-components/src/components/Button/Button.tsx
@@ -85,8 +85,7 @@ export const Button = ({
       {loading && (
         <span className={cn(!noContent && styles['spinner-wrapper--absolute'])}>
           <Spinner
-            /*TODO: bytte til icon size token for button når den er på plass*/
-            size="calc(var(--dds-font-lineheight-x1) * 1em)"
+            size="1em"
             color={
               purpose === 'primary' || purpose === 'danger'
                 ? 'iconOnAction'


### PR DESCRIPTION
## Beskrivelse
Størrelse og spacing på spinner skal følge tekst/knapp den erstatter.

Før:
![image](https://github.com/user-attachments/assets/bdde34f2-2459-4fa7-b668-bb90bccf4c36)


Etter:
![image](https://github.com/user-attachments/assets/656012f8-9cce-4bd5-b03d-fefd82b2cce8)


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
