### PR TITLE
ELSA1-540 Mønster: skjema

### DIFF
--- a/.changeset/small-buckets-play.md
+++ b/.changeset/small-buckets-play.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Utbedrer oppførselen til `width` prop i input-komponenter; Hvis bredde settes kun på enkelte brekkpunkter vil resterende brekkpunkter få default bredde definert i komponenten. Før fikk utelatte brekkpunkter ingen definert bredde, og dermed utforutsigbar bredde. Kan potensielt føre til endringer i layout. Påvirker komponentene `<TextInput>`, `<Select>`, `<PhoneInput>`, `<ProgressBar>`, `<NativeSelect>`, `<TextArea>`, `<DatePicker>`, `<TimePicker>`.

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.tsx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.tsx
@@ -22,7 +22,7 @@ import {
   type CookieBannerCheckboxProps,
 } from './CookieBannerCheckbox';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
-import { applyResponsiveStyle } from '../layout/common/utils';
+import { styleUpToBreakpoint } from '../layout/common/utils';
 
 export type CookieBannerProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
@@ -80,7 +80,7 @@ export function CookieBanner({
       )}
       role="region"
       aria-label={tAriaLabel}
-      padding={applyResponsiveStyle('x1', 'sm', 'x1.5')}
+      padding={styleUpToBreakpoint('x1', 'sm', 'x1.5')}
       width={width}
       maxHeight={maxHeight}
       border="border-default"
@@ -118,7 +118,7 @@ export function CookieBanner({
           )}
           {buttons && (
             <HStack
-              gap={applyResponsiveStyle('x1', 'sm', 'x1.5')}
+              gap={styleUpToBreakpoint('x1', 'sm', 'x1.5')}
               flexWrap="wrap"
               paddingBlock="x0.25 0"
             >

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.tsx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.tsx
@@ -12,7 +12,7 @@ import { focusable } from '../helpers/styling/focus.module.css';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { MenuIcon, MoreVerticalIcon, PersonIcon } from '../Icon/icons';
 import { Box } from '../layout';
-import { applyResponsiveStyle } from '../layout/common/utils';
+import { styleUpToBreakpoint } from '../layout/common/utils';
 import { ShowHide } from '../layout/ShowHide';
 import {
   OverflowMenu,
@@ -94,8 +94,8 @@ export const InternalHeader = (props: InternalHeaderProps) => {
     <Box
       display="flex"
       alignItems="center"
-      gap={applyResponsiveStyle('x1.5', smallScreenBreakpoint, 'x1')}
-      paddingInline={applyResponsiveStyle(
+      gap={styleUpToBreakpoint('x1.5', smallScreenBreakpoint, 'x1')}
+      paddingInline={styleUpToBreakpoint(
         'x1.5',
         smallScreenBreakpoint,
         'x1 x0.5',

--- a/packages/dds-components/src/components/Pagination/Pagination.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.tsx
@@ -15,7 +15,7 @@ import {
   MoreHorizontalIcon,
 } from '../Icon/icons';
 import { Box, type Breakpoint, ShowHide } from '../layout';
-import { applyResponsiveStyle } from '../layout/common/utils';
+import { styleUpToBreakpoint } from '../layout/common/utils';
 import { Select } from '../Select';
 import { Paragraph } from '../Typography';
 
@@ -299,8 +299,8 @@ export const Pagination = ({
       gap="x0.75"
       justifyContent="space-between"
       flexWrap="wrap"
-      flexDirection={applyResponsiveStyle('column', smallScreenBreakpoint)}
-      alignItems={applyResponsiveStyle('center', smallScreenBreakpoint)}
+      flexDirection={styleUpToBreakpoint('column', smallScreenBreakpoint)}
+      alignItems={styleUpToBreakpoint('center', smallScreenBreakpoint)}
       {...getBaseHTMLProps(id, className, htmlProps, rest)}
     >
       <div className={styles.indicators}>

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.tsx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.tsx
@@ -27,7 +27,7 @@ import inputStyles from '../helpers/Input/Input.module.css';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { renderInputMessage } from '../InputMessage';
 import { Box, type Breakpoint } from '../layout';
-import { applyResponsiveStyle } from '../layout/common/utils';
+import { styleUpToBreakpoint } from '../layout/common/utils';
 import { NativeSelect } from '../Select';
 import { Label } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
@@ -277,7 +277,7 @@ export const PhoneInput = ({
       )}
       <Box
         display="flex"
-        flexDirection={applyResponsiveStyle('column', bp, 'row')}
+        flexDirection={styleUpToBreakpoint('column', bp, 'row')}
         className={cn(
           styles['inputs-container'],
           !!bp && styles[`inputs-container--small-screen-${bp}`],
@@ -290,7 +290,7 @@ export const PhoneInput = ({
           {tSelectLabel}
         </label>
         <NativeSelect
-          width={applyResponsiveStyle(
+          width={styleUpToBreakpoint(
             '100%',
             bp,
             componentSize === 'xsmall' ? '5rem' : '8rem',

--- a/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -12,7 +12,7 @@ export default {
   component: VisuallyHidden,
   argTypes: {
     ...commonArgTypes,
-    as: { control: 'text' },
+    as: { control: 'text', table: { defaultValue: { summary: 'span' } } },
     style: htmlArgType,
   },
 } satisfies Meta<typeof VisuallyHidden>;

--- a/packages/dds-components/src/components/helpers/Input/Input.types.tsx
+++ b/packages/dds-components/src/components/helpers/Input/Input.types.tsx
@@ -7,7 +7,7 @@ import { type StaticTypographyType } from '../../Typography';
 export interface CommonInputProps {
   /**Ledetekst. */
   label?: string;
-  /**Bredde for inputfeltet. */
+  /**Bredde for inputfeltet. Kan settes per brekkpunkt, manglende brekkpunter får da default bredde. */
   width?: ResponsiveProps['width'];
   /**Hjelpetekst. */
   tip?: string;

--- a/packages/dds-components/src/components/helpers/Input/Input.utils.tsx
+++ b/packages/dds-components/src/components/helpers/Input/Input.utils.tsx
@@ -1,4 +1,6 @@
 import { type ResponsiveProps } from '../../layout';
+import { BREAKPOINTS } from '../../layout/common/Responsive.types';
+import { isBreakpointObject } from '../../layout/common/utils';
 
 export function getDefaultText(
   value?: string | number | ReadonlyArray<string>,
@@ -19,5 +21,18 @@ export function getInputWidth(
   width?: ResponsiveProps['width'],
   defaultW?: ResponsiveProps['width'] | false | null,
 ): ResponsiveProps['width'] {
-  return width ? width : defaultW ? defaultW : 'var(--dds-input-default-width)';
+  const fallback: ResponsiveProps['width'] = defaultW
+    ? defaultW
+    : 'var(--dds-input-default-width)';
+
+  if (isBreakpointObject(width)) {
+    return BREAKPOINTS.reduce((acc, bp) => {
+      return {
+        ...acc,
+        [bp]: bp in width ? width[bp] : fallback,
+      };
+    }, {});
+  }
+
+  return width ?? fallback;
 }

--- a/packages/dds-components/src/components/layout/common/utils.tsx
+++ b/packages/dds-components/src/components/layout/common/utils.tsx
@@ -101,7 +101,15 @@ export function getResponsiveCSSProperties<T>(
   return properties;
 }
 
-export function applyResponsiveStyle<T>(
+/**
+ * Setter styling opptil et brekkpunkt og muligens annen styling over det brekkpunktet.
+ * @param p styling under og inkludert brekkpunktet.
+ * @param bp brekkpunktet.
+ * @param largeScreenP styling over brekkpunktet.
+ * @returns responsiv styling for en CSS prop.
+ */
+
+export function styleUpToBreakpoint<T>(
   p: T,
   bp?: Breakpoint,
   largeScreenP?: T,

--- a/packages/dds-components/stories/patterns/Form/Form.mdx
+++ b/packages/dds-components/stories/patterns/Form/Form.mdx
@@ -1,0 +1,65 @@
+import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
+import {
+  ComponentLinkRow,
+  Source,
+} from '@norges-domstoler/storybook-components';
+import * as FormStories from './Form.stories';
+
+<Meta of={FormStories} />
+
+# Form
+
+<ComponentLinkRow
+  docsHref="https://design.domstol.no/987b33f71/p/30227e-useonkeydown"
+  githubHref="https://github.com/domstolene/designsystem/blob/main/packages/dds-components/src/hooks/Form/Form.tsx"
+  withBottomSpacing
+/>
+
+**OBS!** Se demoer/stories utenfor Docs for riktig responsiv layout.
+
+## Hvordan implementere?
+
+Skjema-mønsteret bruker gjerne en del komponenter, layout primitives og props for å implementere typisk layout. Du trenger i utganspunktet ingen egen CSS styling.
+
+### Layout primitives
+
+- **`<Grid>`**: overordnet layout.
+- **`<VStack>`, `<HStack>`, `<Box>`, `<ShowHide>`**: lokalisert layout. Bruk gjerne `as` prop aktivt for å sette layout i semantiske elementer, f.eks. `<form>` kan kodes som `<VStack as="form" gap="x1">`.
+
+### Komponenter
+
+- **Skjemakomponenter**: skjema er ikke et skjema uten skjemakomponenter! Bruk gjerne `width` prop med brekkpunkter i komponenter som støtter den, som `<TextInput>`.
+- **`<Paragraph>`, `<Heading>`, `<Lead>`, `<Typography>` osv.**: bruk typografikomponenter for å beskrive hva skjema gjelder og tigjenglighetsinformasjon, som markering av påkrevde felt. Bruk standard marginer med `withMargins` prop.
+- **`<Fieldset>`, `<Legend>`, `<FieldsetGroup>`**: hvis du grupperer inputelementer gjør det semantisk med dedikerte komponenter.
+
+### Styling
+
+- **Spacing**: komponenter som `<FieldsetGroup>` har innbakt spacing som følger retningslinjer. Typografikomponenter bør brukes med `withMargins` prop. Sett i tillegg egen spacing for generiske containere; bruk gjerne [layout primitives](#layout-primitives).
+- **Tekstfarge**: det meste av tekst skal ha standardisert farge, men ikke alt. Info om markering av påkrevde felt og påkrevd-markør skal bruke fargene `dds-color-text-subtle` og `dds-color-text-requiredfield`; disse kan settes med `color` prop i typografikomponeter.
+- **Størrelse på `<Legend>`**: hvis du bruker flere overskrifter på skjemasiden kan det hende du trenger å tilpasse størrelsen på din `<Legend>`. Bruk `typographyType` prop ved behov.
+
+## Vanlig
+
+<Canvas of={FormStories.Form} />
+
+## Med steg
+
+Hvis skjema har steg bruker du i tillegg:
+
+- **`<ProgressTracker>`**: til høyre for skjema.
+- **`<ShowHide>` for mobilversjon av `<ProgressTracker>`**. Den tilgjenngeligjøres via `<Drawer>`, `<NativeSelect>` e.l. på mindre skjerm. Hvis du bruker `<Drawer>` trenger utløserknappen en tilgjengelig tekst; for eksempel, hvis knappeteksten er "Steg 1 av 2" med chevron-ikon vil seende brukere forstå hva den gjør. Du kan utvide denne med `<VisuallyHidden>` og usynlig tekst som "Vis stegnavigasjon" for assisterende verktøy.
+
+<Canvas of={FormStories.FormWithSteps} />
+
+## Med steg - custom grid
+
+Istedenfor å bruke default kolonner i vårt `<Grid>` kan du f.eks. bruke to kolonner, der selve skjema har opptil spesifisert bredde og `<ProgressTracker>` tar resten.
+Default CSS for `margin-inline` fra `<Grid>` er riktig her, men pass på spacing mellom kolonnene.
+
+<Canvas of={FormStories.FormWithStepsCustomGrid} />
+
+## Forlate skjema
+
+Implementer advarsel for når brukeren prøver å forlate påbegynt skjema, slik at de kan ombestemme seg og bli på siden. `<Modal>` kan være en slik advarsel.
+
+<Canvas of={FormStories.ExitForm} />

--- a/packages/dds-components/stories/patterns/Form/Form.stories.tsx
+++ b/packages/dds-components/stories/patterns/Form/Form.stories.tsx
@@ -3,6 +3,7 @@ import { type FormEvent, Fragment, useState } from 'react';
 
 import {
   ArrowLeftIcon,
+  BackLink,
   Box,
   Button,
   ChevronRightIcon,
@@ -16,6 +17,9 @@ import {
   Heading,
   InternalHeader,
   Legend,
+  Modal,
+  ModalActions,
+  ModalBody,
   NativeSelect,
   Paragraph,
   ProgressTracker,
@@ -23,8 +27,9 @@ import {
   TextInput,
   Typography,
   VStack,
-} from '../../src';
-import { StoryThemeProvider } from '../../src/components/ThemeProvider/utils/StoryThemeProvider';
+  VisuallyHidden,
+} from '../../../src';
+import { StoryThemeProvider } from '../../../src/components/ThemeProvider/utils/StoryThemeProvider';
 
 const meta: Meta = {
   title: 'Patterns/Form',
@@ -42,36 +47,34 @@ export const Form = () => {
         applicationName="Applikasjon"
         applicationDesc="Beskrivelse"
         navItems={[
-          { children: 'Lenkenavn', href: '/' },
-          { children: 'Lenkenavn', href: '/' },
+          { children: 'Menypunkt', href: '//' },
+          { children: 'Menypunkt', href: '///' },
         ]}
         smallScreenBreakpoint="sm"
+        currentPageHref="//"
       />
-      <Box
-        maxWidth="60ch"
-        marginInline={{ xs: 'x2', sm: 'x2', md: 'x4', lg: 'x6', xl: 'x10' }}
-      >
-        <Heading level={1} withMargins>
-          Navn på skjema
-        </Heading>
-        <Paragraph withMargins typographyType="leadMedium">
-          Dette er et avsnitt/ingress. Bruk "body" og "lead" i meg. Lead er
-          ingress og body er vanlig mengdetekst.
-        </Paragraph>
-        <Paragraph withMargins typographyType="bodySmall" color="text-subtle">
-          Obligatoriske felter er merket med{' '}
-          <Typography as="span" color="text-requiredfield">
-            *
-          </Typography>
-          .
-        </Paragraph>
-        <form>
-          <VStack gap="x1">
+      <Grid maxWidth="60ch" marginBlock="0 x1">
+        <GridChild columnsOccupied="all">
+          <Heading level={1} withMargins>
+            Navn på skjema
+          </Heading>
+          <Paragraph withMargins typographyType="leadMedium">
+            Dette er et avsnitt/ingress. Bruk "body" og "lead" i meg. Lead er
+            ingress og body er vanlig mengdetekst.
+          </Paragraph>
+          <Paragraph withMargins typographyType="bodySmall" color="text-subtle">
+            Obligatoriske felter er merket med{' '}
+            <Typography as="span" color="text-requiredfield">
+              *
+            </Typography>
+            .
+          </Paragraph>
+          <VStack as="form" gap="x1">
             <Fieldset>
               <Legend withMargins>Overskrift for gruppe</Legend>
               <FieldsetGroup>
-                <TextInput label="Ledetekst" />
-                <NativeSelect label="Ledetekst">
+                <TextInput label="Ledetekst" width={{ xs: '100%' }} />
+                <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
                   <option></option>
                   <option>Valg 1</option>
                   <option>Valg 2</option>
@@ -82,8 +85,8 @@ export const Form = () => {
             <Fieldset>
               <Legend withMargins>Overskrift for gruppe</Legend>
               <FieldsetGroup>
-                <TextInput label="Ledetekst" />
-                <NativeSelect label="Ledetekst">
+                <TextInput label="Ledetekst" width={{ xs: '100%' }} />
+                <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
                   <option></option>
                   <option>Valg 1</option>
                   <option>Valg 2</option>
@@ -94,7 +97,7 @@ export const Form = () => {
             <Fieldset>
               <Legend withMargins>Adresse</Legend>
               <FieldsetGroup>
-                <TextInput label="Adresse" />
+                <TextInput label="Adresse" width={{ xs: '100%' }} />
                 <Box
                   display="flex"
                   flexDirection={{
@@ -103,18 +106,28 @@ export const Form = () => {
                   gap="x1.5"
                 >
                   <TextInput width="94px" label="Postnummer" />
-                  <TextInput label="Sted" readOnly width="202px" />
+                  <TextInput
+                    label="Sted"
+                    readOnly
+                    width={{
+                      xs: '100%',
+                      sm: '202px',
+                      md: '202px',
+                      lg: '202px',
+                      xl: '202px',
+                    }}
+                  />
                 </Box>
               </FieldsetGroup>
             </Fieldset>
 
-            <HStack gap="x1.5" paddingBlock="x1 0">
+            <HStack gap="x1.5" paddingBlock="x1.5">
               <Button>Send inn</Button>
               <Button purpose="tertiary">Avbryt og forkast</Button>
             </HStack>
           </VStack>
-        </form>
-      </Box>
+        </GridChild>
+      </Grid>
     </StoryThemeProvider>
   );
 };
@@ -160,8 +173,8 @@ export const FormWithSteps = () => {
             Overskrift for gruppe
           </Legend>
           <FieldsetGroup>
-            <TextInput label="Ledetekst" />
-            <NativeSelect label="Ledetekst">
+            <TextInput label="Ledetekst" width={{ xs: '100%' }} />
+            <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
               <option></option>
               <option>Valg 1</option>
               <option>Valg 2</option>
@@ -174,8 +187,8 @@ export const FormWithSteps = () => {
             Overskrift for gruppe
           </Legend>
           <FieldsetGroup>
-            <TextInput label="Ledetekst" />
-            <NativeSelect label="Ledetekst">
+            <TextInput label="Ledetekst" width={{ xs: '100%' }} />
+            <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
               <option></option>
               <option>Valg 1</option>
               <option>Valg 2</option>
@@ -188,7 +201,7 @@ export const FormWithSteps = () => {
             Adresse
           </Legend>
           <FieldsetGroup>
-            <TextInput label="Adresse" />
+            <TextInput label="Adresse" width={{ xs: '100%' }} />
             <Box
               display="flex"
               flexDirection={{
@@ -197,11 +210,21 @@ export const FormWithSteps = () => {
               gap="x1.5"
             >
               <TextInput width="94px" label="Postnummer" />
-              <TextInput label="Sted" readOnly width="202px" />
+              <TextInput
+                label="Sted"
+                readOnly
+                width={{
+                  xs: '100%',
+                  sm: '202px',
+                  md: '202px',
+                  lg: '202px',
+                  xl: '202px',
+                }}
+              />
             </Box>
           </FieldsetGroup>
         </Fieldset>
-        <HStack gap="x1.5" paddingBlock="x1 0">
+        <HStack gap="x1.5" paddingBlock="x1.5">
           <Button>Neste</Button>
           <Button purpose="tertiary">Avbryt og forkast</Button>
         </HStack>
@@ -223,8 +246,8 @@ export const FormWithSteps = () => {
             Overskrift for gruppe
           </Legend>
           <FieldsetGroup>
-            <TextInput label="Ledetekst" />
-            <NativeSelect label="Ledetekst">
+            <TextInput label="Ledetekst" width={{ xs: '100%' }} />
+            <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
               <option></option>
               <option>Valg 1</option>
               <option>Valg 2</option>
@@ -237,8 +260,8 @@ export const FormWithSteps = () => {
             Overskrift for gruppe
           </Legend>
           <FieldsetGroup>
-            <TextInput label="Ledetekst" />
-            <NativeSelect label="Ledetekst">
+            <TextInput label="Ledetekst" width={{ xs: '100%' }} />
+            <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
               <option></option>
               <option>Valg 1</option>
               <option>Valg 2</option>
@@ -259,9 +282,10 @@ export const FormWithSteps = () => {
         applicationName="Applikasjon"
         applicationDesc="Beskrivelse"
         navItems={[
-          { children: 'Lenkenavn', href: '/' },
-          { children: 'Lenkenavn', href: '/' },
+          { children: 'Menypunkt', href: '//' },
+          { children: 'Menypunkt', href: '///' },
         ]}
+        currentPageHref="//"
         smallScreenBreakpoint="sm"
       />
       <Grid as="div" marginBlock="0 x1" maxWidth="1100px">
@@ -299,7 +323,8 @@ export const FormWithSteps = () => {
                   iconPosition="right"
                   icon={ChevronRightIcon}
                 >
-                  Steg {activeStep + 1} av {steps.length}
+                  Steg {activeStep + 1} av {steps.length}{' '}
+                  <VisuallyHidden>Vis stegnavigasjon</VisuallyHidden>
                 </Button>
                 <Drawer>
                   <ProgressTracker
@@ -352,12 +377,16 @@ export const FormWithStepsCustomGrid = () => {
   const [progressTrackerDrawerOpen, setProgressTrackerDrawerOpen] =
     useState(false);
 
-  const steps = ['Steg 1 ', 'Steg 2'];
+  const steps = ['Skjemasteg 1 ', 'Skjemasteg 2'];
 
   const completeStep = (step: number, e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setCompletedSteps(s => new Set([...s, activeStep]));
     setActiveStep(step + 1);
+  };
+
+  const previousStep = () => {
+    setActiveStep(activeStep - 1);
   };
 
   const stepItems = steps.map((step, index) => (
@@ -380,8 +409,8 @@ export const FormWithStepsCustomGrid = () => {
               Overskrift for gruppe
             </Legend>
             <FieldsetGroup>
-              <TextInput label="Ledetekst" />
-              <NativeSelect label="Ledetekst">
+              <TextInput label="Ledetekst" width={{ xs: '100%' }} />
+              <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
                 <option></option>
                 <option>Valg 1</option>
                 <option>Valg 2</option>
@@ -394,8 +423,8 @@ export const FormWithStepsCustomGrid = () => {
               Overskrift for gruppe
             </Legend>
             <FieldsetGroup>
-              <TextInput label="Ledetekst" />
-              <NativeSelect label="Ledetekst">
+              <TextInput label="Ledetekst" width={{ xs: '100%' }} />
+              <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
                 <option></option>
                 <option>Valg 1</option>
                 <option>Valg 2</option>
@@ -403,7 +432,35 @@ export const FormWithStepsCustomGrid = () => {
               </NativeSelect>
             </FieldsetGroup>
           </Fieldset>
-          <HStack gap="x1.5" paddingBlock="x1 0">
+          <Fieldset>
+            <Legend withMargins typographyType="headingMedium">
+              Adresse
+            </Legend>
+            <FieldsetGroup>
+              <TextInput label="Adresse" width={{ xs: '100%' }} />
+              <Box
+                display="flex"
+                flexDirection={{
+                  xs: 'column',
+                }}
+                gap="x1.5"
+              >
+                <TextInput width="94px" label="Postnummer" />
+                <TextInput
+                  label="Sted"
+                  readOnly
+                  width={{
+                    xs: '100%',
+                    sm: '202px',
+                    md: '202px',
+                    lg: '202px',
+                    xl: '202px',
+                  }}
+                />
+              </Box>
+            </FieldsetGroup>
+          </Fieldset>
+          <HStack gap="x1.5" paddingBlock="x1.5">
             <Button>Neste</Button>
             <Button purpose="tertiary">Avbryt og forkast</Button>
           </HStack>
@@ -422,8 +479,8 @@ export const FormWithStepsCustomGrid = () => {
             Overskrift for gruppe
           </Legend>
           <FieldsetGroup>
-            <TextInput label="Ledetekst" />
-            <NativeSelect label="Ledetekst">
+            <TextInput label="Ledetekst" width={{ xs: '100%' }} />
+            <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
               <option></option>
               <option>Valg 1</option>
               <option>Valg 2</option>
@@ -436,8 +493,8 @@ export const FormWithStepsCustomGrid = () => {
             Overskrift for gruppe
           </Legend>
           <FieldsetGroup>
-            <TextInput label="Ledetekst" />
-            <NativeSelect label="Ledetekst">
+            <TextInput label="Ledetekst" width={{ xs: '100%' }} />
+            <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
               <option></option>
               <option>Valg 1</option>
               <option>Valg 2</option>
@@ -445,7 +502,7 @@ export const FormWithStepsCustomGrid = () => {
             </NativeSelect>
           </FieldsetGroup>
         </Fieldset>
-        <HStack gap="x1.5" paddingBlock="x1 0">
+        <HStack gap="x1.5" paddingBlock="x1.5">
           <Button>Send inn</Button>
           <Button purpose="tertiary">Avbryt og forkast</Button>
         </HStack>
@@ -460,7 +517,7 @@ export const FormWithStepsCustomGrid = () => {
         gridTemplateColumns={{
           xs: '100%',
           sm: '60ch',
-          md: '60ch',
+          md: '60ch 1fr',
           lg: '60ch 1fr',
           xl: '60ch 1fr',
         }}
@@ -490,7 +547,8 @@ export const FormWithStepsCustomGrid = () => {
                     iconPosition="right"
                     icon={ChevronRightIcon}
                   >
-                    Steg {activeStep + 1} av {steps.length}
+                    Steg {activeStep + 1} av {steps.length}{' '}
+                    <VisuallyHidden>Vis stegnavigasjon</VisuallyHidden>
                   </Button>
                   <Drawer>
                     <ProgressTracker
@@ -503,7 +561,11 @@ export const FormWithStepsCustomGrid = () => {
                 </DrawerGroup>
               </ShowHide>
               {activeStep > 0 && (
-                <Button purpose="secondary" icon={ArrowLeftIcon}>
+                <Button
+                  purpose="secondary"
+                  icon={ArrowLeftIcon}
+                  onClick={() => previousStep()}
+                >
                   Forrige steg
                 </Button>
               )}
@@ -511,7 +573,7 @@ export const FormWithStepsCustomGrid = () => {
             {formSteps[activeStep]}
           </VStack>
         </GridChild>
-        <GridChild hideBelow="md" marginBlock="x3 x1">
+        <GridChild hideBelow="sm" marginBlock="x3 x1">
           <ProgressTracker
             activeStep={activeStep}
             onStepChange={newStep => setActiveStep(newStep)}
@@ -519,6 +581,100 @@ export const FormWithStepsCustomGrid = () => {
             {stepItems}
           </ProgressTracker>
         </GridChild>
+      </Grid>
+    </StoryThemeProvider>
+  );
+};
+
+export const ExitForm = () => {
+  const [isFormPage, setIsFormPage] = useState(true);
+  const [showModal, setShowModal] = useState(false);
+
+  function closeModal() {
+    setShowModal(false);
+  }
+
+  function exitForm() {
+    closeModal();
+    setIsFormPage(false);
+  }
+
+  return (
+    <StoryThemeProvider>
+      <InternalHeader
+        applicationName="Applikasjon"
+        applicationDesc="Beskrivelse"
+      />
+      <Grid maxWidth="60ch" marginBlock="0 x1">
+        <GridChild columnsOccupied="all">
+          {isFormPage ? (
+            <>
+              <Box marginBlock="x1">
+                <BackLink
+                  label="Tilbake"
+                  href="//"
+                  onClick={() => setShowModal(true)}
+                />
+              </Box>
+              <Heading level={1} withMargins>
+                Navn på skjema
+              </Heading>
+              <Paragraph withMargins typographyType="leadMedium">
+                Dette er et avsnitt/ingress. Bruk "body" og "lead" i meg. Lead
+                er ingress og body er vanlig mengdetekst.
+              </Paragraph>
+              <Paragraph
+                withMargins
+                typographyType="bodySmall"
+                color="text-subtle"
+              >
+                Obligatoriske felter er merket med{' '}
+                <Typography as="span" color="text-requiredfield">
+                  *
+                </Typography>
+                .
+              </Paragraph>
+              <VStack as="form" gap="x1">
+                <Fieldset>
+                  <Legend withMargins>Overskrift for gruppe</Legend>
+                  <FieldsetGroup>
+                    <TextInput label="Ledetekst" width={{ xs: '100%' }} />
+                    <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
+                      <option></option>
+                      <option>Valg 1</option>
+                      <option>Valg 2</option>
+                      <option>Valg 3</option>
+                    </NativeSelect>
+                  </FieldsetGroup>
+                </Fieldset>
+                <HStack gap="x1.5" paddingBlock="x1.5">
+                  <Button>Send inn</Button>
+                  <Button purpose="tertiary">Avbryt og forkast</Button>
+                </HStack>
+              </VStack>
+            </>
+          ) : (
+            <>
+              <Heading level={1} withMargins>
+                Ute av skjema
+              </Heading>
+              <Button onClick={() => setIsFormPage(true)}>Gå til skjema</Button>
+            </>
+          )}
+        </GridChild>
+        <Modal
+          isOpen={showModal}
+          onClose={closeModal}
+          header="Du er i ferd med å forlate skjema"
+        >
+          <ModalBody>Alle endringer vil bli tapt.</ModalBody>
+          <ModalActions>
+            <Button onClick={exitForm}>Forlat</Button>
+            <Button purpose="secondary" onClick={closeModal}>
+              Bli på siden
+            </Button>
+          </ModalActions>
+        </Modal>
       </Grid>
     </StoryThemeProvider>
   );

--- a/packages/dds-components/stories/patterns/introduction.mdx
+++ b/packages/dds-components/stories/patterns/introduction.mdx
@@ -1,0 +1,21 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Patterns/Introduction" />
+
+# Patterns
+
+Her finner du mønstre - eksempler på sammensatte komponenter og sideoppsett som dekker vanlige brukerbehov - som skjemaer, oppsummeringssider, og andre typiske interaksjonsmønstre.
+I motsetning til enkeltkomponenter, viser mønstre hvordan elementer fungerer sammen i en helhetlig kontekst.
+
+Mønstrene hjelper deg som utvikler med å:
+
+- Spare tid ved å gjenbruke etablerte løsninger.
+- Sikre konsistens i brukeropplevelsen på tvers av tjenester.
+- Forstå kontekst for hvordan komponenter bør brukes sammen.
+- Følge beste praksis for tilgjengelighet, responsivitet og interaksjon.
+
+## Hvordan bruke mønstrene
+
+- Utforsk mønstrene i Elsa Storybook for å se hvordan de er bygget opp; skjekk de opp mot skisser.
+- Kopier og tilpass mønstrene til dine behov - de er ment som utgangspunkt, ikke fasit.
+- Bidra gjerne med tilbakemeldinger, forbedringer eller nye mønstre hvis vi blir enige om gjentakende behov.


### PR DESCRIPTION
## Beskrivelse

Implementerer ferdig eksempler for skjema-mønstre: vanlig, med steg og forsøk på å forlate påbegynt skjema. Skriver ferdig docs for disse samt for mønstre generelt. Docs er tilgjengelige under "Patterns": https://elsa1-540-form-pattern.designsystem.pages.dev/?path=/docs/patterns-introduction--docs

Andre endringer gjort for å utbedre bruk av mønstre:

- Justerer på hvordan `width` prop fungerer på skjemakomponenter. Hvis bredde settes kun på enkelte brekkpunkter vil resterende brekkpunkter få default bredde definert i komponenten. Før fikk utelatte brekkpunkter ingen definert bredde, og dermed utforutsigbar bredde. Kan potensielt føre til endringer i layout. Påvirker komponentene `<TextInput>`, `<Select>`, `<PhoneInput>`, `<ProgressBar>`, `<NativeSelect>`, `<TextArea>`, `<DatePicker>`, `<TimePicker>`.
- Refaktorerer funksjonen som setter styling opptil et brekkpunkt og muligens annen styling over det brekkpunktet; bytter navn til `styleUpToBreakpoint` + JS Doc.
- Viser default verdi for `as` prop i `<VisuallyHidden>` i docs, da den ikke ble plukket opp grunnet polymorfi. Kunne skapt forvirring da mønstre bruker default-verdien `span`.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
