### PR TITLE
ELSA1-641 Bytter navn på primær story til `preview`

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -30,7 +30,8 @@ const preview: Preview = {
           </Unstyled>
         </DocsContainer>
       ),
-
+      canvas: { sourceState: 'shown' },
+      story: { inline: true },
       controls: { sort: 'requiredFirst' },
       codePanel: true,
     },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -359,15 +359,15 @@ import * as delkomponentStories from './DelkomponentNavn.stories'
 
 ## Props
 
-// Referanse til primære storien, ofte komponentStories.Default.
+// Referanse til primære storien, ofte komponentStories.Preview.
 // Bruk Canvas for demo og Controls for kotrollere.
-<Canvas of={komponentStories.Default} />
-<Controls of={komponentStories.Default} />
+<Canvas of={komponentStories.Preview} />
+<Controls of={komponentStories.Preview} />
 
 // Hvis det er delkomponenter, vis demoer for de også.
 ### Delkomponent
 
-<Canvas of={delkomponentStories.Default} />
+<Canvas of={delkomponentStories.Preview} />
 
 // Eksempler ved behov
 ## Eksempler

--- a/packages/dds-components/src/components/Accordion/Accordion.mdx
+++ b/packages/dds-components/src/components/Accordion/Accordion.mdx
@@ -37,9 +37,9 @@ En container for Accordion-subkomponenter som håndterer oppførsel og universel
 
 En gruppe med `<Accordion>` legges i en `<div>` container.
 
-<Canvas of={AccordionStories.Default} />
+<Canvas of={AccordionStories.Preview} />
 
-<Controls of={AccordionStories.Default} />
+<Controls of={AccordionStories.Preview} />
 
 ### AccordionHeader
 

--- a/packages/dds-components/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/dds-components/src/components/Accordion/Accordion.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { Button } from '../Button';
 import {
   DetailList,
@@ -19,20 +19,14 @@ import { Accordion, AccordionBody, AccordionHeader } from '.';
 export default {
   title: 'dds-components/Components/Accordion',
   component: Accordion,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof Accordion>;
 
 type Story = StoryObj<typeof Accordion>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => (
     <Accordion {...args}>
       <AccordionHeader>Header</AccordionHeader>

--- a/packages/dds-components/src/components/BackLink/BackLink.mdx
+++ b/packages/dds-components/src/components/BackLink/BackLink.mdx
@@ -18,8 +18,8 @@ import * as BackLinkStories from './BackLink.stories';
 
 ## Props
 
-<Canvas of={BackLinkStories.Default} />
-<Controls of={BackLinkStories.Default} />
+<Canvas of={BackLinkStories.Preview} />
+<Controls of={BackLinkStories.Preview} />
 
 I tillegg støttes native props `href` og `onClick`.
 

--- a/packages/dds-components/src/components/BackLink/BackLink.stories.tsx
+++ b/packages/dds-components/src/components/BackLink/BackLink.stories.tsx
@@ -9,12 +9,6 @@ import { BackLink } from '.';
 const meta: Meta<typeof BackLink> = {
   title: 'dds-components/Components/BackLink',
   component: BackLink,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
   argTypes: {
     href: {
       table: categoryHtml,
@@ -35,6 +29,6 @@ export default meta;
 
 type Story = StoryObj<typeof BackLink>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { label: 'Forrige nivå', href: '#' },
 };

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumb.stories.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumb.stories.tsx
@@ -9,12 +9,6 @@ import { Breadcrumb } from '.';
 export default {
   title: 'dds-components/Components/Breadcrumbs/Breadcrumb',
   component: Breadcrumb,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
   argTypes: {
     href: {
       control: 'text',
@@ -27,7 +21,7 @@ export default {
 
 type Story = StoryObj<typeof Breadcrumb>;
 
-export const BreadcrumbDefault: Story = {
+export const BreadcrumbPreview: Story = {
   args: {
     children: 'Side',
   },

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -28,8 +28,8 @@ Komponenten kan være responsiv hvis et brekkepunkt er spesifisert.
 
 ### Breadcrumbs
 
-<Canvas of={BreadcrumbsStories.Default} />
-<Controls of={BreadcrumbsStories.Default} />
+<Canvas of={BreadcrumbsStories.Preview} />
+<Controls of={BreadcrumbsStories.Preview} />
 
 Selve brødsmulestien. Skal ha `<Breadcrumb>` som barn.
 
@@ -41,7 +41,7 @@ Brødsmule. Returnerer `<a>` hvis `href`-prop er oppgitt eller `<span>` hvis ikk
 
 **OBS!** Alle `<Breadcrumb>`-komponenter bør være lenker bortsett fra den siste som tilsvarer siden brukeren er inne på.
 
-<Canvas of={BreadcrumbStories.BreadcrumbDefault} />
+<Canvas of={BreadcrumbStories.BreadcrumbPreview} />
 
 Den støtter alle native HTML-attributter som er en del av `AnchorHTMLAttributes<HTMLAnchorElement>` eller `HTMLAttributes<HTMLSpanElement>` -interface.
 

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -9,12 +9,6 @@ import { Breadcrumb, Breadcrumbs } from '.';
 const meta: Meta<typeof Breadcrumbs> = {
   title: 'dds-components/Components/Breadcrumbs',
   component: Breadcrumbs,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
   argTypes: {
     ...commonArgTypes,
   },
@@ -38,7 +32,7 @@ const children = [
   <Breadcrumb>Siden du er på</Breadcrumb>,
 ];
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     children,
   },

--- a/packages/dds-components/src/components/Button/Button.mdx
+++ b/packages/dds-components/src/components/Button/Button.mdx
@@ -15,8 +15,8 @@ import * as ButtonStories from './Button.stories';
 
 ## Props
 
-<Canvas of={ButtonStories.Default} sourceState="shown" />
-<Controls of={ButtonStories.Default} />
+<Canvas of={ButtonStories.Preview} />
+<Controls of={ButtonStories.Preview} />
 
 Native HTML-attributter `type`, `onClick`, `onFocus` og `onBlur` er tilgjengelige på rotnivå.
 

--- a/packages/dds-components/src/components/Button/Button.stories.tsx
+++ b/packages/dds-components/src/components/Button/Button.stories.tsx
@@ -4,8 +4,8 @@ import { fn } from 'storybook/test';
 import { ArrowLeftIcon } from '../..';
 import {
   categoryHtml,
+  commonArgTypes,
   htmlEventArgType,
-  htmlPropsArgType,
 } from '../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
@@ -14,18 +14,12 @@ import { Button } from '.';
 export default {
   title: 'dds-components/Components/Button',
   component: Button,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
   argTypes: {
     href: { table: categoryHtml },
     children: { control: 'text' },
     target: { control: false, table: categoryHtml },
     icon: { control: false },
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
     onClick: htmlEventArgType,
     onBlur: htmlEventArgType,
     onFocus: htmlEventArgType,
@@ -35,7 +29,7 @@ export default {
 
 type Story = StoryObj<typeof Button>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { children: 'Tekst' },
 };
 

--- a/packages/dds-components/src/components/ButtonGroup/ButtonGroup.mdx
+++ b/packages/dds-components/src/components/ButtonGroup/ButtonGroup.mdx
@@ -18,8 +18,8 @@ import * as ButtonGroupStories from './ButtonGroup.stories';
 
 ## Props
 
-<Canvas of={ButtonGroupStories.Default} />
-<Controls of={ButtonGroupStories.Default} />
+<Canvas of={ButtonGroupStories.Preview} />
+<Controls of={ButtonGroupStories.Preview} />
 
 ## Retningslinjer
 

--- a/packages/dds-components/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/dds-components/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { categoryHtml, htmlPropsArgType } from '../../storybook/helpers';
+import { categoryHtml, commonArgTypes } from '../../storybook/helpers';
 import { Button } from '../Button/Button';
 import { StoryVStack } from '../layout/Stack/utils';
 
@@ -9,23 +9,17 @@ import { ButtonGroup } from '.';
 export default {
   title: 'dds-components/Components/ButtonGroup',
   component: ButtonGroup,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
   argTypes: {
     role: { control: 'text', table: categoryHtml },
     'aria-label': { table: categoryHtml },
     'aria-labelledby': { table: categoryHtml },
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof ButtonGroup>;
 
 type Story = StoryObj<typeof ButtonGroup>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => (
     <ButtonGroup {...args}>
       <Button>Første</Button>

--- a/packages/dds-components/src/components/Card/Card.mdx
+++ b/packages/dds-components/src/components/Card/Card.mdx
@@ -37,8 +37,8 @@ Det finnes følgene typer `<Card>`:
 
 Wrapper for innhold i et kort. Bruk design-tokens for spacing og annet styling der relevant. Har default typografi.
 
-<Canvas of={CardStories.Default} />
-<Controls of={CardStories.Default} />
+<Canvas of={CardStories.Preview} />
+<Controls of={CardStories.Preview} />
 
 ### CardExpandable
 

--- a/packages/dds-components/src/components/Card/Card.stories.tsx
+++ b/packages/dds-components/src/components/Card/Card.stories.tsx
@@ -2,7 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 
-import { htmlEventArgType, htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes, htmlEventArgType } from '../../storybook/helpers';
 import {
   DescriptionList,
   DescriptionListDesc,
@@ -22,14 +22,8 @@ import {
 export default {
   title: 'dds-components/Components/Card',
   component: Card,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
     cardRef: { control: false },
     onClick: htmlEventArgType,
   },
@@ -54,7 +48,7 @@ const contentContainerStyle = (
   </style>
 );
 
-export const Default: Story = {
+export const Preview: Story = {
   decorators: [
     Story => (
       <>

--- a/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectable.stories.tsx
+++ b/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectable.stories.tsx
@@ -5,8 +5,9 @@ import { fn } from 'storybook/test';
 import { CardSelectable } from './CardSelectable';
 import {
   categoryHtml,
+  commonArgTypes,
+  htmlArgType,
   htmlEventArgType,
-  htmlPropsArgType,
   responsivePropsArgTypes,
 } from '../../../storybook/helpers';
 import { VStack } from '../../layout';
@@ -18,24 +19,16 @@ import {
   type CardSelectableType,
 } from '../Card.types';
 
-const { padding } = responsivePropsArgTypes;
-
 export default {
   title: 'dds-components/Components/Card/CardSelectable',
   component: CardSelectable,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
     checked: { table: categoryHtml, control: 'boolean' },
     disabled: { table: categoryHtml, control: 'boolean' },
-    value: htmlPropsArgType,
-    defaultValue: htmlPropsArgType,
-    padding,
+    value: htmlArgType,
+    defaultValue: htmlArgType,
+    padding: responsivePropsArgTypes.padding,
     onChange: htmlEventArgType,
     onBlur: htmlEventArgType,
   },

--- a/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectableGroup.stories.tsx
+++ b/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectableGroup.stories.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import { CardSelectable } from './CardSelectable';
 import { CardSelectableGroup } from './CardSelectableGroup';
 import {
-  htmlPropsArgType,
+  commonArgTypes,
   responsivePropsArgTypes,
 } from '../../../storybook/helpers';
 import { Button } from '../../Button';
@@ -28,16 +28,8 @@ const {
 export default {
   title: 'dds-components/Components/Card/CardSelectable/Group',
   component: CardSelectableGroup,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
   argTypes: {
-    htmlProps: htmlPropsArgType,
-    className: htmlPropsArgType,
-    id: htmlPropsArgType,
+    ...commonArgTypes,
     alignItems,
     flexDirection,
     columnGap,

--- a/packages/dds-components/src/components/Chip/Chip.mdx
+++ b/packages/dds-components/src/components/Chip/Chip.mdx
@@ -24,12 +24,12 @@ Komponenten består av to subkomponenter:
 
 ### Chip
 
-<Canvas of={ChipStories.Default} />
-<Controls of={ChipStories.Default} />
+<Canvas of={ChipStories.Preview} />
+<Controls of={ChipStories.Preview} />
 
 ### ChipGroup
 
-<Canvas of={ChipGroupStories.Default} />
+<Canvas of={ChipGroupStories.Preview} />
 
 Det støttes alle native HTML-attributter for `<ul>`.
 

--- a/packages/dds-components/src/components/Chip/Chip.stories.tsx
+++ b/packages/dds-components/src/components/Chip/Chip.stories.tsx
@@ -1,27 +1,21 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 
 import { Chip } from '.';
 
 export default {
   title: 'dds-components/Components/Chip',
   component: Chip,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
   args: { onClose: fn() },
 } satisfies Meta<typeof Chip>;
 
 type Story = StoryObj<typeof Chip>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { text: 'Chip' },
 };

--- a/packages/dds-components/src/components/Chip/ChipGroup.stories.tsx
+++ b/packages/dds-components/src/components/Chip/ChipGroup.stories.tsx
@@ -1,26 +1,15 @@
 import { type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
-
 import { Chip, ChipGroup } from '.';
 
 export default {
   title: 'dds-components/Components/Chip/ChipGroup',
   component: ChipGroup,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
-  argTypes: {
-    htmlProps: htmlPropsArgType,
-  },
 };
 
 type Story = StoryObj<typeof ChipGroup>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => (
     <ChipGroup {...args}>
       <Chip text="Chip 1" />

--- a/packages/dds-components/src/components/Contrast/Contrast.mdx
+++ b/packages/dds-components/src/components/Contrast/Contrast.mdx
@@ -22,8 +22,8 @@ På denne måten slipper konsumenten å tenke på fargene, og komponenten følge
 
 Komponenten har default bakgrunnsfarge som kan overskrives med egen CSS. **OBS!** bruk farger med `surface-inverse` i navnet.
 
-<Canvas of={ContrastStories.Default} />
-<Controls of={ContrastStories.Default} />
+<Canvas of={ContrastStories.Preview} />
+<Controls of={ContrastStories.Preview} />
 
 ## Eksempler
 

--- a/packages/dds-components/src/components/Contrast/Contrast.stories.tsx
+++ b/packages/dds-components/src/components/Contrast/Contrast.stories.tsx
@@ -19,12 +19,6 @@ import { Contrast } from '.';
 const meta: Meta<typeof Contrast> = {
   title: 'dds-components/Components/Contrast',
   component: Contrast,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
   argTypes: {
     as: { control: 'text' },
   },
@@ -40,7 +34,7 @@ const meta: Meta<typeof Contrast> = {
 export default meta;
 type Story = StoryObj<typeof Contrast>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => (
     <Contrast {...args} style={{ padding: 'var(--dds-spacing-x2)' }}>
       <Paragraph>

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.mdx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.mdx
@@ -21,8 +21,8 @@ import * as CookieBannerStories from './CookieBanner.stories';
 
 ## Props
 
-<Canvas of={CookieBannerStories.Default} />
-<Controls of={CookieBannerStories.Default} />
+<Canvas of={CookieBannerStories.Preview} />
+<Controls of={CookieBannerStories.Preview} />
 
 ## Retningslinjer
 

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.stories.tsx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.stories.tsx
@@ -3,8 +3,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { CookieBanner } from './CookieBanner';
 import { LanguageProvider } from '../../i18n';
 import {
-  categoryHtml,
-  htmlPropsArgType,
+  commonArgTypes,
   responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
@@ -19,8 +18,7 @@ const meta: Meta<typeof CookieBanner> = {
   title: 'dds-components/Components/CookieBanner',
   component: CookieBanner,
   argTypes: {
-    htmlProps: htmlPropsArgType,
-    id: { control: false, table: categoryHtml },
+    ...commonArgTypes,
     position,
     left,
     right,
@@ -28,12 +26,6 @@ const meta: Meta<typeof CookieBanner> = {
     bottom,
     maxHeight,
     width,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
   },
   decorators: [
     Story => (
@@ -48,7 +40,7 @@ export default meta;
 
 type Story = StoryObj<typeof CookieBanner>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     headerText: 'Tittel for banner',
     description: (

--- a/packages/dds-components/src/components/DescriptionList/DescriptionList.mdx
+++ b/packages/dds-components/src/components/DescriptionList/DescriptionList.mdx
@@ -31,8 +31,8 @@ Beskrivelseslister bygges med følgende subkomponenter:
 
 Tilsvarer `<dl>`.
 
-<Canvas of={DescriptionListStories.Default} sourceState="shown" />
-<Controls of={DescriptionListStories.Default} />
+<Canvas of={DescriptionListStories.Preview} />
+<Controls of={DescriptionListStories.Preview} />
 
 ### DescriptionListTerm
 
@@ -57,4 +57,4 @@ til andre formål.
 Hvis beskrivelseslisten skal legge seg over flere kolonner
 på en spesifikk måte kan man sette `direction="row"` på DescriptionList-elementet.
 
-<Canvas of={DescriptionListStories.RowDirectionExample} sourceState="shown" />
+<Canvas of={DescriptionListStories.RowDirectionExample} />

--- a/packages/dds-components/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/packages/dds-components/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { CallIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { Typography } from '../Typography';
@@ -15,20 +15,15 @@ import {
 export default {
   title: 'dds-components/Components/DescriptionList',
   component: DescriptionList,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
+
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof DescriptionList>;
 
 type Story = StoryObj<typeof DescriptionList>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => (
     <DescriptionList {...args}>
       <DescriptionListTerm>Tittel</DescriptionListTerm>

--- a/packages/dds-components/src/components/DetailList/DetailList.mdx
+++ b/packages/dds-components/src/components/DetailList/DetailList.mdx
@@ -31,8 +31,8 @@ Detaljert liste er en beskrivelsesliste formatert som en tabell. Den bygges med 
 
 Tilsvarer `<dl>`.
 
-<Canvas of={DetailListStories.Default} sourceState="shown" />
-<Controls of={DetailListStories.Default} />
+<Canvas of={DetailListStories.Preview} sourceState="shown" />
+<Controls of={DetailListStories.Preview} />
 
 ### DetailListTerm
 

--- a/packages/dds-components/src/components/DetailList/DetailList.stories.tsx
+++ b/packages/dds-components/src/components/DetailList/DetailList.stories.tsx
@@ -1,9 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import {
-  htmlPropsArgType,
-  windowWidthDecorator,
-} from '../../storybook/helpers';
+import { commonArgTypes, windowWidthDecorator } from '../../storybook/helpers';
 import { InlineButton } from '../InlineButton';
 
 import { DetailList, DetailListDesc, DetailListRow, DetailListTerm } from '.';
@@ -11,13 +8,8 @@ import { DetailList, DetailListDesc, DetailListRow, DetailListTerm } from '.';
 export default {
   title: 'dds-components/Components/DetailList',
   component: DetailList,
-  parameters: {
-    docs: {
-      story: { inline: true },
-    },
-  },
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof DetailList>;
 
@@ -84,7 +76,7 @@ const children = [
   </DetailListRow>,
 ];
 
-export const Default: Story = {
+export const Preview: Story = {
   decorators: [
     Story => (
       <>

--- a/packages/dds-components/src/components/Divider/Divider.mdx
+++ b/packages/dds-components/src/components/Divider/Divider.mdx
@@ -15,5 +15,5 @@ import * as DividerStories from './Divider.stories';
 
 ## Props
 
-<Canvas of={DividerStories.Default} sourceState="shown" />
-<Controls of={DividerStories.Default} />
+<Canvas of={DividerStories.Preview} />
+<Controls of={DividerStories.Preview} />

--- a/packages/dds-components/src/components/Divider/Divider.stories.tsx
+++ b/packages/dds-components/src/components/Divider/Divider.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { Contrast } from '../Contrast';
 import { Typography } from '../Typography';
 
@@ -9,20 +9,14 @@ import { Divider } from '.';
 export default {
   title: 'dds-components/Components/Divider',
   component: Divider,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof Divider>;
 
 type Story = StoryObj<typeof Divider>;
 
-export const Default: Story = {};
+export const Preview: Story = {};
 
 const contrastStyling = `
   .story-container {

--- a/packages/dds-components/src/components/Drawer/Drawer.mdx
+++ b/packages/dds-components/src/components/Drawer/Drawer.mdx
@@ -32,8 +32,8 @@ Hovedkomponenten. Den kan brukes kontrollert eller ikke kontrollert.
 
 **OBS!** Støtter ikke `id`; se [DrawerGroup](#drawergroup).
 
-<Canvas of={DrawerStories.Default} />
-<Controls of={DrawerStories.Default} />
+<Canvas of={DrawerStories.Preview} />
+<Controls of={DrawerStories.Preview} />
 
 ### DrawerGroup
 

--- a/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
@@ -3,7 +3,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 import { LanguageProvider } from '../../i18n';
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
@@ -16,12 +16,11 @@ const meta: Meta<typeof Drawer> = {
   component: Drawer,
   parameters: {
     docs: {
-      story: { height: '500px', inline: true, scrollbar: false },
-      canvas: { sourceState: 'shown' },
+      story: { height: '500px', scrollbar: false },
     },
   },
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
     parentElement: { control: false },
     widthProps: { control: false },
   },
@@ -40,7 +39,7 @@ export default meta;
 
 type Story = StoryObj<typeof Drawer>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { header: 'Tittel' },
   render: args => (
     <DrawerGroup>

--- a/packages/dds-components/src/components/EmptyContent/EmptyContent.mdx
+++ b/packages/dds-components/src/components/EmptyContent/EmptyContent.mdx
@@ -18,8 +18,8 @@ Komponenten brukes som en empty state når brukeren er forventet å velge innhol
 
 ## Props
 
-<Canvas of={EmptyContentStories.Default} sourceState="shown" />
-<Controls of={EmptyContentStories.Default} />
+<Canvas of={EmptyContentStories.Preview} />
+<Controls of={EmptyContentStories.Preview} />
 
 ## Eksempler
 

--- a/packages/dds-components/src/components/EmptyContent/EmptyContent.stories.tsx
+++ b/packages/dds-components/src/components/EmptyContent/EmptyContent.stories.tsx
@@ -7,17 +7,11 @@ import { Link } from '../Typography';
 export default {
   title: 'dds-components/Components/EmptyContent',
   component: EmptyContent,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
 } satisfies Meta<typeof EmptyContent>;
 
 type Story = StoryObj<typeof EmptyContent>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { headerText: 'Tittel', message: 'Dette er en tekst.' },
 };
 

--- a/packages/dds-components/src/components/FavStar/FavStar.mdx
+++ b/packages/dds-components/src/components/FavStar/FavStar.mdx
@@ -22,8 +22,8 @@ En komponent for å legge noe til i favoritter; bruker `<input type="checkbox">`
 
 ## Props
 
-<Canvas of={FavStarStories.Default} sourceState="shown" />
-<Controls of={FavStarStories.Default} />
+<Canvas of={FavStarStories.Preview} sourceState="shown" />
+<Controls of={FavStarStories.Preview} />
 
 ## Bruk
 

--- a/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
+++ b/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
@@ -5,8 +5,8 @@ import { fn } from 'storybook/test';
 import { FavStar } from './FavStar';
 import {
   categoryHtml,
+  commonArgTypes,
   htmlEventArgType,
-  htmlPropsArgType,
 } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { focusable } from '../helpers/styling/focus.module.css';
@@ -21,16 +21,10 @@ import { Caption, Link, Typography } from '../Typography';
 const meta: Meta<typeof FavStar> = {
   title: 'dds-components/Components/FavStar',
   component: FavStar,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
   argTypes: {
     checked: { control: false, table: categoryHtml },
     defaultChecked: { table: categoryHtml },
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
     onChange: htmlEventArgType,
   },
   args: { onChange: fn() },
@@ -40,7 +34,7 @@ export default meta;
 
 type Story = StoryObj<typeof FavStar>;
 
-export const Default: Story = {};
+export const Preview: Story = {};
 
 export const OverviewSizes: Story = {
   render: args => (

--- a/packages/dds-components/src/components/Feedback/Feedback.mdx
+++ b/packages/dds-components/src/components/Feedback/Feedback.mdx
@@ -18,8 +18,8 @@ import * as FeedbackStories from './Feedback.stories';
 
 ## Props
 
-<Canvas of={FeedbackStories.Default} sourceState="shown" />
-<Controls of={FeedbackStories.Default} />
+<Canvas of={FeedbackStories.Preview} />
+<Controls of={FeedbackStories.Preview} />
 
 ## Implementasjon hos domstolene
 

--- a/packages/dds-components/src/components/Feedback/Feedback.stories.tsx
+++ b/packages/dds-components/src/components/Feedback/Feedback.stories.tsx
@@ -15,17 +15,11 @@ export default {
       },
     },
   },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
 } satisfies Meta<typeof Feedback>;
 
 type Story = StoryObj<typeof Feedback>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { ratingLabel: 'Hva syns du om tjenesten?' },
 };
 

--- a/packages/dds-components/src/components/Fieldset/Fieldset.mdx
+++ b/packages/dds-components/src/components/Fieldset/Fieldset.mdx
@@ -19,8 +19,8 @@ import * as FieldsetStories from './Fieldset.stories';
 
 ### Fieldset
 
-<Canvas of={FieldsetStories.Default} sourceState="shown" />
-<Controls of={FieldsetStories.Default} />
+<Canvas of={FieldsetStories.Preview} />
+<Controls of={FieldsetStories.Preview} />
 
 ### FieldsetGroup
 

--- a/packages/dds-components/src/components/Fieldset/Fieldset.stories.tsx
+++ b/packages/dds-components/src/components/Fieldset/Fieldset.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import { Fieldset } from './Fieldset';
-import { categoryHtml, htmlPropsArgType } from '../../storybook/helpers';
+import { categoryHtml, commonArgTypes } from '../../storybook/helpers';
 import { TextInput } from '../TextInput';
 import { Legend } from '../Typography';
 import { FieldsetGroup } from './FieldsetGroup';
@@ -11,18 +11,13 @@ export default {
   component: Fieldset,
   argTypes: {
     disabled: { table: categoryHtml },
-    htmlProps: htmlPropsArgType,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-    },
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof Fieldset>;
 
 type Story = StoryObj<typeof Fieldset>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => (
     <Fieldset {...args}>
       <Legend withMargins>Telefon og epost</Legend>

--- a/packages/dds-components/src/components/FileUploader/FileUploader.mdx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.mdx
@@ -18,8 +18,8 @@ import * as FileUploaderStories from './FileUploader.stories';
 
 ## Props
 
-<Canvas of={FileUploaderStories.Default} />
-<Controls of={FileUploaderStories.Default} />
+<Canvas of={FileUploaderStories.Preview} />
+<Controls of={FileUploaderStories.Preview} />
 
 ## Bruk
 

--- a/packages/dds-components/src/components/FileUploader/FileUploader.stories.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.stories.tsx
@@ -21,17 +21,11 @@ export default {
     accept: { control: false },
   },
   args: { onChange: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
 } satisfies Meta<typeof FileUploader>;
 
 type Story = StoryObj<typeof FileUploader>;
 
-export const Default: Story = {};
+export const Preview: Story = {};
 
 const SingleFileUploader = () => {
   const [files, setFiles] = useState<Array<File>>([]);

--- a/packages/dds-components/src/components/Footer/Footer.mdx
+++ b/packages/dds-components/src/components/Footer/Footer.mdx
@@ -36,8 +36,8 @@ Følgende subkomponenter er tilgjengelige:
 
 Du kan åpne [alenestående demo](https://domstolene.github.io/designsystem/?path=/story/dds-components-components-footer--default) og endre bredden til nettleservinduet for å se implementasjonen av brekkpunktene.
 
-<Canvas of={FooterStories.Default} />
-<Controls of={FooterStories.Default} />
+<Canvas of={FooterStories.Preview} />
+<Controls of={FooterStories.Preview} />
 
 ## Subkomponenter
 

--- a/packages/dds-components/src/components/Footer/Footer.stories.tsx
+++ b/packages/dds-components/src/components/Footer/Footer.stories.tsx
@@ -19,12 +19,6 @@ import {
 export default {
   title: 'dds-components/Components/Footer',
   component: Footer,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
 } satisfies Meta<typeof Footer>;
 
 type Story = StoryObj<typeof Footer>;
@@ -79,7 +73,7 @@ const socials = (
   </FooterSocialsGroup>
 );
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => (
     <Footer {...args}>
       <Grid

--- a/packages/dds-components/src/components/GlobalMessage/GlobalMessage.mdx
+++ b/packages/dds-components/src/components/GlobalMessage/GlobalMessage.mdx
@@ -15,5 +15,5 @@ import * as GlobalMessageStories from './GlobalMessage.stories';
 
 ## Props
 
-<Canvas of={GlobalMessageStories.Default} sourceState="shown" />
-<Controls of={GlobalMessageStories.Default} />
+<Canvas of={GlobalMessageStories.Preview} />
+<Controls of={GlobalMessageStories.Preview} />

--- a/packages/dds-components/src/components/GlobalMessage/GlobalMessage.stories.tsx
+++ b/packages/dds-components/src/components/GlobalMessage/GlobalMessage.stories.tsx
@@ -2,27 +2,21 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
 import { GlobalMessage } from './GlobalMessage';
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { StoryVStack } from '../layout/Stack/utils';
 
 export default {
   title: 'dds-components/Components/GlobalMessage',
   component: GlobalMessage,
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
   args: { onClose: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
 } satisfies Meta<typeof GlobalMessage>;
 
 type Story = StoryObj<typeof GlobalMessage>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     purpose: 'info',
     message: 'En tilfeldig melding',

--- a/packages/dds-components/src/components/Icon/Icon.mdx
+++ b/packages/dds-components/src/components/Icon/Icon.mdx
@@ -19,5 +19,5 @@ import * as IconStories from './Icon.stories';
 
 ## Props
 
-<Canvas of={IconStories.Default} sourceState="shown" />
-<Controls of={IconStories.Default} />
+<Canvas of={IconStories.Preview} />
+<Controls of={IconStories.Preview} />

--- a/packages/dds-components/src/components/Icon/Icon.stories.tsx
+++ b/packages/dds-components/src/components/Icon/Icon.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import { OpenExternalIcon as OpenExternal } from './icons/openExternal';
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { StoryHStack } from '../layout/Stack/utils';
 import { Paragraph } from '../Typography';
 
@@ -12,14 +12,8 @@ export default {
   component: Icon,
   argTypes: {
     color: { control: 'text' },
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
     icon: { control: false },
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
   },
 } satisfies Meta<typeof Icon>;
 
@@ -27,7 +21,7 @@ type Story = StoryObj<typeof Icon>;
 
 const icon = OpenExternal;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { icon },
 };
 

--- a/packages/dds-components/src/components/Icon/Icon.tsx
+++ b/packages/dds-components/src/components/Icon/Icon.tsx
@@ -1,3 +1,5 @@
+import { type HTMLAttributes } from 'react';
+
 import { type SvgIcon } from './utils';
 import { type BaseComponentProps, getBaseHTMLProps } from '../../types';
 import { type TextColor } from '../../utils';
@@ -32,7 +34,8 @@ export type IconProps = BaseComponentProps<
      * @default "currentcolor"
      */
     color?: TextColor;
-  }
+  },
+  Omit<HTMLAttributes<SVGSVGElement>, 'color'>
 >;
 
 export function Icon(props: IconProps) {

--- a/packages/dds-components/src/components/Icon/icons.stories.tsx
+++ b/packages/dds-components/src/components/Icon/icons.stories.tsx
@@ -14,6 +14,7 @@ import { Heading, Typography } from '../Typography';
 
 export default {
   title: 'Icons/Overview',
+  parameters: { docs: { canvas: { sourceState: 'none' } } },
 };
 
 export const Overview = () => {

--- a/packages/dds-components/src/components/InlineButton/InlineButton.mdx
+++ b/packages/dds-components/src/components/InlineButton/InlineButton.mdx
@@ -18,8 +18,8 @@ import * as InlineButtontories from './InlineButton.stories';
 
 ## Props
 
-<Canvas of={InlineButtontories.Default} sourceState="shown" />
-<Controls of={InlineButtontories.Default} />
+<Canvas of={InlineButtontories.Preview} />
+<Controls of={InlineButtontories.Preview} />
 
 ## Eksempel
 

--- a/packages/dds-components/src/components/InlineButton/InlineButton.stories.tsx
+++ b/packages/dds-components/src/components/InlineButton/InlineButton.stories.tsx
@@ -16,17 +16,11 @@ export default {
     onBlur: htmlEventArgType,
   },
   args: { onClick: fn(), onBlur: fn(), onFocus: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
 } satisfies Meta<typeof InlineButton>;
 
 type Story = StoryObj<typeof InlineButton>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     children: 'Vis mer',
   },

--- a/packages/dds-components/src/components/InlineEdit/InlineEdit.mdx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEdit.mdx
@@ -29,19 +29,19 @@ import * as InlineEditSelectStories from './InlineEditSelect/InlineEditSelect.st
 
 Inputfelt. Returnerer `<input>`.
 
-<Canvas of={InlineEditInputStories.Default} sourceState="shown" />
-<Controls of={InlineEditInputStories.Default} />
+<Canvas of={InlineEditInputStories.Preview} />
+<Controls of={InlineEditInputStories.Preview} />
 
 ### InlineEditTextArea
 
 Inputfelt med flere linjer. Returnerer `<textarea>`.
 
-<Canvas of={InlineEditTextAreaStories.Default} sourceState="shown" />
-<Controls of={InlineEditTextAreaStories.Default} />
+<Canvas of={InlineEditTextAreaStories.Preview} />
+<Controls of={InlineEditTextAreaStories.Preview} />
 
 ### InlineEditSelect
 
 Nedtrekksliste. Returnerer nativ `<select>`. Bruk `<option>` som barn. **OBS!** husk tom `<option>` for initiell tom verdi og/eller tømbar variant. Komponenten tømmer verdi ved å velge `<option>` uten barn.
 
-<Canvas of={InlineEditSelectStories.Default} sourceState="shown" />
-<Controls of={InlineEditSelectStories.Default} />
+<Canvas of={InlineEditSelectStories.Preview} />
+<Controls of={InlineEditSelectStories.Preview} />

--- a/packages/dds-components/src/components/InlineEdit/InlineEditInput/InlineEditInput.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEditInput/InlineEditInput.stories.tsx
@@ -4,8 +4,8 @@ import { fn } from 'storybook/test';
 
 import { InlineEditInput } from './InlineEditInput';
 import {
-  categoryCss,
   htmlEventArgType,
+  responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../../storybook/helpers';
 import { StoryVStack } from '../../layout/Stack/utils';
@@ -15,7 +15,7 @@ export default {
   title: 'dds-components/Components/InlineEdit/InlineEditInput',
   component: InlineEditInput,
   argTypes: {
-    width: { control: 'text', table: categoryCss },
+    width: responsivePropsArgTypes.width,
     onFocus: htmlEventArgType,
     onBlur: htmlEventArgType,
     onChange: htmlEventArgType,
@@ -30,7 +30,7 @@ export default {
 } satisfies Meta<typeof InlineEditInput>;
 type Story = StoryObj<typeof InlineEditInput>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => {
     const [value, setValue] = useState('');
     return <InlineEditInput {...args} value={value} onSetValue={setValue} />;

--- a/packages/dds-components/src/components/InlineEdit/InlineEditSelect/InlineEditSelect.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEditSelect/InlineEditSelect.stories.tsx
@@ -37,7 +37,7 @@ const children = [
   <option>Alt 3</option>,
 ];
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => {
     const [value, setValue] = useState('');
     return (

--- a/packages/dds-components/src/components/InlineEdit/InlineEditTextArea/InlineEditTextArea.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEditTextArea/InlineEditTextArea.stories.tsx
@@ -31,7 +31,7 @@ export default {
 
 type Story = StoryObj<typeof InlineEditTextArea>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => {
     const [value, setValue] = useState('');
     return <InlineEditTextArea {...args} value={value} onSetValue={setValue} />;

--- a/packages/dds-components/src/components/InputMessage/InputMessage.mdx
+++ b/packages/dds-components/src/components/InputMessage/InputMessage.mdx
@@ -20,5 +20,5 @@ import * as InputMessageStories from './InputMessage.stories';
 
 ## Props
 
-<Canvas of={InputMessageStories.Default} sourceState="shown" />
-<Controls of={InputMessageStories.Default} />
+<Canvas of={InputMessageStories.Preview} />
+<Controls of={InputMessageStories.Preview} />

--- a/packages/dds-components/src/components/InputMessage/InputMessage.stories.tsx
+++ b/packages/dds-components/src/components/InputMessage/InputMessage.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { StoryHStack } from '../layout/Stack/utils';
 
 import { InputMessage } from '.';
@@ -9,19 +9,13 @@ export default {
   title: 'dds-components/Components/InputMessage',
   component: InputMessage,
   argTypes: {
-    htmlProps: htmlPropsArgType,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof InputMessage>;
 
 type Story = StoryObj<typeof InputMessage>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     messageType: 'error',
     message: 'Feilmelding',

--- a/packages/dds-components/src/components/InputStepper/InputStepper.mdx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.mdx
@@ -18,5 +18,5 @@ import * as InputStepperStories from './InputStepper.stories';
 
 ## Props
 
-<Canvas of={InputStepperStories.Default} sourceState="shown" />
-<Controls of={InputStepperStories.Default} />
+<Canvas of={InputStepperStories.Preview} sourceState="shown" />
+<Controls of={InputStepperStories.Preview} />

--- a/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
@@ -4,9 +4,9 @@ import { fn } from 'storybook/test';
 
 import { InputStepper } from './InputStepper';
 import {
-  categoryCss,
   categoryHtml,
-  htmlPropsArgType,
+  commonArgTypes,
+  responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
 import { Button } from '../Button';
@@ -19,21 +19,15 @@ export default {
     defaultValue: { control: 'number', table: categoryHtml },
     disabled: { table: categoryHtml },
     value: { control: 'number', table: categoryHtml },
-    htmlProps: htmlPropsArgType,
-    width: { control: 'text', table: categoryCss },
+    ...commonArgTypes,
+    width: responsivePropsArgTypes.width,
   },
   args: { onChange: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
 } satisfies Meta<typeof InputStepper>;
 
 type Story = StoryObj<typeof InputStepper>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     maxValue: 5,
   },

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.mdx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.mdx
@@ -37,10 +37,7 @@ applikasjoner vil være tilgjengelige ved å trykke på det som i dag er navn p�
 
 ## Props
 
-<Canvas
-  of={InternalHeaderStories.WithNavigationAndContextMenu}
-  sourceState="shown"
-/>
+<Canvas of={InternalHeaderStories.WithNavigationAndContextMenu} />
 <Controls of={InternalHeaderStories.WithNavigationAndContextMenu} />
 
 ### Types

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.stories.tsx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.stories.tsx
@@ -2,10 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
 import { LanguageProvider } from '../../i18n';
-import {
-  htmlPropsArgType,
-  windowWidthDecorator,
-} from '../../storybook/helpers';
+import { commonArgTypes, windowWidthDecorator } from '../../storybook/helpers';
 import { EditIcon } from '../Icon/icons';
 import { StoryVStack } from '../layout/Stack/utils';
 
@@ -18,13 +15,12 @@ const meta: Meta<typeof InternalHeader> = {
     navItems: { control: false },
     contextMenuItems: { control: false },
     user: { control: false },
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
   args: { onCurrentPageChange: fn() },
   parameters: {
     docs: {
-      story: { inline: true, height: '320px' },
-      canvas: { sourceState: 'hidden' },
+      story: { height: '320px' },
     },
   },
   decorators: [

--- a/packages/dds-components/src/components/List/List.mdx
+++ b/packages/dds-components/src/components/List/List.mdx
@@ -25,8 +25,8 @@ Lister bygges med to subkomponenter som tilsvarer native HTML-elementer:
 
 Tilsvarer `<ul>` eller `<ol>`.
 
-<Canvas of={ListStories.Default} sourceState="shown" />
-<Controls of={ListStories.Default} />
+<Canvas of={ListStories.Preview} />
+<Controls of={ListStories.Preview} />
 
 ### ListItem
 

--- a/packages/dds-components/src/components/List/List.stories.tsx
+++ b/packages/dds-components/src/components/List/List.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { StoryHStack } from '../layout/Stack/utils';
 import { Typography } from '../Typography';
 
@@ -9,20 +9,14 @@ import { List, ListItem, type ListProps } from '.';
 export default {
   title: 'dds-components/Components/List',
   component: List,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof List>;
 
 type Story = StoryObj<typeof List>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => (
     <List {...args}>
       <ListItem>Item</ListItem>

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.mdx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.mdx
@@ -15,5 +15,5 @@ import * as LocalMessageStories from './LocalMessage.stories';
 
 ## Props
 
-<Canvas of={LocalMessageStories.Default} sourceState="shown" />
-<Controls of={LocalMessageStories.Default} />
+<Canvas of={LocalMessageStories.Preview} />
+<Controls of={LocalMessageStories.Preview} />

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
@@ -3,8 +3,8 @@ import { fn } from 'storybook/test';
 
 import { LocalMessage } from './LocalMessage';
 import {
-  categoryCss,
-  htmlPropsArgType,
+  commonArgTypes,
+  responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
@@ -15,21 +15,15 @@ export default {
   title: 'dds-components/Components/LocalMessage',
   component: LocalMessage,
   argTypes: {
-    width: { control: 'text', table: categoryCss },
-    htmlProps: htmlPropsArgType,
+    width: responsivePropsArgTypes.width,
+    ...commonArgTypes,
   },
   args: { onClose: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
 } satisfies Meta<typeof LocalMessage>;
 
 type Story = StoryObj<typeof LocalMessage>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     children: 'Dette er en lokal melding',
   },

--- a/packages/dds-components/src/components/Modal/Modal.mdx
+++ b/packages/dds-components/src/components/Modal/Modal.mdx
@@ -34,8 +34,8 @@ Siden modal er en komponent som låser sideinnholdet idet den dukker opp er det 
 
 Hovedkomponenten for modal. Kan ha `<ModalBody>`, `<ModalActions>` og ellers fritt valgt innhold som barn. Legger vertikal spacing mellom barn.
 
-<Canvas of={ModalStories.Default} sourceState="shown" />
-<Controls of={ModalStories.Default} />
+<Canvas of={ModalStories.Preview} />
+<Controls of={ModalStories.Preview} />
 
 ### ModalBody
 

--- a/packages/dds-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/dds-components/src/components/Modal/Modal.stories.tsx
@@ -2,7 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useRef, useState } from 'react';
 import { fn } from 'storybook/test';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { StoryHStack } from '../layout/Stack/utils';
 import { Search } from '../Search';
@@ -22,19 +22,17 @@ const meta: Meta<typeof Modal> = {
   ],
   argTypes: {
     header: { control: 'text' },
-    scrollable: { control: 'boolean' },
     parentElement: { control: false },
     onClose: { control: false },
     isOpen: { control: false },
     triggerRef: { control: false },
     initialFocusRef: { control: false },
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
   args: { onClose: fn() },
   parameters: {
     docs: {
-      story: { height: '350px', inline: true },
-      canvas: { sourceState: 'hidden' },
+      story: { height: '350px' },
     },
   },
 };
@@ -42,7 +40,7 @@ export default meta;
 
 type Story = StoryObj<typeof Modal>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { onClose: undefined },
   render: args => {
     const [closed, setClosed] = useState(true);

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.mdx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.mdx
@@ -56,9 +56,9 @@ Hovedkomponenten `<OverflowMenu>`. Kan brukes kontrollert eller ikke kontrollert
 **OBS!** Støtter ikke `id`; se [OverflowMenuGroup](#overflowmenugroup).
 
 <Canvas>
-  <Story of={OverflowMenuStories.Default} />
+  <Story of={OverflowMenuStories.Preview} />
 </Canvas>
-<Controls of={OverflowMenuStories.Default} />
+<Controls of={OverflowMenuStories.Preview} />
 
 ### OverflowMenuGroup
 

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { EditIcon, MenuIcon, PersonIcon, TrashIcon } from '../Icon/icons';
 import { VStack } from '../layout';
@@ -17,23 +17,26 @@ import {
   OverflowMenuSpan,
 } from '.';
 
+const { className, htmlProps, ref } = commonArgTypes;
+
 export default {
   title: 'dds-components/Components/OverflowMenu',
   component: OverflowMenu,
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    className,
+    htmlProps,
+    ref,
   },
   parameters: {
     docs: {
-      story: { height: '350px', inline: true },
-      canvas: { sourceState: 'shown' },
+      story: { height: '350px' },
     },
   },
 } satisfies Meta<typeof OverflowMenu>;
 
 type Story = StoryObj<typeof OverflowMenu>;
 
-export const Default: Story = {
+export const Preview: Story = {
   parameters: { docs: { story: { height: '480px' } } },
   render: args => {
     return (

--- a/packages/dds-components/src/components/Pagination/Pagination.mdx
+++ b/packages/dds-components/src/components/Pagination/Pagination.mdx
@@ -21,8 +21,8 @@ import * as PaginationStories from './Pagination.stories';
 
 ## Props
 
-<Canvas of={PaginationStories.Default} sourceState="shown" />
-<Controls of={PaginationStories.Default} />
+<Canvas of={PaginationStories.Preview} />
+<Controls of={PaginationStories.Preview} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLElement>`-interface i `htmlProps`.
 

--- a/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
@@ -1,10 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
-import {
-  htmlPropsArgType,
-  windowWidthDecorator,
-} from '../../storybook/helpers';
+import { commonArgTypes, windowWidthDecorator } from '../../storybook/helpers';
 import { StoryVStack } from '../layout/Stack/utils';
 import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
 
@@ -15,15 +12,9 @@ const meta: Meta<typeof Pagination> = {
   component: Pagination,
   argTypes: {
     selectOptions: { control: false },
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
   args: { onChange: fn(), onSelectOptionChange: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
   decorators: [
     Story => (
       <StoryThemeProvider>
@@ -42,7 +33,7 @@ const customOptions = [17, 32, customOptionsItemsAmount].map(o => ({
 
 type Story = StoryObj<typeof Pagination>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { itemsAmount: 100 },
 };
 

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.mdx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.mdx
@@ -23,8 +23,8 @@ import * as PhoneInputStories from './PhoneInput.stories';
 
 ## Props
 
-<Canvas of={PhoneInputStories.Default} />
-<Controls of={PhoneInputStories.Default} />
+<Canvas of={PhoneInputStories.Preview} />
+<Controls of={PhoneInputStories.Preview} />
 
 ## Eksempler
 

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.stories.tsx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.stories.tsx
@@ -5,6 +5,7 @@ import { fn } from 'storybook/test';
 import {
   categoryCss,
   categoryHtml,
+  htmlArgType,
   windowWidthDecorator,
 } from '../../storybook/helpers';
 import { Button } from '../Button';
@@ -23,20 +24,14 @@ export default {
     selectRef: { control: false },
     value: { control: false },
     defaultValue: { control: false },
-    id: { control: false },
+    id: htmlArgType,
   },
   args: { onChange: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
 } satisfies Meta<typeof PhoneInput>;
 
 type Story = StoryObj<typeof PhoneInput>;
 
-export const Default: Story = { args: { label: 'Telefonnummer' } };
+export const Preview: Story = { args: { label: 'Telefonnummer' } };
 
 export const Overview: Story = {
   args: { label: 'Telefonnummer' },

--- a/packages/dds-components/src/components/Popover/Popover.mdx
+++ b/packages/dds-components/src/components/Popover/Popover.mdx
@@ -37,9 +37,9 @@ Komponenten består av tre elementer:
 Selve popover-elementet. Den åpnes når anchor-elementet trykkes. Den kan lukkes på fire måter: ved å trykke på anchor-elementet igjen, Esc-tast, lukkeknapptrykk og via `onBlur`-effekt.
 
 <Canvas>
-  <Story of={PopoverStories.Default} />
+  <Story of={PopoverStories.Preview} />
 </Canvas>
-<Controls of={PopoverStories.Default} />
+<Controls of={PopoverStories.Preview} />
 
 #### Types
 

--- a/packages/dds-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.stories.tsx
@@ -3,7 +3,7 @@ import { useRef, useState } from 'react';
 import { fn } from 'storybook/test';
 
 import { type Placement } from '../../hooks';
-import { htmlEventArgType, htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes, htmlEventArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { InlineButton } from '../InlineButton';
 import { VStack } from '../layout';
@@ -29,14 +29,13 @@ const meta: Meta<typeof Popover> = {
     onBlur: htmlEventArgType,
     isOpen: { control: false },
     anchorRef: { control: false },
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
     sizeProps: { control: false },
   },
   args: { onBlur: fn(), onClose: fn() },
   parameters: {
     docs: {
-      story: { inline: true, height: '300px' },
-      canvas: { sourceState: 'shown' },
+      story: { height: '300px' },
     },
   },
 };
@@ -45,7 +44,7 @@ export default meta;
 
 type Story = StoryObj<typeof Popover>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => (
     <VStack>
       <PopoverGroup>

--- a/packages/dds-components/src/components/ProgressBar/ProgressBar.mdx
+++ b/packages/dds-components/src/components/ProgressBar/ProgressBar.mdx
@@ -21,8 +21,8 @@ import * as ProgressBarStories from './ProgressBar.stories';
 
 ## Props
 
-<Canvas of={ProgressBarStories.Default} sourceState="shown" />
-<Controls of={ProgressBarStories.Default} />
+<Canvas of={ProgressBarStories.Preview} />
+<Controls of={ProgressBarStories.Preview} />
 
 ## Retningslinjer
 

--- a/packages/dds-components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/dds-components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,6 +1,9 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { categoryCss, windowWidthDecorator } from '../../storybook/helpers';
+import {
+  responsivePropsArgTypes,
+  windowWidthDecorator,
+} from '../../storybook/helpers';
 import { StoryVStack } from '../layout/Stack/utils';
 
 import { ProgressBar } from '.';
@@ -9,19 +12,13 @@ export default {
   title: 'dds-components/Components/ProgressBar',
   component: ProgressBar,
   argTypes: {
-    width: { control: 'text', table: categoryCss },
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
+    width: responsivePropsArgTypes.width,
   },
 } satisfies Meta<typeof ProgressBar>;
 
 type Story = StoryObj<typeof ProgressBar>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     label: 'Label',
   },

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.mdx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.mdx
@@ -29,8 +29,8 @@ Komponenten består av:
 
 Ytterste container som styrer hvilket steg skal vises via indeks. Har to eller flere `<ProgressTracker.Item>` som barn.
 
-<Canvas of={ProgressTrackerStories.Default} sourceState="shown" />
-<Controls of={ProgressTrackerStories.Default} />
+<Canvas of={ProgressTrackerStories.Preview} />
+<Controls of={ProgressTrackerStories.Preview} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
 

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
@@ -2,7 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 import { ProgressTracker } from './ProgressTracker';
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { Drawer, DrawerGroup } from '../Drawer';
 import { Fieldset, FieldsetGroup } from '../Fieldset';
@@ -25,19 +25,13 @@ export default {
   title: 'dds-components/Components/ProgressTracker',
   component: ProgressTracker,
   argTypes: {
-    htmlProps: htmlPropsArgType,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof ProgressTracker>;
 
 type Story = StoryObj<typeof ProgressTracker>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => {
     const numSteps = 3;
 

--- a/packages/dds-components/src/components/Search/Search.mdx
+++ b/packages/dds-components/src/components/Search/Search.mdx
@@ -39,8 +39,8 @@ Ikke-compound komponenter er også støttet: `<SearchAutocompleteWrapper>`, `<Se
 
 ### Search
 
-<Canvas of={SearchStories.Default} sourceState="shown" />
-<Controls of={SearchStories.Default} />
+<Canvas of={SearchStories.Preview} />
+<Controls of={SearchStories.Preview} />
 
 #### Types
 

--- a/packages/dds-components/src/components/Search/Search.stories.tsx
+++ b/packages/dds-components/src/components/Search/Search.stories.tsx
@@ -19,12 +19,6 @@ export default {
     onChange: htmlEventArgType,
   },
   args: { onChange: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
 } satisfies Meta<typeof Search>;
 
 const array = [
@@ -47,7 +41,7 @@ const array = [
 
 type Story = StoryObj<typeof Search>;
 
-export const Default: Story = {};
+export const Preview: Story = {};
 
 export const Overview: Story = {
   render: args => (
@@ -133,12 +127,9 @@ export const WithSuggestions: Story = {
       </Search.AutocompleteWrapper>
       <div>
         Elementer i listen:{' '}
-        {array.map((item, index) => (
-          <span>
-            {item}
-            {index !== array.length - 1 && ', '}
-          </span>
-        ))}
+        {array.map(
+          (item, index) => `${item}${index !== array.length - 1 ? ', ' : ''}`,
+        )}
         .
       </div>
     </>

--- a/packages/dds-components/src/components/Select/MultiSelect.stories.tsx
+++ b/packages/dds-components/src/components/Select/MultiSelect.stories.tsx
@@ -22,7 +22,7 @@ const meta: Meta<typeof Select<Option, true>> = {
   },
   parameters: {
     docs: {
-      story: { inline: true, height: '450px' },
+      story: { height: '450px' },
     },
     controls: {
       exclude: ['style', 'className', 'items', 'value', 'defaultValue'],
@@ -54,7 +54,7 @@ const options: Array<Option> = [
   'Alternativ 4',
 ].map(s => ({ label: s, value: s }));
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { label: 'Label', options: options, isMulti: true },
 };
 

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.mdx
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.mdx
@@ -29,8 +29,8 @@ Siden `<select>` automatisk velger første alternativ, tilbyr vi også `<NativeS
 
 Returnerer `<select>`. Bruk native HTML-elementer `<option>` og `<optgroup>` som barn.
 
-<Canvas of={NativeSelectStories.Default} sourceState="shown" />
-<Controls of={NativeSelectStories.Default} />
+<Canvas of={NativeSelectStories.Preview} />
+<Controls of={NativeSelectStories.Preview} />
 
 ### NativeSelectPlaceholder
 

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.stories.tsx
@@ -2,9 +2,9 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
 import {
-  categoryCss,
   categoryHtml,
   htmlEventArgType,
+  responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../../storybook/helpers';
 import { StoryVStack } from '../../layout/Stack/utils';
@@ -14,17 +14,11 @@ import { NativeSelect, NativeSelectPlaceholder } from '.';
 export default {
   title: 'dds-components/Components/Select/NativeSelect',
   component: NativeSelect,
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
   argTypes: {
     label: { control: 'text' },
     tip: { control: 'text' },
     errorMessage: { control: 'text' },
-    width: { control: 'text', table: categoryCss },
+    width: responsivePropsArgTypes.width,
     disabled: { control: 'boolean', table: categoryHtml },
     required: { control: 'boolean', table: categoryHtml },
     readOnly: { control: 'boolean' },
@@ -54,7 +48,7 @@ const nativeOptions = options.map((item, index) => (
 
 const children = [<NativeSelectPlaceholder />, ...nativeOptions];
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     label: 'Label',
     children,

--- a/packages/dds-components/src/components/Select/Select.mdx
+++ b/packages/dds-components/src/components/Select/Select.mdx
@@ -30,13 +30,13 @@ Komponenten har to varianter:
 
 Komponenten bruker <Link href="https://react-select.com/home" external>React-select</Link>. Det støttes props definert i designsystemet (Elsa props) og native React-select props.
 
-<Canvas of={SelectStories.Default} sourceState="shown" />
+<Canvas of={SelectStories.Preview} />
 
 ### Elsa props
 
 Tabellen inkluderer native HTML props som brukes til styling.
 
-<Controls of={SelectStories.Default} />
+<Controls of={SelectStories.Preview} />
 
 ### Native React-select props
 
@@ -155,7 +155,7 @@ Brukeren kan filtrere alternativer ved å gi tekstlig input. Det brukes en custo
 
 Du kan bruke `options` i custom format, og sette label og value basert på option som du vil.
 
-<Canvas of={SelectStories.CustomData} />
+<Canvas of={SelectStories.CustomData} sourceState="hidden" />
 
 <Source
   code={`const employees = [
@@ -186,36 +186,43 @@ Du kan customisere visuelle elementer for både det valgte elemetet og alternati
 
 <Source
   code={`
-  const ref: SelectForwardRefType<
-    {
-      label: string;
-      value: string;
-    },
-    false
-  > = useRef(null);
+import { type SelectForwardRefType } from '@norges-domstoler/dds-components';
+
+function MyComponent() {
+
+const ref: SelectForwardRefType<
+{
+label: string;
+value: string;
+},
+false
+
+> = useRef(null);
 
 return <Select options={[{ label: 'alt', value: 'alt' }]} ref={ref} />;
+
+};
 `}
 />
 
 ### Multiselect
 
-<Canvas of={MultiSelectStories.Default} sourceState="shown" />
-<Controls of={MultiSelectStories.Default} />
+<Canvas of={MultiSelectStories.Preview} />
+<Controls of={MultiSelectStories.Preview} />
 
 #### Bredde ved `isMulti`
 
 Komponenten har default bredde. Dette gjør at valgte alternativer ved `isMulti` vil prøve å fylle opp bredden og videre legge seg nedover. Hvis det er ønsket at komponenten skal utvide seg i bredden når flere alternativer blir valgt bør det settes f.eks. `width='fit-content'` og `min-width` i styling:
 
-<Canvas of={MultiSelectStories.WithFitContent} sourceState="shown" />
+<Canvas of={MultiSelectStories.WithFitContent} />
 
 #### Med verdi
 
-<Canvas of={MultiSelectStories.WithValue} sourceState="shown" />
+<Canvas of={MultiSelectStories.WithValue} />
 
 #### Med default verdi
 
-<Canvas of={MultiSelectStories.WithDefaultValue} sourceState="shown" />
+<Canvas of={MultiSelectStories.WithDefaultValue} />
 
 ## Retningslinjer
 

--- a/packages/dds-components/src/components/Select/Select.stories.tsx
+++ b/packages/dds-components/src/components/Select/Select.stories.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { fn } from 'storybook/internal/test';
 
 import {
-  categoryCss,
   htmlEventArgType,
+  responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
 import { Button } from '../Button';
@@ -20,7 +20,7 @@ const meta: Meta<typeof Select> = {
   title: 'dds-components/Components/Select/Select',
   component: Select,
   argTypes: {
-    width: { control: 'text', table: categoryCss },
+    width: responsivePropsArgTypes.width,
     placeholder: { control: 'text' },
     isDisabled: { control: 'boolean' },
     isClearable: { control: 'boolean' },
@@ -35,7 +35,7 @@ const meta: Meta<typeof Select> = {
   args: { onChange: fn(), onInputChange: fn(), onBlur: fn(), onFocus: fn() },
   parameters: {
     docs: {
-      story: { inline: true, height: '450px' },
+      story: { height: '450px' },
     },
     controls: {
       exclude: ['style', 'className', 'items', 'value', 'defaultValue'],
@@ -90,7 +90,7 @@ const groupedOptions = [
   },
 ];
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { label: 'Label', options: options },
 };
 

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.mdx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.mdx
@@ -24,8 +24,8 @@ Følgende komponenter er tilgjengelige:
 
 ### Checkbox
 
-<Canvas of={CheckboxStories.Default} sourceState="shown" />
-<Controls of={CheckboxStories.Default} />
+<Canvas of={CheckboxStories.Preview} />
+<Controls of={CheckboxStories.Preview} />
 
 Native HTML-attributter `name`, `checked`, `defaultChecked`, `value`, `defaultValue`, `onChange`, `onBlur` er tilgjengelige på rotnivå.
 
@@ -33,8 +33,8 @@ Native HTML-attributter `name`, `checked`, `defaultChecked`, `value`, `defaultVa
 
 Wrapper for en `<Checkbox>` gruppe. Brukes ved flere barn.
 
-<Canvas of={CheckboxGroupStories.Default} sourceState="shown" />
-<Controls of={CheckboxGroupStories.Default} />
+<Canvas of={CheckboxGroupStories.Preview} />
+<Controls of={CheckboxGroupStories.Preview} />
 
 #### Med `<Fieldset>`
 

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
@@ -3,8 +3,9 @@ import { fn } from 'storybook/internal/test';
 
 import {
   categoryHtml,
+  commonArgTypes,
+  htmlArgType,
   htmlEventArgType,
-  htmlPropsArgType,
 } from '../../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../../layout/Stack/utils';
 
@@ -15,28 +16,22 @@ export default {
   component: Checkbox,
   argTypes: {
     disabled: { table: categoryHtml },
-    htmlProps: htmlPropsArgType,
-    'aria-describedby': { control: false, table: categoryHtml },
-    name: { control: false, table: categoryHtml },
-    checked: { control: false, table: categoryHtml },
-    defaultChecked: { control: false, table: categoryHtml },
-    value: { control: false, table: categoryHtml },
-    defaultValue: { control: false, table: categoryHtml },
+    ...commonArgTypes,
+    'aria-describedby': htmlArgType,
+    name: htmlArgType,
+    checked: htmlArgType,
+    defaultChecked: htmlArgType,
+    value: htmlArgType,
+    defaultValue: htmlArgType,
     onBlur: htmlEventArgType,
     onChange: htmlEventArgType,
   },
   args: { onChange: fn(), onBlur: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
 } satisfies Meta<typeof Checkbox>;
 
 type Story = StoryObj<typeof Checkbox>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { label: 'Label' },
 };
 

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../../storybook/helpers';
+import { commonArgTypes } from '../../../storybook/helpers';
 import { Fieldset } from '../../Fieldset';
 import { StoryHStack, StoryVStack } from '../../layout/Stack/utils';
 import { Legend } from '../../Typography';
@@ -11,22 +11,13 @@ export default {
   title: 'dds-components/Components/Checkbox/CheckboxGroup',
   component: CheckboxGroup,
   argTypes: {
-    required: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    readOnly: { control: 'boolean' },
-    htmlProps: htmlPropsArgType,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof CheckboxGroup>;
 
 type Story = StoryObj<typeof CheckboxGroup>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     label: 'Label',
     children: [

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.mdx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.mdx
@@ -24,15 +24,15 @@ Følgende komponenter er tilgjengelige:
 
 ### RadioButton
 
-<Canvas of={RadioButtonStories.Default} sourceState="shown" />
-<Controls of={RadioButtonStories.Default} />
+<Canvas of={RadioButtonStories.Preview} />
+<Controls of={RadioButtonStories.Preview} />
 
 ### RadioButtonGroup
 
 Wrapper for en `<RadioButton>` gruppe. Den håndtere universell utforming og oppførsel.
 
-<Canvas of={RadioButtonGroupStories.Default} sourceState="shown" />
-<Controls of={RadioButtonGroupStories.Default} />
+<Canvas of={RadioButtonGroupStories.Preview} />
+<Controls of={RadioButtonGroupStories.Preview} />
 
 ## Retningslinjer
 

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
@@ -3,8 +3,9 @@ import { fn } from 'storybook/test';
 
 import {
   categoryHtml,
+  commonArgTypes,
+  htmlArgType,
   htmlEventArgType,
-  htmlPropsArgType,
 } from '../../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../../layout/Stack/utils';
 
@@ -15,21 +16,20 @@ export default {
   component: RadioButton,
   argTypes: {
     disabled: { table: categoryHtml },
-    htmlProps: htmlPropsArgType,
+    required: { table: categoryHtml },
+    ...commonArgTypes,
+    'aria-describedby': htmlArgType,
+    name: htmlArgType,
+    checked: htmlArgType,
+    value: htmlArgType,
     onChange: htmlEventArgType,
   },
   args: { onChange: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
 } satisfies Meta<typeof RadioButton>;
 
 type Story = StoryObj<typeof RadioButton>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { label: 'Label' },
 };
 

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
@@ -1,6 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
+import { commonArgTypes } from '../../../storybook/helpers';
 import { Button } from '../../Button';
 import { StoryHStack, StoryVStack } from '../../layout/Stack/utils';
 
@@ -10,18 +11,8 @@ export default {
   title: 'dds-components/Components/RadioButton/RadioButtonGroup',
   component: RadioButtonGroup,
   argTypes: {
-    label: { control: { type: 'text' } },
-    errorMessage: { control: { type: 'text' } },
-    tip: { control: { type: 'text' } },
-    disabled: { control: 'boolean' },
-    readOnly: { control: 'boolean' },
-    required: { control: 'boolean' },
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
+    ...commonArgTypes,
+    value: { control: false },
   },
 } satisfies Meta<typeof RadioButtonGroup>;
 
@@ -42,7 +33,7 @@ const childrenString = [
 let counter = 0;
 const name = () => `test${counter++}`;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { label: 'Label', children },
 };
 

--- a/packages/dds-components/src/components/Skeleton/Skeleton.mdx
+++ b/packages/dds-components/src/components/Skeleton/Skeleton.mdx
@@ -20,8 +20,8 @@ import * as SkeletonStories from './Skeleton.stories';
 
 For hvert element du skal emulere bygger du en individuell `<Skeleton>` med `height`, `width` og `borderRadius`, slik at det ligner på det faktiske innholdet.
 
-<Canvas of={SkeletonStories.Default} />
-<Controls of={SkeletonStories.Default} />
+<Canvas of={SkeletonStories.Preview} />
+<Controls of={SkeletonStories.Preview} />
 
 ## Eksempel
 

--- a/packages/dds-components/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/dds-components/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,28 +1,26 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import { Skeleton } from './Skeleton';
-import { categoryCss, windowWidthDecorator } from '../../storybook/helpers';
+import {
+  categoryCss,
+  responsivePropsArgTypes,
+  windowWidthDecorator,
+} from '../../storybook/helpers';
 import { StoryVStack } from '../layout/Stack/utils';
 
 export default {
   title: 'dds-components/Components/Skeleton',
   component: Skeleton,
   argTypes: {
-    width: { control: 'text', table: categoryCss },
-    height: { control: 'text', table: categoryCss },
-    borderRadius: { control: 'text' },
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
+    width: responsivePropsArgTypes.width,
+    height: responsivePropsArgTypes.height,
+    borderRadius: { control: 'text', table: categoryCss },
   },
 } satisfies Meta<typeof Skeleton>;
 
 type Story = StoryObj<typeof Skeleton>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     width: '320px',
     height: 'var(--dds-spacing-x2)',

--- a/packages/dds-components/src/components/SkipToContent/SkipToContent.mdx
+++ b/packages/dds-components/src/components/SkipToContent/SkipToContent.mdx
@@ -18,8 +18,8 @@ import * as SkipToContentStories from './SkipToContent.stories';
 
 ## Props
 
-<Canvas of={SkipToContentStories.Default} sourceState="shown" />
-<Controls of={SkipToContentStories.Default} />
+<Canvas of={SkipToContentStories.Preview} />
+<Controls of={SkipToContentStories.Preview} />
 
 ## Bruk
 

--- a/packages/dds-components/src/components/SkipToContent/SkipToContent.stories.tsx
+++ b/packages/dds-components/src/components/SkipToContent/SkipToContent.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { categoryCss, commonArgTypes } from '../../storybook/helpers';
 import { Heading } from '../Typography';
 
 import { SkipToContent } from '.';
@@ -9,20 +9,14 @@ export default {
   title: 'dds-components/Components/SkipToContent',
   component: SkipToContent,
   argTypes: {
-    top: { control: 'text' },
-    htmlProps: htmlPropsArgType,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
+    top: { control: 'text', table: categoryCss },
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof SkipToContent>;
 
 type Story = StoryObj<typeof SkipToContent>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { href: '#innhold' },
   render: args => (
     <div style={{ position: 'relative' }}>

--- a/packages/dds-components/src/components/Spinner/Spinner.mdx
+++ b/packages/dds-components/src/components/Spinner/Spinner.mdx
@@ -20,8 +20,8 @@ import * as SpinnerStories from './Spinner.stories';
 
 ## Props
 
-<Canvas of={SpinnerStories.Default} />
-<Controls of={SpinnerStories.Default} />
+<Canvas of={SpinnerStories.Preview} />
+<Controls of={SpinnerStories.Preview} />
 
 ## Retningslinjer
 

--- a/packages/dds-components/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/dds-components/src/components/Spinner/Spinner.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { StoryHStack } from '../layout/Stack/utils';
 
 import { Spinner } from '.';
@@ -11,26 +11,20 @@ export default {
   argTypes: {
     color: { control: 'text' },
     size: { control: 'text' },
-    htmlProps: htmlPropsArgType,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof Spinner>;
 
 type Story = StoryObj<typeof Spinner>;
 
-export const Default: Story = {};
+export const Preview: Story = {};
 
 export const Overview: Story = {
   render: args => (
     <StoryHStack>
       <Spinner {...args} />
-      <Spinner {...args} color="iconSubtle" />
-      <Spinner {...args} color="iconOnSuccessDefault" />
+      <Spinner {...args} color="icon-subtle" />
+      <Spinner {...args} color="icon-on-success-default" />
       <Spinner {...args} size="60px" />
     </StoryHStack>
   ),

--- a/packages/dds-components/src/components/SplitButton/SplitButton.mdx
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.mdx
@@ -24,5 +24,5 @@ Når menyen åpnes og en handling velges blir den umiddelbart gjennomført.
 
 ## Props
 
-<Canvas of={SplitButtonStories.Default} />
-<Controls of={SplitButtonStories.Default} />
+<Canvas of={SplitButtonStories.Preview} />
+<Controls of={SplitButtonStories.Preview} />

--- a/packages/dds-components/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.stories.tsx
@@ -14,8 +14,7 @@ export default {
   component: SplitButton,
   parameters: {
     docs: {
-      story: { inline: true, height: '200px' },
-      canvas: { sourceState: 'shown' },
+      story: { height: '200px' },
     },
   },
   argTypes: {
@@ -38,7 +37,7 @@ const items = [
 
 type Story = StoryObj<typeof SplitButton>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     primaryAction: { children: 'Tekst' },
     secondaryActions: items,

--- a/packages/dds-components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
+++ b/packages/dds-components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
@@ -24,6 +24,11 @@ const meta: Meta<typeof CollapsibleTable> = {
   title: 'dds-components/Components/Table/CollapsibleTable',
   component: CollapsibleTable,
   parameters: {
+    docs: {
+      canvas: {
+        sourceState: 'hidden',
+      },
+    },
     controls: {
       exclude: ['headerValues', 'definingColumnIndex'],
     },

--- a/packages/dds-components/src/components/Table/normal/Table.mdx
+++ b/packages/dds-components/src/components/Table/normal/Table.mdx
@@ -42,7 +42,7 @@ Ikke-compound komponenter er også støttet: `<TableWrapper>`, `<TableHead>`, `<
 
 ### Tabell
 
-<Canvas of={TableStories.Default} />
+<Canvas of={TableStories.Preview} />
 
 ### Kollapsibel tabell
 
@@ -60,8 +60,8 @@ Støtter alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivEl
 
 Tilsvarer `<table>`.
 
-<Canvas of={TableStories.Default} />
-<Controls of={TableStories.Default} />
+<Canvas of={TableStories.Preview} />
+<Controls of={TableStories.Preview} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLTableElement>`-interface.
 

--- a/packages/dds-components/src/components/Table/normal/Table.stories.tsx
+++ b/packages/dds-components/src/components/Table/normal/Table.stories.tsx
@@ -22,7 +22,6 @@ const meta: Meta<typeof Table> = {
   component: Table,
   parameters: {
     docs: {
-      story: { inline: true },
       canvas: { sourceState: 'hidden' },
     },
   },
@@ -47,7 +46,7 @@ const mappedHeaderCells = headerCells.map(headerCell => {
   );
 });
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => (
     <Table.Wrapper>
       <Table {...args}>

--- a/packages/dds-components/src/components/Tabs/Tabs.mdx
+++ b/packages/dds-components/src/components/Tabs/Tabs.mdx
@@ -38,9 +38,9 @@ Komponenten består av flere subkomponenter:
 
 Ytterste container som styrer hvilket panel skal vises via indeks. Har `<TabList>` og `<TabPanels>` som barn.
 
-<Canvas of={TabsStories.Default} sourceState="shown" />
+<Canvas of={TabsStories.Preview} />
 
-<Controls of={TabsStories.Default} />
+<Controls of={TabsStories.Preview} />
 
 ### Tab
 

--- a/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
@@ -2,8 +2,8 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 import {
-  categoryCss,
-  htmlPropsArgType,
+  commonArgTypes,
+  responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
 import { NotificationsIcon } from '../Icon/icons';
@@ -17,21 +17,15 @@ export default {
   title: 'dds-components/Components/Tabs',
   component: Tabs,
   argTypes: {
-    width: { control: 'text', table: categoryCss },
-    htmlProps: htmlPropsArgType,
+    width: responsivePropsArgTypes.width,
+    ...commonArgTypes,
     addTabButtonProps: { control: false },
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
   },
 } satisfies Meta<typeof Tabs>;
 
 type Story = StoryObj<typeof Tabs>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => (
     <Tabs {...args}>
       <TabList>

--- a/packages/dds-components/src/components/Tag/Tag.mdx
+++ b/packages/dds-components/src/components/Tag/Tag.mdx
@@ -15,5 +15,5 @@ import * as TagStories from './Tag.stories';
 
 ## Props
 
-<Canvas of={TagStories.Default} sourceState="shown" />
-<Controls of={TagStories.Default} />
+<Canvas of={TagStories.Preview} />
+<Controls of={TagStories.Preview} />

--- a/packages/dds-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/dds-components/src/components/Tag/Tag.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 import { Tag } from '.';
@@ -10,13 +10,13 @@ export default {
   component: Tag,
   argTypes: {
     children: { control: 'text' },
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
 } satisfies Meta<typeof Tag>;
 
 type Story = StoryObj<typeof Tag>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { children: 'default' },
 };
 

--- a/packages/dds-components/src/components/TextArea/TextArea.mdx
+++ b/packages/dds-components/src/components/TextArea/TextArea.mdx
@@ -15,8 +15,8 @@ import * as TextAreaStories from './TextArea.stories';
 
 ## Props
 
-<Canvas of={TextAreaStories.Default} />
-<Controls of={TextAreaStories.Default} />
+<Canvas of={TextAreaStories.Preview} />
+<Controls of={TextAreaStories.Preview} />
 
 I tillegg støttes alle native HTML-attributter som er en del av `TextareaHTMLAttributes<HTMLTextAreaElement>`-interface.
 

--- a/packages/dds-components/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/dds-components/src/components/TextArea/TextArea.stories.tsx
@@ -21,17 +21,11 @@ export default {
     onChange: htmlEventArgType,
   },
   args: { onChange: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
 } satisfies Meta<typeof TextArea>;
 
 type Story = StoryObj<typeof TextArea>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { label: 'Label' },
 };
 

--- a/packages/dds-components/src/components/TextInput/TextInput.mdx
+++ b/packages/dds-components/src/components/TextInput/TextInput.mdx
@@ -15,8 +15,8 @@ import * as TextInputStories from './TextInput.stories';
 
 ## Props
 
-<Canvas of={TextInputStories.Default} />
-<Controls of={TextInputStories.Default} />
+<Canvas of={TextInputStories.Preview} />
+<Controls of={TextInputStories.Preview} />
 
 ### maxLength
 

--- a/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
@@ -26,17 +26,11 @@ export default {
     onChange: htmlEventArgType,
   },
   args: { onChange: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
 } satisfies Meta<typeof TextInput>;
 
 type Story = StoryObj<typeof TextInput>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { label: 'Label' },
 };
 

--- a/packages/dds-components/src/components/Toggle/Toggle.stories.tsx
+++ b/packages/dds-components/src/components/Toggle/Toggle.stories.tsx
@@ -4,8 +4,9 @@ import { fn } from 'storybook/test';
 
 import {
   categoryHtml,
+  commonArgTypes,
+  htmlArgType,
   htmlEventArgType,
-  htmlPropsArgType,
 } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
@@ -17,23 +18,17 @@ export default {
   component: Toggle,
   argTypes: {
     children: { control: 'text' },
-    disabled: { table: categoryHtml },
-    checked: { table: categoryHtml },
-    defaultChecked: { table: categoryHtml },
-    value: { control: 'boolean', table: categoryHtml },
-    defaultValue: { control: 'boolean', table: categoryHtml },
-    name: { table: categoryHtml },
-    'aria-describedby': { table: categoryHtml },
+    disabled: { control: 'boolean', table: categoryHtml },
+    checked: htmlArgType,
+    defaultChecked: htmlArgType,
+    value: htmlArgType,
+    defaultValue: htmlArgType,
+    name: htmlArgType,
+    'aria-describedby': htmlArgType,
     onBlur: htmlEventArgType,
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
   args: { onChange: fn(), onBlur: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
 } satisfies Meta<typeof Toggle>;
 
 type Story = StoryObj<typeof Toggle>;

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.mdx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.mdx
@@ -26,14 +26,14 @@ ToggleBar er en rad med semantiske radioknapper. Den består av følgende subkom
 
 En rad med `<ToggleRadio>`.
 
-<Canvas of={ToggleBarStories.Default} sourceState="shown" />
-<Controls of={ToggleBarStories.Default} />
+<Canvas of={ToggleBarStories.Preview} />
+<Controls of={ToggleBarStories.Preview} />
 
 #### Bredde
 
 Bredden på alle `<ToggleRadio>` i en `<ToggleBar>` skal være den samme. `<ToggleBar>` tar i utganspunktet hele tigjengelige bredden og fordeler den likt mellom barna. Spesifikk bredde kan settes enten i `<ToggleBar>` eller i selvutviklede wrapperen til `<ToggleBar>`.
 
-<Canvas of={ToggleBarStories.WithWidth} sourceState="shown" />
+<Canvas of={ToggleBarStories.WithWidth} />
 
 ### ToggleRadio
 

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
@@ -3,8 +3,8 @@ import { useState } from 'react';
 import { fn } from 'storybook/test';
 
 import {
-  categoryCss,
-  htmlPropsArgType,
+  commonArgTypes,
+  responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
 import { PlusCircledIcon } from '../Icon/icons';
@@ -16,22 +16,16 @@ export default {
   title: 'dds-components/Components/ToggleBar',
   component: ToggleBar,
   argTypes: {
-    width: { control: 'text', table: categoryCss },
+    width: responsivePropsArgTypes.width,
     value: { control: false },
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
   },
   args: { onChange: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
 } satisfies Meta<typeof ToggleBar>;
 
 type Story = StoryObj<typeof ToggleBar>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => {
     const [value, setValue] = useState<string | undefined>();
     return (

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.types.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.types.tsx
@@ -21,7 +21,7 @@ export type ToggleBarProps<T extends string | number> =
       label?: string;
       /**Funksjonen for `onChange`-event for barna. */
       onChange?: (event: ChangeEvent<HTMLInputElement>, value?: T) => void;
-      /**Den valgte verdien i gruppen. Hvis satt ved innlastning blir en `<ToggleRadio />` forhåndsvalgt. */
+      /**Den valgte verdien i gruppen. Hvis satt ved innlastning blir en `<ToggleRadio>` forhåndsvalgt. */
       value?: T;
       /** Gir alle barna samme `name` prop.*/
       name?: string;

--- a/packages/dds-components/src/components/ToggleButton/ToggleButton.mdx
+++ b/packages/dds-components/src/components/ToggleButton/ToggleButton.mdx
@@ -24,12 +24,12 @@ Følgende subkomponenter er tilgjengelige:
 
 ### ToggleButton
 
-<Canvas of={ToggleButtonStories.Default} sourceState="shown" />
-<Controls of={ToggleButtonStories.Default} />
+<Canvas of={ToggleButtonStories.Preview} />
+<Controls of={ToggleButtonStories.Preview} />
 
 ### ToggleButtonGroup
 
 Gruppen for `<ToggleButton>`.
 
-<Canvas of={ToggleButtonGroupStories.Default} sourceState="shown" />
-<Controls of={ToggleButtonGroupStories.Default} />
+<Canvas of={ToggleButtonGroupStories.Preview} />
+<Controls of={ToggleButtonGroupStories.Preview} />

--- a/packages/dds-components/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/packages/dds-components/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -3,8 +3,9 @@ import { fn } from 'storybook/test';
 
 import {
   categoryHtml,
+  commonArgTypes,
+  htmlArgType,
   htmlEventArgType,
-  htmlPropsArgType,
 } from '../../storybook/helpers';
 import { NotificationsIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
@@ -15,29 +16,23 @@ export default {
   title: 'dds-components/Components/ToggleButton',
   component: ToggleButton,
   argTypes: {
-    htmlProps: htmlPropsArgType,
-    'aria-describedby': { control: 'text', table: categoryHtml },
-    name: { control: false, table: categoryHtml },
-    checked: { control: false, table: categoryHtml },
+    ...commonArgTypes,
+    'aria-describedby': htmlArgType,
+    name: htmlArgType,
+    checked: htmlArgType,
     defaultChecked: { control: 'boolean', table: categoryHtml },
-    value: { control: false, table: categoryHtml },
-    defaultValue: { control: false, table: categoryHtml },
+    value: htmlArgType,
+    defaultValue: htmlArgType,
     onChange: htmlEventArgType,
     onBlur: htmlEventArgType,
     icon: { control: false },
   },
   args: { onChange: fn(), onBlur: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
 } satisfies Meta<typeof ToggleButton>;
 
 type Story = StoryObj<typeof ToggleButton>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { label: 'Tekst' },
 };
 

--- a/packages/dds-components/src/components/ToggleButton/ToggleButtonGroup.stories.tsx
+++ b/packages/dds-components/src/components/ToggleButton/ToggleButtonGroup.stories.tsx
@@ -1,6 +1,6 @@
 import { type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes } from '../../storybook/helpers';
 
 import { ToggleButton, ToggleButtonGroup } from '.';
 
@@ -8,20 +8,14 @@ export default {
   title: 'dds-components/Components/ToggleButton/ToggleButtonGroup',
   component: ToggleButtonGroup,
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
     labelId: { control: false },
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
   },
 };
 
 type Story = StoryObj<typeof ToggleButtonGroup>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { label: 'Label' },
   render: args => (
     <ToggleButtonGroup {...args}>

--- a/packages/dds-components/src/components/Tooltip/Tooltip.mdx
+++ b/packages/dds-components/src/components/Tooltip/Tooltip.mdx
@@ -27,12 +27,13 @@ En tooltip består av:
 
 ## Props
 
-<Canvas of={TooltipStories.Default} sourceState="shown" />
-<Controls of={TooltipStories.Default} />
+<Canvas of={TooltipStories.Preview} />
+<Controls of={TooltipStories.Preview} />
 
 ### Events
 
-Det brukes ulike events til å lukke eller åpne tooltip. For å bruke callback på event som styrer tooltip må den sendes som prop til riktig element. Se oversikt over hvilket element bruker hvilken event:
+Det brukes ulike events til å lukke eller åpne tooltip.
+Hover-events settes på tooltip, mens focus-events settes på anchor-elementer.
 
 <Table.Wrapper>
   <Table size='small' style={{ width: '100%' }}>

--- a/packages/dds-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/dds-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
-import { htmlEventArgType, htmlPropsArgType } from '../../storybook/helpers';
+import { commonArgTypes, htmlEventArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { HelpIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
@@ -12,24 +12,18 @@ export default {
   title: 'dds-components/Components/Tooltip',
   component: Tooltip,
   argTypes: {
-    htmlProps: htmlPropsArgType,
+    ...commonArgTypes,
     children: { control: false },
     tooltipId: { control: false },
     onMouseLeave: htmlEventArgType,
     onMouseOver: htmlEventArgType,
   },
   args: { onMouseLeave: fn(), onMouseOver: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
-  },
 } satisfies Meta<typeof Tooltip>;
 
 type Story = StoryObj<typeof Tooltip>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { text: 'Dette er en tooltip' },
   render: args => (
     <StoryVStack alignItems="center" paddingBlock="x6">

--- a/packages/dds-components/src/components/Typography/Caption/Caption.mdx
+++ b/packages/dds-components/src/components/Typography/Caption/Caption.mdx
@@ -18,5 +18,5 @@ import * as CaptionStories from './Caption.stories';
 
 ## Props
 
-<Canvas of={CaptionStories.Default} />
-<Controls of={CaptionStories.Default} />
+<Canvas of={CaptionStories.Preview} />
+<Controls of={CaptionStories.Preview} />

--- a/packages/dds-components/src/components/Typography/Caption/Caption.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Caption/Caption.stories.tsx
@@ -1,6 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../../storybook/helpers';
 import { storyTypographyHtmlAttrs } from '../storyUtils';
 
 import { Caption } from '.';
@@ -9,19 +8,12 @@ export default {
   title: 'dds-components/Components/Typography/Caption',
   component: Caption,
   argTypes: {
-    htmlProps: htmlPropsArgType,
     ...storyTypographyHtmlAttrs,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
   },
 } satisfies Meta<typeof Caption>;
 
 type Story = StoryObj<typeof Caption>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { children: 'Caption' },
 };

--- a/packages/dds-components/src/components/Typography/Heading/Heading.mdx
+++ b/packages/dds-components/src/components/Typography/Heading/Heading.mdx
@@ -19,8 +19,8 @@ import * as HeadingStories from './Heading.stories';
 
 ## Props
 
-<Canvas of={HeadingStories.Default} />
-<Controls of={HeadingStories.Default} />
+<Canvas of={HeadingStories.Preview} />
+<Controls of={HeadingStories.Preview} />
 
 ## Med spacing
 

--- a/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
@@ -1,6 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../../storybook/helpers';
 import { StoryVStack } from '../../layout/Stack/utils';
 import { storyTypographyHtmlAttrs } from '../storyUtils';
 
@@ -10,20 +9,13 @@ export default {
   title: 'dds-components/Components/Typography/Heading',
   component: Heading,
   argTypes: {
-    htmlProps: htmlPropsArgType,
     ...storyTypographyHtmlAttrs,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
   },
 } satisfies Meta<typeof Heading>;
 
 type Story = StoryObj<typeof Heading>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { children: 'Heading', level: 1 },
 };
 

--- a/packages/dds-components/src/components/Typography/Label/Label.mdx
+++ b/packages/dds-components/src/components/Typography/Label/Label.mdx
@@ -19,5 +19,5 @@ import * as LabelStories from './Label.stories';
 
 ## Props
 
-<Canvas of={LabelStories.Default} />
-<Controls of={LabelStories.Default} />
+<Canvas of={LabelStories.Preview} />
+<Controls of={LabelStories.Preview} />

--- a/packages/dds-components/src/components/Typography/Label/Label.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Label/Label.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { categoryHtml, htmlPropsArgType } from '../../../storybook/helpers';
+import { categoryHtml } from '../../../storybook/helpers';
 import { storyTypographyHtmlAttrs } from '../storyUtils';
 
 import { Label } from '.';
@@ -10,19 +10,12 @@ export default {
   component: Label,
   argTypes: {
     htmlFor: { control: false, table: categoryHtml },
-    htmlProps: htmlPropsArgType,
     ...storyTypographyHtmlAttrs,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
   },
 } satisfies Meta<typeof Label>;
 
 type Story = StoryObj<typeof Label>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { children: 'Label' },
 };

--- a/packages/dds-components/src/components/Typography/Legend/Legend.mdx
+++ b/packages/dds-components/src/components/Typography/Legend/Legend.mdx
@@ -27,8 +27,8 @@ For eksempler og mer utfyllende informasjon om bruk av `<fieldset>` og `<legend>
 
 ## Props
 
-<Canvas of={LegendStories.Default} />
-<Controls of={LegendStories.Default} />
+<Canvas of={LegendStories.Preview} />
+<Controls of={LegendStories.Preview} />
 
 ## Bruk
 

--- a/packages/dds-components/src/components/Typography/Legend/Legend.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Legend/Legend.stories.tsx
@@ -1,26 +1,18 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import { Legend } from '..';
-import { htmlPropsArgType } from '../../../storybook/helpers';
 import { storyTypographyHtmlAttrs } from '../storyUtils';
 
 export default {
   title: 'dds-components/Components/Typography/Legend',
   component: Legend,
   argTypes: {
-    htmlProps: htmlPropsArgType,
     ...storyTypographyHtmlAttrs,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
   },
 } satisfies Meta<typeof Legend>;
 
 type Story = StoryObj<typeof Legend>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { children: 'Legend' },
 };

--- a/packages/dds-components/src/components/Typography/Link/Link.mdx
+++ b/packages/dds-components/src/components/Typography/Link/Link.mdx
@@ -22,8 +22,8 @@ import * as LinkStories from './Link.stories';
 
 ## Props
 
-<Canvas of={LinkStories.Default} />
-<Controls of={LinkStories.Default} />
+<Canvas of={LinkStories.Preview} />
+<Controls of={LinkStories.Preview} />
 
 ## Retningslinjer
 

--- a/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
@@ -3,8 +3,8 @@ import { fn } from 'storybook/test';
 
 import {
   categoryHtml,
+  htmlArgType,
   htmlEventArgType,
-  htmlPropsArgType,
 } from '../../../storybook/helpers';
 import { StoryVStack } from '../../layout/Stack/utils';
 import { Paragraph } from '../Paragraph';
@@ -18,22 +18,15 @@ export default {
   argTypes: {
     href: { control: 'text', table: categoryHtml },
     onClick: htmlEventArgType,
-    target: { control: false, table: categoryHtml },
-    htmlProps: htmlPropsArgType,
+    target: htmlArgType,
     ...storyTypographyHtmlAttrs,
   },
   args: { onClick: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
 } satisfies Meta<typeof Link>;
 
 type Story = StoryObj<typeof Link>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { children: 'Link', href: 'https://www.domstol.no' },
 };
 

--- a/packages/dds-components/src/components/Typography/Paragraph/Paragraph.mdx
+++ b/packages/dds-components/src/components/Typography/Paragraph/Paragraph.mdx
@@ -19,5 +19,5 @@ import * as ParagraphStories from './Paragraph.stories';
 
 ## Props
 
-<Canvas of={ParagraphStories.Default} />
-<Controls of={ParagraphStories.Default} />
+<Canvas of={ParagraphStories.Preview} />
+<Controls of={ParagraphStories.Preview} />

--- a/packages/dds-components/src/components/Typography/Paragraph/Paragraph.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Paragraph/Paragraph.stories.tsx
@@ -1,6 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { htmlPropsArgType } from '../../../storybook/helpers';
 import { StoryVStack } from '../../layout/Stack/utils';
 import { storyTypographyHtmlAttrs } from '../storyUtils';
 import { Typography } from '../Typography';
@@ -11,21 +10,13 @@ export default {
   title: 'dds-components/Components/Typography/Paragraph',
   component: Paragraph,
   argTypes: {
-    color: { control: 'text' },
-    htmlProps: htmlPropsArgType,
     ...storyTypographyHtmlAttrs,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
   },
 } satisfies Meta<typeof Paragraph>;
 
 type Story = StoryObj<typeof Paragraph>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { children: 'Paragraph' },
 };
 

--- a/packages/dds-components/src/components/Typography/Typography/Typography.mdx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.mdx
@@ -26,8 +26,8 @@ Hver stil har et default HTML element det blir rendered som. Den kan eventuelt o
 
 ## Props
 
-<Canvas of={TypographyStories.Default} />
-<Controls of={TypographyStories.Default} />
+<Canvas of={TypographyStories.Preview} />
+<Controls of={TypographyStories.Preview} />
 
 ### Bruk av typografi-tokens
 

--- a/packages/dds-components/src/components/Typography/Typography/Typography.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import { Typography } from '..';
-import { categoryHtml, htmlPropsArgType } from '../../../storybook/helpers';
+import { categoryHtml } from '../../../storybook/helpers';
 import { StoryVStack } from '../../layout/Stack/utils';
 import { storyTypographyHtmlAttrs } from '../storyUtils';
 
@@ -15,19 +15,12 @@ export default {
     target: { control: false, table: categoryHtml },
     as: { control: 'text' },
     ...storyTypographyHtmlAttrs,
-    htmlProps: htmlPropsArgType,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
   },
 } satisfies Meta<typeof Typography>;
 
 type Story = StoryObj<typeof Typography>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { children: 'Typography' },
 };
 

--- a/packages/dds-components/src/components/Typography/storyUtils.tsx
+++ b/packages/dds-components/src/components/Typography/storyUtils.tsx
@@ -1,9 +1,9 @@
 import { type ArgTypes } from '@storybook/react-vite';
 
-import { categoryHtml } from '../../storybook/helpers';
+import { commonArgTypes, htmlArgType } from '../../storybook/helpers';
 
 export const storyTypographyHtmlAttrs: ArgTypes = {
-  id: { table: categoryHtml },
-  className: { table: categoryHtml },
+  ...commonArgTypes,
+  style: htmlArgType,
   color: { control: { type: 'text' } },
 };

--- a/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.mdx
+++ b/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.mdx
@@ -17,8 +17,8 @@ import * as VisuallyHiddenStories from './VisuallyHidden.stories';
 
 ## Props
 
-<Canvas of={VisuallyHiddenStories.Default} />
-<Controls of={VisuallyHiddenStories.Default} />
+<Canvas of={VisuallyHiddenStories.Preview} />
+<Controls of={VisuallyHiddenStories.Preview} />
 
 ## Retningslinjer
 

--- a/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -1,6 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { categoryHtml, commonArgTypes } from '../../storybook/helpers';
+import { commonArgTypes, htmlArgType } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { Table } from '../Table/normal';
 import { Link, Paragraph } from '../Typography';
@@ -13,19 +13,13 @@ export default {
   argTypes: {
     ...commonArgTypes,
     as: { control: 'text' },
-    style: { table: categoryHtml },
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
+    style: htmlArgType,
   },
 } satisfies Meta<typeof VisuallyHidden>;
 
 type Story = StoryObj<typeof VisuallyHidden>;
 
-export const Default: Story = {
+export const Preview: Story = {
   render: args => (
     <>
       <Paragraph>Teksten under er usynlig.</Paragraph>

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.mdx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.mdx
@@ -23,9 +23,9 @@ For mer utfyllende dokumentasjon av props referrerer vi deg til [`DatePicker` do
 ## Props
 
 <Canvas>
-  <Story of={DatePickerStories.Default} />
+  <Story of={DatePickerStories.Preview} />
 </Canvas>
-<Controls of={DatePickerStories.Default} />
+<Controls of={DatePickerStories.Preview} />
 
 ## Bruk
 

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
@@ -13,6 +13,7 @@ import { fn } from 'storybook/test';
 import { LanguageProvider } from '../../../i18n';
 import {
   htmlEventArgType,
+  responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../../storybook/helpers';
 import { Button } from '../../Button';
@@ -33,14 +34,11 @@ const meta: Meta<typeof DatePicker> = {
   component: DatePicker,
   parameters: {
     docs: {
-      story: { inline: true, height: '500px' },
-      canvas: { sourceState: 'shown' },
+      story: { height: '500px' },
     },
   },
   argTypes: {
-    width: {
-      control: 'text',
-    },
+    width: responsivePropsArgTypes.width,
     onBlur: htmlEventArgType,
     onChange: htmlEventArgType,
     onFocus: htmlEventArgType,
@@ -69,7 +67,7 @@ export default meta;
 
 type Story = StoryObj<typeof DatePicker>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { label: 'Dato' },
 };
 

--- a/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.mdx
+++ b/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.mdx
@@ -21,8 +21,8 @@ import * as TimePickerStories from './TimePicker.stories';
 `TimePicker`-komponenten er implementert vha. [react-aria](https://react-spectrum.adobe.com/react-aria).
 For mer utfyllende dokumentasjon av props referrerer vi deg til [`useTimeField` dokumentasjon til react-aria](https://react-spectrum.adobe.com/react-aria/useTimeField.html).
 
-<Canvas of={TimePickerStories.Default} sourceState="shown" />
-<Controls of={TimePickerStories.Default} />
+<Canvas of={TimePickerStories.Preview} />
+<Controls of={TimePickerStories.Preview} />
 
 ## Bruk
 

--- a/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.stories.tsx
+++ b/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.stories.tsx
@@ -3,7 +3,10 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 
-import { htmlEventArgType } from '../../../storybook/helpers';
+import {
+  htmlEventArgType,
+  responsivePropsArgTypes,
+} from '../../../storybook/helpers';
 import { Button } from '../../Button';
 import { StoryHStack, StoryVStack } from '../../layout/Stack/utils';
 
@@ -13,26 +16,20 @@ const meta: Meta<typeof TimePicker> = {
   title: 'dds-components/Components/TimePicker',
   component: TimePicker,
   argTypes: {
-    width: { control: 'text' },
+    width: responsivePropsArgTypes.width,
     className: { table: { disable: true } },
     onBlur: htmlEventArgType,
     onChange: htmlEventArgType,
     onFocus: htmlEventArgType,
   },
   args: { onBlur: fn(), onFocus: fn(), onChange: fn(), onFocusChange: fn() },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
-  },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof TimePicker>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { label: 'Tidspunkt' },
 };
 

--- a/packages/dds-components/src/components/layout/Box/Box.mdx
+++ b/packages/dds-components/src/components/layout/Box/Box.mdx
@@ -27,5 +27,5 @@ import * as BoxStories from './Box.stories';
 
 ## Props
 
-<Canvas of={BoxStories.Default} sourceState="shown" />
-<Controls of={BoxStories.Default} />
+<Canvas of={BoxStories.Preview} />
+<Controls of={BoxStories.Preview} />

--- a/packages/dds-components/src/components/layout/Box/Box.stories.tsx
+++ b/packages/dds-components/src/components/layout/Box/Box.stories.tsx
@@ -19,18 +19,13 @@ const meta: Meta<typeof Box> = {
   argTypes: {
     ...responsivePropsArgTypes,
   },
-  parameters: {
-    docs: {
-      story: { inline: true },
-    },
-  },
   decorators: [Story => windowWidthDecorator(<Story />)],
 };
 export default meta;
 
 type Story = StoryObj<typeof Box>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     style: {
       border: '1px solid var(--dds-color-border-default)',

--- a/packages/dds-components/src/components/layout/Grid/Grid.mdx
+++ b/packages/dds-components/src/components/layout/Grid/Grid.mdx
@@ -74,15 +74,15 @@ En responsiv container-komponent for `<GridChild>` barn. Den håndterer grid lay
 
 Komponenten har defaults for enkelte CSS props som implementerer Elsas grid system, men kan overskrives: `gridTemplateColumns`, `columnGap`, `rowGap` (se props-tabell).
 
-<Canvas of={GridStories.Default} />
-<Controls of={GridStories.Default} />
+<Canvas of={GridStories.Preview} />
+<Controls of={GridStories.Preview} />
 
 ## GridChild
 
 En responsiv wrapper-component som håndterer hvor mange kolonner innhold skal ta. Den støtter også alle standard layout primitive props.
 
-<Canvas of={GridChildStories.Default} />
-<Controls of={GridChildStories.Default} />
+<Canvas of={GridChildStories.Preview} />
+<Controls of={GridChildStories.Preview} />
 
 ### Typer
 

--- a/packages/dds-components/src/components/layout/Grid/Grid.stories.tsx
+++ b/packages/dds-components/src/components/layout/Grid/Grid.stories.tsx
@@ -25,16 +25,11 @@ export default {
     ...responsivePropsArgTypes,
     gridTemplateColumns: { control: 'text', table: categoryCss },
   },
-  parameters: {
-    docs: {
-      story: { inline: true },
-    },
-  },
 } satisfies Meta<typeof Grid>;
 
 type Story = StoryObj<typeof Grid>;
 
-export const Default: Story = {
+export const Preview: Story = {
   decorators: [
     Story =>
       windowWidthDecorator(

--- a/packages/dds-components/src/components/layout/Grid/GridChild.stories.tsx
+++ b/packages/dds-components/src/components/layout/Grid/GridChild.stories.tsx
@@ -14,20 +14,14 @@ export default {
   argTypes: {
     gridRow: { control: 'text' },
     justifySelf: { control: 'text', table: categoryCss },
-    columnsOccupied: { control: 'text', table: categoryCss },
+    columnsOccupied: { control: 'text' },
     ...responsivePropsArgTypes,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'hidden' },
-    },
   },
 } satisfies Meta<typeof GridChild>;
 
 type Story = StoryObj<typeof GridChild>;
 
-export const Default: Story = {
+export const Preview: Story = {
   decorators: [
     Story => (
       <>

--- a/packages/dds-components/src/components/layout/Paper/Paper.mdx
+++ b/packages/dds-components/src/components/layout/Paper/Paper.mdx
@@ -28,5 +28,5 @@ Den støtter design tokens aliases direkte via props.
 
 ## Props
 
-<Canvas of={PaperStories.Default} />
-<Controls of={PaperStories.Default} />
+<Canvas of={PaperStories.Preview} />
+<Controls of={PaperStories.Preview} />

--- a/packages/dds-components/src/components/layout/Paper/Paper.stories.tsx
+++ b/packages/dds-components/src/components/layout/Paper/Paper.stories.tsx
@@ -1,8 +1,8 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import {
-  categoryCss,
-  htmlPropsArgType,
+  CSSSelectArgType,
+  htmlArgType,
   responsivePropsArgTypes,
 } from '../../../storybook/helpers';
 
@@ -11,39 +11,22 @@ import { Paper } from '.';
 const meta: Meta<typeof Paper> = {
   title: 'dds-components/Layout Primitives/Paper',
   component: Paper,
-  parameters: {
-    docs: {
-      story: { inline: true },
-    },
-  },
   argTypes: {
     as: { control: 'text' },
     ...responsivePropsArgTypes,
-    elevation: {
-      control: { type: 'select' },
-      table: categoryCss,
-    },
-    border: {
-      control: { type: 'select' },
-      table: categoryCss,
-    },
-    borderRadius: {
-      control: { type: 'select' },
-      table: categoryCss,
-    },
-    background: {
-      control: { type: 'select' },
-      table: categoryCss,
-    },
-    tabIndex: htmlPropsArgType,
-    role: htmlPropsArgType,
+    elevation: CSSSelectArgType,
+    border: CSSSelectArgType,
+    borderRadius: CSSSelectArgType,
+    background: CSSSelectArgType,
+    tabIndex: htmlArgType,
+    role: htmlArgType,
   },
 };
 export default meta;
 
 type Story = StoryObj<typeof Paper>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     border: 'border-default',
     padding: 'x1.5',

--- a/packages/dds-components/src/components/layout/ShowHide/ShowHide.mdx
+++ b/packages/dds-components/src/components/layout/ShowHide/ShowHide.mdx
@@ -27,8 +27,8 @@ import * as ShowHideStories from './ShowHide.stories';
 
 ## Props
 
-<Canvas of={ShowHideStories.Default} sourceState="shown" />
-<Controls of={ShowHideStories.Default} />
+<Canvas of={ShowHideStories.Preview} />
+<Controls of={ShowHideStories.Preview} />
 
 ## Retningslinjer
 

--- a/packages/dds-components/src/components/layout/ShowHide/ShowHide.stories.tsx
+++ b/packages/dds-components/src/components/layout/ShowHide/ShowHide.stories.tsx
@@ -1,7 +1,7 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import {
-  commonBasePropsArgTypes,
+  commonResponsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../../storybook/helpers';
 import { Icon } from '../../Icon';
@@ -14,12 +14,7 @@ const meta: Meta<typeof ShowHide> = {
   title: 'dds-components/Layout Primitives/ShowHide',
   component: ShowHide,
   argTypes: {
-    ...commonBasePropsArgTypes,
-  },
-  parameters: {
-    docs: {
-      story: { inline: true },
-    },
+    ...commonResponsivePropsArgTypes,
   },
   decorators: [Story => windowWidthDecorator(<Story />)],
 };
@@ -28,28 +23,32 @@ export default meta;
 type Story = StoryObj<typeof ShowHide>;
 
 export const Preview: Story = {
-  render: () => (
+  render: args => (
     <Grid gridTemplateColumns="150px 150px" gap="x1">
       <div>
         Denne skjules ved sm brekkpunkt og nedover
         <div>
           <Icon icon={ArrowDownIcon} />
         </div>
-        <ShowHide hideBelow="sm">😜</ShowHide>
+        <ShowHide {...args} hideBelow="sm">
+          😜
+        </ShowHide>
       </div>
       <div>
         Denne vises ved sm brekkpunkt og nedover
         <div>
           <Icon icon={ArrowDownIcon} />
         </div>
-        <ShowHide showBelow="sm">🤓</ShowHide>
+        <ShowHide {...args} showBelow="sm">
+          🤓
+        </ShowHide>
       </div>
     </Grid>
   ),
 };
 
-export const Default: Story = {
+export const SetBreakpoints: Story = {
   args: {
-    children: 'Skjul meg ved å sette brekkpunkt i props',
+    children: 'Skjul eller vis meg ved å sette brekkpunkter i props',
   },
 };

--- a/packages/dds-components/src/components/layout/Stack/HStack/HStack.mdx
+++ b/packages/dds-components/src/components/layout/Stack/HStack/HStack.mdx
@@ -27,8 +27,8 @@ De lar deg respektivt legge elementer i en kolonne eller rad.
 
 ## Props
 
-<Canvas of={StackStories.Default} />
-<Controls of={StackStories.Default} />
+<Canvas of={StackStories.Preview} />
+<Controls of={StackStories.Preview} />
 
 ## Bruk
 

--- a/packages/dds-components/src/components/layout/Stack/HStack/HStack.stories.tsx
+++ b/packages/dds-components/src/components/layout/Stack/HStack/HStack.stories.tsx
@@ -27,7 +27,7 @@ const ExampleElement = () => (
 
 type Story = StoryObj<typeof HStack>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     children: [
       <ExampleElement />,

--- a/packages/dds-components/src/components/layout/Stack/VStack/VStack.mdx
+++ b/packages/dds-components/src/components/layout/Stack/VStack/VStack.mdx
@@ -27,8 +27,8 @@ De lar deg respektivt legge elementer i en kolonne eller rad.
 
 ## Props
 
-<Canvas of={StackStories.Default} />
-<Controls of={StackStories.Default} />
+<Canvas of={StackStories.Preview} />
+<Controls of={StackStories.Preview} />
 
 ## Bruk
 

--- a/packages/dds-components/src/components/layout/Stack/VStack/VStack.stories.tsx
+++ b/packages/dds-components/src/components/layout/Stack/VStack/VStack.stories.tsx
@@ -27,7 +27,7 @@ const ExampleElement = () => (
 
 type Story = StoryObj<typeof VStack>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: {
     children: [
       <ExampleElement />,

--- a/packages/dds-components/src/storybook/helpers.tsx
+++ b/packages/dds-components/src/storybook/helpers.tsx
@@ -11,23 +11,31 @@ import { getBreakpointFromScreenWidth } from '../components/layout/common/utils'
 import { Paragraph } from '../components/Typography';
 import { useWindowResize } from '../hooks';
 
+export interface ArgType {
+  control?: Control;
+  table?: { category: string };
+}
+
+type ResponsiveArgTypes<T> = {
+  [k in keyof T]: ArgType;
+};
+
 export const categories = {
   html: 'HTML attributes',
   css: 'CSS properties',
 };
-
 export const categoryHtml = { category: categories.html };
 export const categoryCss = { category: categories.css };
 
-export const htmlPropsArgType: Partial<ArgTypes> = {
+export const htmlArgType: Partial<ArgTypes> = {
   control: { disable: true },
   table: categoryHtml,
 };
 
-export const commonArgTypes: ArgTypes = {
-  id: { table: categoryHtml },
-  className: { table: categoryHtml },
-  htmlProps: htmlPropsArgType,
+export const commonArgTypes: Partial<ArgTypes> = {
+  id: htmlArgType,
+  className: htmlArgType,
+  htmlProps: htmlArgType,
   ref: { control: { disable: true } },
 };
 
@@ -36,36 +44,28 @@ export const htmlEventArgType: Partial<ArgTypes> = {
   table: categoryHtml,
 };
 
-export const CSSArgType = {
+export const CSSArgType: ArgType = {
   control: { type: 'text' },
   table: categoryCss,
 };
 
-export const CSSSelectArgType = {
+export const CSSSelectArgType: ArgType = {
   control: { type: 'select' },
   table: categoryCss,
 };
 
-type ResponsiveArgTypes<T> = {
-  [k in keyof T]: {
-    control?: Control;
-    table?: { category: string };
+export const commonResponsivePropsArgTypes: ResponsiveArgTypes<ShowHideProps> =
+  {
+    ...commonArgTypes,
+    as: { control: 'text' },
+    children: { control: { disable: true } },
+    style: htmlArgType,
+    showBelow: { control: { type: 'select' } },
+    hideBelow: { control: { type: 'select' } },
   };
-};
-
-export const commonBasePropsArgTypes: ResponsiveArgTypes<ShowHideProps> = {
-  as: { control: 'text' },
-  ref: { control: { disable: true } },
-  children: { control: { disable: true } },
-  className: htmlPropsArgType,
-  style: htmlPropsArgType,
-  htmlProps: htmlPropsArgType,
-  showBelow: { control: { type: 'select' } },
-  hideBelow: { control: { type: 'select' } },
-};
 
 export const responsivePropsArgTypes: ResponsiveArgTypes<ResponsiveProps> = {
-  ...commonBasePropsArgTypes,
+  ...commonResponsivePropsArgTypes,
   padding: CSSArgType,
   paddingBlock: CSSArgType,
   paddingInline: CSSArgType,
@@ -132,38 +132,36 @@ export const windowWidthDecorator = (Story: ReactNode, intro?: string) => {
   };
 
   return (
-    <>
-      <VStack gap="x1">
-        <HStack>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="1.5rem"
-            height="1.5rem"
-            fill="none"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              fill="currentColor"
-              fill-rule="evenodd"
-              d={getIcon()}
-              clip-rule="evenodd"
-            ></path>
-          </svg>
-          {bp}{' '}
-          <span
-            style={{
-              color: 'var(--dds-color-text-subtle)',
-              marginInlineStart: 'var(--dds-spacing-x1)',
-            }}
-          >
-            {' '}
-            {width}px
-          </span>
-        </HStack>
-        {intro && <Paragraph typographyType="bodySmall">{intro}</Paragraph>}
-        {Story}
-      </VStack>
-    </>
+    <VStack gap="x1">
+      <HStack>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="1.5rem"
+          height="1.5rem"
+          fill="none"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            fill="currentColor"
+            fill-rule="evenodd"
+            d={getIcon()}
+            clip-rule="evenodd"
+          ></path>
+        </svg>
+        {bp}{' '}
+        <span
+          style={{
+            color: 'var(--dds-color-text-subtle)',
+            marginInlineStart: 'var(--dds-spacing-x1)',
+          }}
+        >
+          {' '}
+          {width}px
+        </span>
+      </HStack>
+      {intro && <Paragraph typographyType="bodySmall">{intro}</Paragraph>}
+      {Story}
+    </VStack>
   );
 };

--- a/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBannerProvider.mdx
+++ b/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBannerProvider.mdx
@@ -1,5 +1,5 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
-import { Default } from './EnvironmentBannerProvider.stories';
+import { Preview } from './EnvironmentBannerProvider.stories';
 
 <Meta title="development-utils/EnvironmentBannerProvider" />
 
@@ -8,8 +8,8 @@ import { Default } from './EnvironmentBannerProvider.stories';
 Denne komponenten kan brukes for å hjelpe utviklere/testere med å se hvilket miljø de jobber i. Den viser en banner (med unik farge per miljø) øverst på siden med miljønavnet.
 I produksjon (ved `environment="PROD"`) eller ved et ukjent miljø er den skjult, så du trenger ikke å håndtere skjuling av banneren.
 
-<Canvas of={Default} />
-<Controls of={Default} />
+<Canvas of={Preview} />
+<Controls of={Preview} />
 
 ## 🔨 Bruk
 

--- a/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBannerProvider.stories.tsx
+++ b/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBannerProvider.stories.tsx
@@ -7,10 +7,6 @@ const meta: Meta<typeof EnvironmentBannerProvider> = {
   component: EnvironmentBannerProvider,
   parameters: {
     disableGlobalDecorator: true,
-    docs: {
-      story: { inline: true },
-      canvas: { sourceState: 'shown' },
-    },
   },
 };
 
@@ -18,7 +14,7 @@ export default meta;
 
 type Story = StoryObj<typeof EnvironmentBannerProvider>;
 
-export const Default: Story = {
+export const Preview: Story = {
   args: { bannerPosition: 'fixed', environment: 'TEST' },
   render: args => <EnvironmentBannerProvider {...args} />,
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
     "allowSyntheticDefaultImports": true,
     "downlevelIteration": true
   },
-  "include": ["packages", "stories"],
+  "include": ["packages", "stories", ".storybook"],
   "exclude": ["**/node_modules"]
 }


### PR DESCRIPTION

## Beskrivelse
Primære story for hver komponent het før `'default'`, endrer standarden til `'preview'`; det er mer riktig og generisk, der flere komponenter ikke har en default.

Andre Storybook-chores i samme slengen:

- Modulariserer, refaktorerer og rydder oppi hvordan props er presentert i controls-tabellen. For eksempel, `id` og `className` skal vises i "HTML attributes"-seksjonen av tabellen.
- Flytter common configs for docs til global storybook config fra komponent-nivå. Det er får stories som ikke skal vise kode i docs, overskriver global i komponent istedet.
- Fikser props type for enkelte komponenter, der en egendefinert prop skulle overskrive HTML-attributtet men ikke gjorde det, som `color`. Dette resulterte i mangel i controls-table og er nå fikset.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
