### PR TITLE
ELSA1-644 Ny prop i `<Tooltip>`: `keepMounted`

### DIFF
--- a/.changeset/bright-moons-pick.md
+++ b/.changeset/bright-moons-pick.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Ny prop i `<Tooltip>`: `keepMounted`. Tillater å rendre komponenten når den skal vises, uten at den er alltid i DOM. Har `true` som default.

--- a/packages/dds-components/src/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/dds-components/src/components/Tooltip/Tooltip.spec.tsx
@@ -12,100 +12,410 @@ window.IntersectionObserver = vi.fn().mockImplementation(() => ({
   unobserve: vi.fn(),
   disconnect: vi.fn(),
 }));
+const text = 'text';
 
 describe('<Tooltip>', () => {
-  it('should render tooltip', async () => {
-    const text = 'text';
-    render(
-      <Tooltip text={text}>
-        <Button />
-      </Tooltip>,
-    );
-    const tooltip = screen.getByText(text);
-    await waitFor(() => {
-      expect(tooltip).toHaveAttribute('role', 'tooltip');
-    });
-  });
-  it('should render tooltip text', async () => {
-    const text = 'text';
-    render(
-      <Tooltip text={text}>
-        <Button />
-      </Tooltip>,
-    );
-    const textElement = screen.getByText(text);
-    await waitFor(() => {
-      expect(textElement).toBeInTheDocument();
-    });
-  });
-  it('anchor element should have tooltip id as aria-describedby', async () => {
-    const text = 'text';
-    const id = 'id';
-    render(
-      <Tooltip text={text} tooltipId={id}>
-        <Button />
-      </Tooltip>,
-    );
-    const anchorElement = screen.getByRole('button');
-    const tooltip = screen.getByText(text);
-    expect(anchorElement).toHaveAttribute('aria-describedby', id);
-    expect(tooltip).toHaveAttribute('id', id);
-  });
-  it('should give tooltip aria-hidden=false on focus', async () => {
-    const text = 'text';
-    render(
-      <Tooltip text={text}>
-        <Button />
-      </Tooltip>,
-    );
-    const anchorElement = screen.getByRole('button');
-    fireEvent.focusIn(anchorElement);
-    await waitFor(() => {
-      expect(screen.getByText(text)).toHaveAttribute('aria-hidden', 'false');
-    });
-  });
-  it('should give tooltip aria-hidden=false on mouse over', async () => {
-    const text = 'text';
-    render(
-      <Tooltip text={text}>
-        <Button />
-      </Tooltip>,
-    );
+  describe('persistent', async () => {
+    it('should not make tooltip accessible initially ', async () => {
+      render(
+        <Tooltip text={text}>
+          <Button />
+        </Tooltip>,
+      );
 
-    await userEvent.hover(screen.getByRole('button'));
-    await waitFor(() =>
-      expect(screen.getByText(text)).toHaveAttribute('aria-hidden', 'false'),
-    );
-  });
-  it('should call button onFocus event', async () => {
-    const event = vi.fn();
-    const text = 'text';
-    render(
-      <Tooltip text={text}>
-        <Button onFocus={event} />
-      </Tooltip>,
-    );
-    const anchorElement = screen.getByRole('button');
-    fireEvent.focus(anchorElement!);
-    await waitFor(() => {
+      await waitFor(() => {
+        expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should render tooltip text', async () => {
+      render(
+        <Tooltip text={text}>
+          <Button />
+        </Tooltip>,
+      );
+      const textElement = screen.getByText(text);
+      await waitFor(() => {
+        expect(textElement).toBeInTheDocument();
+      });
+    });
+    it('should make tooltip accessible on hover', async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip text={text}>
+          <Button />
+        </Tooltip>,
+      );
+      const anchorElement = screen.getByRole('button');
+      await user.hover(anchorElement);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      });
+    });
+
+    it('should make tooltip accessible on focus', async () => {
+      render(
+        <Tooltip text={text}>
+          <Button />
+        </Tooltip>,
+      );
+      const anchorElement = screen.getByRole('button');
+      fireEvent.focus(anchorElement);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      });
+    });
+
+    it('anchor element should have tooltip text as accessible description', async () => {
+      const id = 'id';
+      render(
+        <Tooltip text={text} tooltipId={id}>
+          <Button />
+        </Tooltip>,
+      );
+      const anchorElement = screen.getByRole('button');
+      expect(anchorElement).toHaveAccessibleDescription(text);
+    });
+
+    it('should give tooltip aria-hidden=false on focus', async () => {
+      render(
+        <Tooltip text={text}>
+          <Button />
+        </Tooltip>,
+      );
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+      const anchorElement = screen.getByRole('button');
+      fireEvent.focus(anchorElement);
+
+      await waitFor(() => {
+        expect(screen.getByText(text)).toHaveAttribute('aria-hidden', 'false');
+        expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      });
+    });
+
+    it('should give tooltip aria-hidden=true on blur', async () => {
+      render(
+        <Tooltip text={text}>
+          <Button />
+        </Tooltip>,
+      );
+
+      const anchorElement = screen.getByRole('button');
+      fireEvent.focus(anchorElement);
+
+      await waitFor(() => {
+        expect(screen.getByText(text)).toHaveAttribute('aria-hidden', 'false');
+      });
+      fireEvent.blur(anchorElement);
+      await waitFor(() => {
+        expect(screen.getByText(text)).toHaveAttribute('aria-hidden', 'true');
+      });
+    });
+
+    it('should give tooltip aria-hidden=false on mouse over', async () => {
+      render(
+        <Tooltip text={text}>
+          <Button />
+        </Tooltip>,
+      );
+
+      await userEvent.hover(screen.getByRole('button'));
+      await waitFor(() =>
+        expect(screen.getByText(text)).toHaveAttribute('aria-hidden', 'false'),
+      );
+    });
+
+    it('should give tooltip aria-hidden=true on mouse leave', async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip text={text}>
+          <Button />
+        </Tooltip>,
+      );
+
+      await user.hover(screen.getByRole('button'));
+      await user.unhover(screen.getByRole('button'));
+      await waitFor(() =>
+        expect(screen.getByText(text)).toHaveAttribute('aria-hidden', 'true'),
+      );
+    });
+
+    it('should call button onFocus event', async () => {
+      const event = vi.fn();
+      render(
+        <Tooltip text={text}>
+          <Button onFocus={event} />
+        </Tooltip>,
+      );
+      const anchorElement = screen.getByRole('button');
+      fireEvent.focus(anchorElement!);
+      await waitFor(() => {
+        expect(event).toHaveBeenCalled();
+      });
+    });
+
+    it('should call button onBlur event', async () => {
+      const event = vi.fn();
+      render(
+        <Tooltip text={text}>
+          <Button onBlur={event} />
+        </Tooltip>,
+      );
+      const anchorElement = screen.getByRole('button');
+      fireEvent.focus(anchorElement!);
+      fireEvent.blur(anchorElement!);
+      await waitFor(() => {
+        expect(event).toHaveBeenCalled();
+      });
+    });
+
+    it('should call container onMouseOver event', async () => {
+      const event = vi.fn();
+      const testId = 'test1';
+      render(
+        <Tooltip onMouseOver={event} text={text} data-testid={testId}>
+          <Button />
+        </Tooltip>,
+      );
+
+      const containerElement = screen.getByTestId(testId);
+
+      await userEvent.hover(containerElement);
+
       expect(event).toHaveBeenCalled();
     });
+
+    it('should call container onMouseLeave event', async () => {
+      const event = vi.fn();
+      const user = userEvent.setup();
+      const testId = 'test1';
+      render(
+        <Tooltip onMouseLeave={event} text={text} data-testid={testId}>
+          <Button />
+        </Tooltip>,
+      );
+
+      const containerElement = screen.getByTestId(testId);
+
+      await user.hover(containerElement);
+      await user.unhover(containerElement);
+
+      expect(event).toHaveBeenCalled();
+    });
+
+    it('should close on Esc', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Tooltip text={text}>
+          <Button />
+        </Tooltip>,
+      );
+      await user.hover(screen.getByRole('button'));
+      await waitFor(() => {
+        expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      });
+
+      await user.keyboard('{Escape}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+      });
+    });
   });
-  it('should call container onMouseLeave event', async () => {
-    const event = vi.fn();
-    const text = 'text';
-    const testId = 'test1';
-    render(
-      <Tooltip onMouseLeave={event} text={text} data-testid={testId}>
-        <Button />
-      </Tooltip>,
-    );
+  describe('not persistent', () => {
+    it('should not render tooltip initially', async () => {
+      render(
+        <Tooltip keepMounted={false} text={text}>
+          <Button />
+        </Tooltip>,
+      );
+      await waitFor(() => {
+        expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+      });
+    });
 
-    const containerElement = screen.getByTestId(testId);
+    it('should render tooltip on hover', async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip keepMounted={false} text={text}>
+          <Button />
+        </Tooltip>,
+      );
+      const button = screen.getByRole('button');
+      await user.hover(button);
 
-    await userEvent.hover(containerElement);
-    await userEvent.unhover(containerElement);
+      await waitFor(() => {
+        expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      });
+    });
 
-    expect(event).toHaveBeenCalled();
+    it('should render tooltip on focus', async () => {
+      render(
+        <Tooltip keepMounted={false} text={text}>
+          <Button />
+        </Tooltip>,
+      );
+      const button = screen.getByRole('button');
+      fireEvent.focus(button);
+
+      await waitFor(() => {
+        expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      });
+    });
+
+    it('should render tooltip text when mounted', async () => {
+      render(
+        <Tooltip keepMounted={false} text={text}>
+          <Button />
+        </Tooltip>,
+      );
+      const anchorElement = screen.getByRole('button');
+      await userEvent.hover(anchorElement);
+
+      await waitFor(() => {
+        expect(screen.getByText(text)).toBeInTheDocument();
+      });
+    });
+
+    it('anchor element should not have accessible description when tooltip not mounted', async () => {
+      const id = 'id';
+      render(
+        <Tooltip keepMounted={false} text={text} tooltipId={id}>
+          <Button />
+        </Tooltip>,
+      );
+      const anchorElement = screen.getByRole('button');
+      expect(anchorElement).not.toHaveAccessibleDescription();
+    });
+
+    it('anchor element should have tooltip text as accessible description', async () => {
+      const id = 'id';
+      const user = userEvent.setup();
+      render(
+        <Tooltip keepMounted={false} text={text} tooltipId={id}>
+          <Button />
+        </Tooltip>,
+      );
+      const anchorElement = screen.getByRole('button');
+      await user.hover(anchorElement);
+      await waitFor(() => {
+        expect(anchorElement).toHaveAccessibleDescription(text);
+      });
+    });
+
+    it('should call button onFocus event', async () => {
+      const event = vi.fn();
+
+      render(
+        <Tooltip keepMounted={false} text={text}>
+          <Button onFocus={event} />
+        </Tooltip>,
+      );
+      const anchorElement = screen.getByRole('button');
+      fireEvent.focus(anchorElement!);
+      await waitFor(() => {
+        expect(event).toHaveBeenCalled();
+      });
+    });
+
+    it('should call button onBlur event', async () => {
+      const event = vi.fn();
+      render(
+        <Tooltip keepMounted={false} text={text}>
+          <Button onBlur={event} />
+        </Tooltip>,
+      );
+      const anchorElement = screen.getByRole('button');
+      fireEvent.focus(anchorElement!);
+      fireEvent.blur(anchorElement!);
+      await waitFor(() => {
+        expect(event).toHaveBeenCalled();
+      });
+    });
+
+    it('should call container onMouseOver event', async () => {
+      const event = vi.fn();
+      const testId = 'test1';
+      render(
+        <Tooltip
+          keepMounted={false}
+          onMouseOver={event}
+          text={text}
+          data-testid={testId}
+        >
+          <Button />
+        </Tooltip>,
+      );
+
+      const containerElement = screen.getByTestId(testId);
+
+      await userEvent.hover(containerElement);
+
+      expect(event).toHaveBeenCalled();
+    });
+
+    it('should call container onMouseLeave event', async () => {
+      const event = vi.fn();
+
+      const testId = 'test1';
+      render(
+        <Tooltip
+          keepMounted={false}
+          onMouseLeave={event}
+          text={text}
+          data-testid={testId}
+        >
+          <Button />
+        </Tooltip>,
+      );
+      const containerElement = screen.getByTestId(testId);
+
+      await userEvent.hover(containerElement);
+      await userEvent.unhover(containerElement);
+
+      expect(event).toHaveBeenCalled();
+    });
+
+    it('should not use aria-hidden', async () => {
+      const user = userEvent.setup();
+      render(
+        <Tooltip keepMounted={false} text={text}>
+          <Button />
+        </Tooltip>,
+      );
+      const button = screen.getByRole('button');
+      await user.hover(button);
+
+      await waitFor(() => {
+        const tooltip = screen.getByRole('tooltip');
+        expect(tooltip).toBeInTheDocument();
+        expect(tooltip).not.toHaveAttribute('aria-hidden');
+      });
+    });
+
+    it('should close on Esc', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <Tooltip keepMounted={false} text={text}>
+          <Button />
+        </Tooltip>,
+      );
+      await user.hover(screen.getByRole('button'));
+      await waitFor(() => {
+        expect(screen.getByRole('tooltip')).toBeInTheDocument();
+      });
+
+      await user.keyboard('{Escape}');
+
+      await waitFor(() => {
+        expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/packages/dds-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/dds-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -40,6 +40,17 @@ export const Default: Story = {
   ),
 };
 
+export const NotKeptMounted: Story = {
+  args: { text: 'Dette er en tooltip' },
+  render: args => (
+    <StoryVStack alignItems="center" paddingBlock="x6">
+      <Tooltip {...args} keepMounted={false}>
+        <Button icon={HelpIcon} aria-label="Vis forklaring" />
+      </Tooltip>
+    </StoryVStack>
+  ),
+};
+
 export const Overview: Story = {
   render: () => (
     <StoryHStack justifyContent="center" paddingBlock="x6">


### PR DESCRIPTION
## Beskrivelse

Tillater å rendre komponenten når den skal vises, uten at den er alltid i DOM. Har `true` som default.

Refaktorerer tester i samme slengen og legger til flere.


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
