### PR TITLE
ELSA1-669 hydration feil i select komponent

### DIFF
--- a/.changeset/three-baboons-knock.md
+++ b/.changeset/three-baboons-knock.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser hydreringsfeil i `<Select>`-komponent

--- a/packages/dds-components/src/components/Select/Select.tsx
+++ b/packages/dds-components/src/components/Select/Select.tsx
@@ -196,6 +196,10 @@ export function Select<Option = unknown, IsMulti extends boolean = false>({
             ...props,
             readOnly,
             'aria-required': ariaRequired,
+            'aria-activedescendant':
+              props['aria-activedescendant'] === ''
+                ? undefined
+                : props['aria-activedescendant'],
           },
           hasErrorMessage,
           spaceSeparatedIdListGenerator([


### PR DESCRIPTION
## Beskrivelse

Denne PRen fikser feilen beskrevet i https://domstol.atlassian.net/browse/ELSA1-669. Kort oppsummert er det to utfordringer knyttet til Select-komponenten dersom man benytter server side rendering. Dette resulterer i hydration-feil på sider som benytter komponenten. JIRA-oppgaven lenker til en ticket på Github som beskriver problemet mer i detalj, og inneholder en måte å omgå problemet på.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
