### PR TITLE
ELSA1-654 Standardiserer size stories i Storybook

### DIFF
--- a/packages/dds-components/src/components/Button/Button.mdx
+++ b/packages/dds-components/src/components/Button/Button.mdx
@@ -18,8 +18,6 @@ import * as ButtonStories from './Button.stories';
 <Canvas of={ButtonStories.Preview} />
 <Controls of={ButtonStories.Preview} />
 
-Native HTML-attributter `type`, `onClick`, `onFocus` og `onBlur` er tilgjengelige på rotnivå.
-
 ## Retningslinjer
 
 - Unngå å bruke `disabled`-attributtet da det fører til [dårlig brukeropplevelse](https://axesslab.com/disabled-buttons-suck/). Knappen skal være interaktiv, og dersom knappehandlingen ikke kan fullføres, bør det vises en tydelig feilmelding eller en annen relevant tilbakemelding.

--- a/packages/dds-components/src/components/Button/Button.stories.tsx
+++ b/packages/dds-components/src/components/Button/Button.stories.tsx
@@ -2,24 +2,28 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
 import { ArrowLeftIcon } from '../..';
+import { BUTTON_SIZES } from './Button.types';
 import {
   categoryHtml,
   commonArgTypes,
+  htmlArgType,
   htmlEventArgType,
+  labelText,
 } from '../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
-import { Button } from '.';
+import { Button, type ButtonPurpose } from '.';
 
 export default {
   title: 'dds-components/Components/Button',
   component: Button,
   argTypes: {
-    href: { table: categoryHtml },
-    children: { control: 'text' },
-    target: { control: false, table: categoryHtml },
-    icon: { control: false },
     ...commonArgTypes,
+    children: { control: 'text' },
+    icon: { control: false },
+    href: { table: categoryHtml },
+    target: htmlArgType,
+    type: htmlArgType,
     onClick: htmlEventArgType,
     onBlur: htmlEventArgType,
     onFocus: htmlEventArgType,
@@ -33,128 +37,82 @@ export const Preview: Story = {
   args: { children: 'Tekst' },
 };
 
-export const OverviewPurposes: Story = {
+const purposes: Array<ButtonPurpose> = [
+  'primary',
+  'secondary',
+  'tertiary',
+  'danger',
+];
+
+export const Purposes: Story = {
   render: args => (
     <StoryHStack>
       <StoryVStack>
-        <Button
-          {...args}
-          purpose="primary"
-          onClick={() => console.log('click')}
-        >
-          Primary
-        </Button>
-        <Button {...args} purpose="secondary">
-          Secondary
-        </Button>
-        <Button {...args} purpose="tertiary">
-          Tertiary
-        </Button>
-        <Button {...args} purpose="danger">
-          Danger
-        </Button>
+        {purposes.map(purpose => (
+          <Button key={`t-${purpose}`} {...args} purpose={purpose}>
+            {labelText(purpose)}
+          </Button>
+        ))}
       </StoryVStack>
       <StoryVStack>
-        <Button
-          {...args}
-          purpose="primary"
-          iconPosition={args.iconPosition ?? 'left'}
-          icon={ArrowLeftIcon}
-        >
-          Primary
-        </Button>
-        <Button
-          {...args}
-          purpose="secondary"
-          iconPosition={args.iconPosition ?? 'left'}
-          icon={ArrowLeftIcon}
-        >
-          Secondary
-        </Button>
-        <Button
-          {...args}
-          purpose="tertiary"
-          iconPosition={args.iconPosition ?? 'left'}
-          icon={ArrowLeftIcon}
-        >
-          Tertiary
-        </Button>
-        <Button
-          {...args}
-          purpose="danger"
-          iconPosition={args.iconPosition ?? 'left'}
-          icon={ArrowLeftIcon}
-        >
-          Danger
-        </Button>
+        {purposes.map(purpose => (
+          <Button
+            key={`i-left-${purpose}`}
+            {...args}
+            purpose={purpose}
+            iconPosition={args.iconPosition ?? 'left'}
+            icon={ArrowLeftIcon}
+          >
+            {labelText(purpose)}
+          </Button>
+        ))}
       </StoryVStack>
       <StoryVStack>
-        <Button {...args} icon={ArrowLeftIcon} purpose="primary" />
-        <Button {...args} icon={ArrowLeftIcon} purpose="secondary" />
-        <Button {...args} icon={ArrowLeftIcon} purpose="tertiary" />
-        <Button {...args} icon={ArrowLeftIcon} purpose="danger" />
+        {purposes.map(purpose => (
+          <Button
+            key={`i-${purpose}`}
+            {...args}
+            icon={ArrowLeftIcon}
+            purpose={purpose}
+          />
+        ))}
       </StoryVStack>
     </StoryHStack>
   ),
 };
 
-export const OverviewSizes: Story = {
-  args: { purpose: 'primary' },
+export const Sizes: Story = {
   render: args => (
     <StoryHStack>
       <StoryVStack>
-        <Button {...args} size="xsmall">
-          Primary
-        </Button>
-        <Button {...args} size="small">
-          Primary
-        </Button>
-        <Button {...args} size="medium">
-          Primary
-        </Button>
-        <Button {...args} size="large">
-          Primary
-        </Button>
+        {BUTTON_SIZES.map(size => (
+          <Button key={size} {...args} size={size}>
+            {labelText(size)}
+          </Button>
+        ))}
       </StoryVStack>
       <StoryVStack>
-        <Button
-          {...args}
-          size="xsmall"
-          iconPosition={args.iconPosition ?? 'left'}
-          icon={ArrowLeftIcon}
-        >
-          Primary
-        </Button>
-        <Button
-          {...args}
-          size="small"
-          iconPosition={args.iconPosition ?? 'left'}
-          icon={ArrowLeftIcon}
-        >
-          Primary
-        </Button>
-        <Button
-          {...args}
-          size="medium"
-          iconPosition={args.iconPosition ?? 'left'}
-          icon={ArrowLeftIcon}
-        >
-          Primary
-        </Button>
-        <Button
-          {...args}
-          size="large"
-          iconPosition={args.iconPosition ?? 'left'}
-          icon={ArrowLeftIcon}
-        >
-          Primary
-        </Button>
+        {BUTTON_SIZES.map(size => (
+          <Button
+            key={`il-${size}`}
+            {...args}
+            size={size}
+            iconPosition={args.iconPosition ?? 'left'}
+            icon={ArrowLeftIcon}
+          >
+            {labelText(size)}
+          </Button>
+        ))}
       </StoryVStack>
       <StoryVStack>
-        <Button {...args} size="xsmall" icon={ArrowLeftIcon} />
-        <Button {...args} size="small" icon={ArrowLeftIcon} />
-        <Button {...args} size="medium" icon={ArrowLeftIcon} />
-        <Button {...args} size="large" icon={ArrowLeftIcon} />
+        {BUTTON_SIZES.map(size => (
+          <Button
+            key={`i-${size}`}
+            {...args}
+            icon={ArrowLeftIcon}
+            size={size}
+          />
+        ))}
       </StoryVStack>
     </StoryHStack>
   ),
@@ -190,8 +148,12 @@ export const OverviewFullWidth: Story = {
   render: args => (
     <StoryVStack>
       <Button {...args}></Button>
-      <Button {...args} iconPosition="left" icon={ArrowLeftIcon}></Button>
-      <Button {...args} iconPosition="right" icon={ArrowLeftIcon}></Button>
+      <Button {...args} iconPosition="left" icon={ArrowLeftIcon}>
+        Tekst og ikon til venstre
+      </Button>
+      <Button {...args} iconPosition="right" icon={ArrowLeftIcon}>
+        Tekst og ikon til høyre
+      </Button>
       <Button {...args} children={undefined} icon={ArrowLeftIcon} />
       <Button {...args} loading>
         label
@@ -202,7 +164,7 @@ export const OverviewFullWidth: Story = {
 
 export const TextWithIcon: Story = {
   args: {
-    children: 'Tekst',
+    children: 'Tekst og ikon',
     icon: ArrowLeftIcon,
     iconPosition: 'left',
   },

--- a/packages/dds-components/src/components/Button/Button.types.tsx
+++ b/packages/dds-components/src/components/Button/Button.types.tsx
@@ -1,10 +1,12 @@
 import { type ButtonHTMLAttributes, type ReactNode } from 'react';
 
-import { type BaseComponentProps, type Size } from '../../types';
+import { type BaseComponentProps, createSizes } from '../../types';
 import { type SvgIcon } from '../Icon/utils';
 
+export const BUTTON_SIZES = createSizes('xsmall', 'small', 'medium', 'large');
+
 export type ButtonPurpose = 'primary' | 'secondary' | 'danger' | 'tertiary';
-export type ButtonSize = Extract<Size, 'xsmall' | 'small' | 'medium' | 'large'>;
+export type ButtonSize = (typeof BUTTON_SIZES)[number];
 export type IconPosition = 'left' | 'right';
 
 type PickedHTMLAttributes = Pick<

--- a/packages/dds-components/src/components/Button/index.tsx
+++ b/packages/dds-components/src/components/Button/index.tsx
@@ -1,2 +1,7 @@
-export * from './Button';
-export * from './Button.types';
+export { Button } from './Button';
+export type {
+  ButtonProps,
+  ButtonPurpose,
+  ButtonSize,
+  IconPosition,
+} from './Button.types';

--- a/packages/dds-components/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/dds-components/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,7 +1,12 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
-import { categoryHtml, commonArgTypes } from '../../storybook/helpers';
+import {
+  categoryHtml,
+  commonArgTypes,
+  labelText,
+} from '../../storybook/helpers';
 import { Button } from '../Button/Button';
+import { BUTTON_SIZES } from '../Button/Button.types';
 import { StoryVStack } from '../layout/Stack/utils';
 
 import { ButtonGroup } from '.';
@@ -32,26 +37,13 @@ export const Preview: Story = {
 export const Sizes: Story = {
   render: args => (
     <StoryVStack>
-      <ButtonGroup {...args} buttonSize="large">
-        <Button>Første</Button>
-        <Button>Andre</Button>
-        <Button>Tredje</Button>
-      </ButtonGroup>
-      <ButtonGroup {...args}>
-        <Button>Første</Button>
-        <Button>Andre</Button>
-        <Button>Tredje</Button>
-      </ButtonGroup>
-      <ButtonGroup {...args} buttonSize="small">
-        <Button>Første</Button>
-        <Button>Andre</Button>
-        <Button>Tredje</Button>
-      </ButtonGroup>
-      <ButtonGroup {...args} buttonSize="xsmall">
-        <Button>Første</Button>
-        <Button>Andre</Button>
-        <Button>Tredje</Button>
-      </ButtonGroup>
+      {BUTTON_SIZES.map(size => (
+        <ButtonGroup key={size} {...args} buttonSize={size}>
+          <Button>{labelText(size)}</Button>
+          <Button>{labelText(size)}</Button>
+          <Button>{labelText(size)}</Button>
+        </ButtonGroup>
+      ))}
     </StoryVStack>
   ),
 };

--- a/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
@@ -8,6 +8,7 @@ import { Button } from '../Button';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
 import { Heading, Paragraph } from '../Typography';
+import { DRAWER_SIZES } from './Drawer';
 
 import { Drawer, DrawerGroup } from '.';
 
@@ -99,82 +100,38 @@ export const OverviewPlacement: Story = {
   ),
 };
 
-export const OverviewSizes: Story = {
-  args: { header: 'Rettsmekling' },
+export const Sizes: Story = {
+  args: { header: 'Header' },
   render: args => (
     <StoryHStack>
-      <DrawerGroup>
-        <Button>Åpne liten</Button>
-        <Drawer {...args}>
-          <div>
-            <Paragraph>
-              En sivil tvist kan løses ved hjelp av rettsmekling i stedet for
-              hovedforhandling og dom. Det går ut på at partene kommer fram til
-              en avtale, kalt rettsforlik, ved hjelp av en mekler. Dette er en
-              raskere, mer effektiv og billigere måte å løse konflikten på.
-            </Paragraph>
-            <Heading level={2} typographyType="headingLarge" withMargins>
-              Hva er rettsmekling?
-            </Heading>
-            <Paragraph>
-              Rettsmekling går ut på at partene selv finner en løsning på
-              konflikten ved å bruke en mekler (vanligvis en dommer i domstolen
-              som behandler saken). Avtalen man kommer fram til, blir
-              rettskraftig på lik linje med en dom. Rettsmekling kan bare brukes
-              i sivile saker, ikke i straffesaker.
-            </Paragraph>
-          </div>
-          <Button>Gjør noe</Button>
-        </Drawer>
-      </DrawerGroup>
-      <DrawerGroup>
-        <Button>Åpne medium</Button>
-        <Drawer {...args} size="medium">
-          <div>
-            <Paragraph>
-              En sivil tvist kan løses ved hjelp av rettsmekling i stedet for
-              hovedforhandling og dom. Det går ut på at partene kommer fram til
-              en avtale, kalt rettsforlik, ved hjelp av en mekler. Dette er en
-              raskere, mer effektiv og billigere måte å løse konflikten på.
-            </Paragraph>
-            <Heading level={2} typographyType="headingLarge" withMargins>
-              Hva er rettsmekling?
-            </Heading>
-            <Paragraph>
-              Rettsmekling går ut på at partene selv finner en løsning på
-              konflikten ved å bruke en mekler (vanligvis en dommer i domstolen
-              som behandler saken). Avtalen man kommer fram til, blir
-              rettskraftig på lik linje med en dom. Rettsmekling kan bare brukes
-              i sivile saker, ikke i straffesaker.
-            </Paragraph>
-          </div>
-          <Button>Gjør noe</Button>
-        </Drawer>
-      </DrawerGroup>
-      <DrawerGroup>
-        <Button>Åpne stor</Button>
-        <Drawer {...args} size="large">
-          <div>
-            <Paragraph>
-              En sivil tvist kan løses ved hjelp av rettsmekling i stedet for
-              hovedforhandling og dom. Det går ut på at partene kommer fram til
-              en avtale, kalt rettsforlik, ved hjelp av en mekler. Dette er en
-              raskere, mer effektiv og billigere måte å løse konflikten på.
-            </Paragraph>
-            <Heading level={2} typographyType="headingLarge" withMargins>
-              Hva er rettsmekling?
-            </Heading>
-            <Paragraph>
-              Rettsmekling går ut på at partene selv finner en løsning på
-              konflikten ved å bruke en mekler (vanligvis en dommer i domstolen
-              som behandler saken). Avtalen man kommer fram til, blir
-              rettskraftig på lik linje med en dom. Rettsmekling kan bare brukes
-              i sivile saker, ikke i straffesaker.
-            </Paragraph>
-          </div>
-          <Button>Gjør noe</Button>
-        </Drawer>
-      </DrawerGroup>
+      {DRAWER_SIZES.map(size => (
+        <DrawerGroup key={size}>
+          <Button>Åpne {size}</Button>
+          <Drawer {...args} size={size}>
+            <div>
+              <Paragraph>
+                Dette er en eksempeletekst. Den er litt lengre slik at man kan
+                tydelig vise forskjeller mellom ulike størrelser på komponenten.
+                Teksten er et par setninger lang.
+              </Paragraph>
+              <Heading level={3} withMargins>
+                Dette er en overskrift
+              </Heading>
+              <Paragraph>
+                Dette er en eksempeletekst. Den er litt lengre slik at man kan
+                tydelig vise forskjeller mellom ulike størrelser på komponenten.
+                Teksten er et par setninger lang. Dette er en eksempeletekst.
+                Den er litt lengre slik at man kan tydelig vise forskjeller
+                mellom ulike størrelser på komponenten. Teksten er et par
+                setninger lang. Dette er en eksempeletekst. Den er litt lengre
+                slik at man kan tydelig vise forskjeller mellom ulike størrelser
+                på komponenten. Teksten er et par setninger lang.
+              </Paragraph>
+            </div>
+            <Button>Gjør noe</Button>
+          </Drawer>
+        </DrawerGroup>
+      ))}
     </StoryHStack>
   ),
 };
@@ -190,7 +147,7 @@ export const Controlled: Story = {
           <Button>Åpne</Button>
           <Drawer {...args}>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+            eiusmod tempor incididunt ut labore en dolore magna aliqua. Ut enim
             ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
             aliquip ex ea commodo consequat. Duis aute irure dolor in
             reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
@@ -248,7 +205,7 @@ export const LongContent: Story = {
             avtale, kalt rettsforlik, ved hjelp av en mekler. Dette er en
             raskere, mer effektiv og billigere måte å løse konflikten på.
           </Paragraph>
-          <Heading level={2} typographyType="headingLarge" withMargins>
+          <Heading level={3} withMargins>
             Hva er rettsmekling?
           </Heading>
           <Paragraph withMargins>
@@ -258,7 +215,7 @@ export const LongContent: Story = {
             på lik linje med en dom. Rettsmekling kan bare brukes i sivile
             saker, ikke i straffesaker.
           </Paragraph>
-          <Heading level={2} typographyType="headingLarge" withMargins>
+          <Heading level={3} withMargins>
             Hva er fordelene med rettsmekling?
           </Heading>
           <Paragraph withMargins>

--- a/packages/dds-components/src/components/Drawer/Drawer.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from '../../i18n';
 import { commonTexts } from '../../i18n/commonTexts';
 import {
   type BaseComponentPropsWithChildren,
-  type Size,
+  createSizes,
   getBaseHTMLProps,
 } from '../../types';
 import { cn } from '../../utils';
@@ -36,7 +36,8 @@ import { Heading } from '../Typography';
 import { useDrawerContext } from './Drawer.context';
 import { HStack, Paper, type ResponsiveProps, VStack } from '../layout';
 
-export type DrawerSize = Extract<Size, 'small' | 'medium' | 'large'>;
+export const DRAWER_SIZES = createSizes('small', 'medium', 'large');
+export type DrawerSize = (typeof DRAWER_SIZES)[number];
 export type DrawerPlacement = 'left' | 'right';
 export type WidthProps = Pick<
   ResponsiveProps,

--- a/packages/dds-components/src/components/Drawer/index.ts
+++ b/packages/dds-components/src/components/Drawer/index.ts
@@ -1,2 +1,7 @@
-export * from './Drawer';
+export {
+  Drawer,
+  type DrawerProps,
+  type DrawerPlacement,
+  type DrawerSize,
+} from './Drawer';
 export * from './DrawerGroup';

--- a/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
+++ b/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
@@ -2,11 +2,12 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useRef, useState } from 'react';
 import { fn } from 'storybook/test';
 
-import { FavStar } from './FavStar';
+import { FAVSTAR_SIZES, FavStar } from './FavStar';
 import {
   categoryHtml,
   commonArgTypes,
   htmlEventArgType,
+  labelText,
 } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { focusable } from '../helpers/styling/focus.module.css';
@@ -36,21 +37,17 @@ type Story = StoryObj<typeof FavStar>;
 
 export const Preview: Story = {};
 
-export const OverviewSizes: Story = {
+export const Sizes: Story = {
   render: args => (
     <StoryHStack>
-      <StoryVStack>
-        <Typography as="span" typographyType="labelMedium">
-          Medium
-        </Typography>
-        <FavStar {...args} size="medium" />
-      </StoryVStack>
-      <StoryVStack>
-        <Typography as="span" typographyType="labelMedium">
-          Large
-        </Typography>
-        <FavStar {...args} size="large" />
-      </StoryVStack>
+      {FAVSTAR_SIZES.map(size => (
+        <StoryVStack key={size}>
+          <Typography as="span" typographyType="labelMedium">
+            {labelText(size)}
+          </Typography>
+          <FavStar {...args} size={size} />
+        </StoryVStack>
+      ))}
     </StoryHStack>
   ),
 };

--- a/packages/dds-components/src/components/FavStar/FavStar.tsx
+++ b/packages/dds-components/src/components/FavStar/FavStar.tsx
@@ -5,6 +5,7 @@ import { useControllableState } from '../../hooks/useControllableState';
 import { createTexts, useTranslation } from '../../i18n';
 import {
   type BaseComponentPropsWithChildren,
+  createSizes,
   getBaseHTMLProps,
 } from '../../types';
 import { cn } from '../../utils';
@@ -13,7 +14,8 @@ import focusStyles from '../helpers/styling/focus.module.css';
 import { Icon } from '../Icon';
 import { StarFilledIcon, StarIcon } from '../Icon/icons';
 
-type ComponentSize = 'medium' | 'large';
+export const FAVSTAR_SIZES = createSizes('medium', 'large');
+type ComponentSize = (typeof FAVSTAR_SIZES)[number];
 
 export type FavStarProps = BaseComponentPropsWithChildren<
   HTMLElement,

--- a/packages/dds-components/src/components/Icon/Icon.stories.tsx
+++ b/packages/dds-components/src/components/Icon/Icon.stories.tsx
@@ -1,9 +1,11 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import { OpenExternalIcon as OpenExternal } from './icons/openExternal';
-import { commonArgTypes } from '../../storybook/helpers';
+import { commonArgTypes, labelText } from '../../storybook/helpers';
 import { StoryHStack } from '../layout/Stack/utils';
-import { Paragraph } from '../Typography';
+import { Paragraph, Typography } from '../Typography';
+import { ICON_SIZES } from './Icon';
+import { VStack } from '../layout';
 
 import { Icon } from '.';
 
@@ -29,10 +31,14 @@ export const Sizes: Story = {
   args: { icon },
   render: args => (
     <StoryHStack>
-      <Icon {...args} iconSize="inherit" />
-      <Icon {...args} iconSize="small" />
-      <Icon {...args} iconSize="medium" />
-      <Icon {...args} iconSize="large" />
+      {ICON_SIZES.map(size => (
+        <VStack key={size}>
+          <Typography as="span" typographyType="labelMedium">
+            {labelText(size)}
+          </Typography>
+          <Icon {...args} iconSize={size} />
+        </VStack>
+      ))}
     </StoryHStack>
   ),
 };

--- a/packages/dds-components/src/components/Icon/Icon.tsx
+++ b/packages/dds-components/src/components/Icon/Icon.tsx
@@ -1,7 +1,11 @@
 import { type HTMLAttributes } from 'react';
 
 import { type SvgIcon } from './utils';
-import { type BaseComponentProps, getBaseHTMLProps } from '../../types';
+import {
+  type BaseComponentProps,
+  createSizes,
+  getBaseHTMLProps,
+} from '../../types';
 import { type TextColor } from '../../utils';
 
 const getSize = (iconSize: IconSize): string => {
@@ -19,7 +23,8 @@ const getSize = (iconSize: IconSize): string => {
   }
 };
 
-export type IconSize = 'small' | 'medium' | 'large' | 'inherit';
+export const ICON_SIZES = createSizes('small', 'medium', 'large', 'inherit');
+export type IconSize = (typeof ICON_SIZES)[number];
 
 export type IconProps = BaseComponentProps<
   SVGSVGElement,

--- a/packages/dds-components/src/components/Icon/index.ts
+++ b/packages/dds-components/src/components/Icon/index.ts
@@ -1,2 +1,2 @@
-export * from './Icon';
+export { Icon, type IconProps, type IconSize } from './Icon';
 export * from './utils';

--- a/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
@@ -6,10 +6,12 @@ import { InputStepper } from './InputStepper';
 import {
   categoryHtml,
   commonArgTypes,
+  labelText,
   responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
 import { Button } from '../Button';
+import { INPUT_STEPPER_SIZES } from './InputStepper.types';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 export default {
@@ -43,8 +45,14 @@ export const Sizes: Story = {
   render: args => {
     return (
       <StoryHStack>
-        <InputStepper {...args} label="Medium" />
-        <InputStepper {...args} label="Small" componentSize="small" />
+        {INPUT_STEPPER_SIZES.map(size => (
+          <InputStepper
+            {...args}
+            key={size}
+            label={labelText(size)}
+            componentSize={size}
+          />
+        ))}
       </StoryHStack>
     );
   },

--- a/packages/dds-components/src/components/InputStepper/InputStepper.types.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.types.tsx
@@ -1,9 +1,10 @@
 import { type InputHTMLAttributes } from 'react';
 
-import { type BaseComponentProps, type Size } from '../../types';
+import { type BaseComponentProps, createSizes } from '../../types';
 import { type InputProps } from '../helpers/Input';
 
-export type InputStepperSize = Extract<Size, 'small' | 'medium'>;
+export const INPUT_STEPPER_SIZES = createSizes('small', 'medium');
+export type InputStepperSize = (typeof INPUT_STEPPER_SIZES)[number];
 
 export function isPositiveInteger(n: number): n is number {
   return Number.isInteger(n) && n >= 0;

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.stories.tsx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.stories.tsx
@@ -6,9 +6,11 @@ import {
   categoryCss,
   categoryHtml,
   htmlArgType,
+  labelText,
   windowWidthDecorator,
 } from '../../storybook/helpers';
 import { Button } from '../Button';
+import { INPUT_SIZES } from '../helpers/Input';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 import { PhoneInput, type PhoneInputValue } from '.';
@@ -58,9 +60,14 @@ export const Sizes: Story = {
   args: { label: 'Label' },
   render: args => (
     <StoryVStack>
-      <PhoneInput {...args} />
-      <PhoneInput {...args} componentSize="small" />
-      <PhoneInput {...args} componentSize="xsmall" />
+      {INPUT_SIZES.map(size => (
+        <PhoneInput
+          {...args}
+          key={size}
+          componentSize={size}
+          label={labelText(size)}
+        />
+      ))}
     </StoryVStack>
   ),
 };

--- a/packages/dds-components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/dds-components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,6 +1,8 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
+import { PROGRESS_BAR_SIZES } from './ProgressBar';
 import {
+  labelText,
   responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
@@ -21,6 +23,8 @@ type Story = StoryObj<typeof ProgressBar>;
 export const Preview: Story = {
   args: {
     label: 'Label',
+    value: 3,
+    max: 5,
   },
 };
 
@@ -41,12 +45,14 @@ export const Overview: Story = {
 export const Sizes: Story = {
   args: {
     label: 'Label',
-    value: 50,
+    value: 3,
+    max: 5,
   },
   render: args => (
     <StoryVStack>
-      <ProgressBar {...args} />
-      <ProgressBar {...args} size="small" />
+      {PROGRESS_BAR_SIZES.map(size => (
+        <ProgressBar {...args} key={size} size={size} label={labelText(size)} />
+      ))}
     </StoryVStack>
   ),
 };
@@ -55,6 +61,8 @@ export const ResponsiveWidth: Story = {
   decorators: [Story => windowWidthDecorator(<Story />)],
   args: {
     label: 'Label',
+    value: 3,
+    max: 5,
     width: {
       xs: '100%',
       sm: '100%',

--- a/packages/dds-components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/dds-components/src/components/ProgressBar/ProgressBar.tsx
@@ -1,5 +1,6 @@
 import { type ComponentPropsWithRef, useId } from 'react';
 
+import { createSizes } from '../../types';
 import { Label } from '../Typography';
 import utilStyles from './../helpers/styling/utilStyles.module.css';
 import styles from './ProgressBar.module.css';
@@ -12,7 +13,8 @@ import { type CommonInputProps, getInputWidth } from '../helpers/Input';
 import { renderInputMessage } from '../InputMessage';
 import { Box } from '../layout';
 
-export type ProgressBarSize = 'medium' | 'small';
+export const PROGRESS_BAR_SIZES = createSizes('small', 'medium');
+export type ProgressBarSize = (typeof PROGRESS_BAR_SIZES)[number];
 
 export type ProgressBarProps = Pick<
   CommonInputProps,

--- a/packages/dds-components/src/components/ProgressBar/index.ts
+++ b/packages/dds-components/src/components/ProgressBar/index.ts
@@ -1,1 +1,2 @@
-export * from './ProgressBar';
+export { ProgressBar } from './ProgressBar';
+export type { ProgressBarProps, ProgressBarSize } from './ProgressBar';

--- a/packages/dds-components/src/components/Search/Search.stories.tsx
+++ b/packages/dds-components/src/components/Search/Search.stories.tsx
@@ -1,8 +1,10 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
+import { SEARCH_SIZES } from './Search.utils';
 import {
   htmlEventArgType,
+  labelText,
   responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
@@ -39,6 +41,16 @@ const array = [
   'Øst-Agder',
 ];
 
+const elementsInfo = (
+  <div>
+    Elementer i listen:{' '}
+    {array.map(
+      (item, index) => `${item}${index !== array.length - 1 ? ', ' : ''}`,
+    )}
+    .
+  </div>
+);
+
 type Story = StoryObj<typeof Search>;
 
 export const Preview: Story = {};
@@ -67,47 +79,37 @@ export const Overview: Story = {
   ),
 };
 
-export const OverviewSizes: Story = {
+export const Sizes: Story = {
   render: args => (
     <StoryHStack>
       <StoryVStack>
-        <Search {...args} componentSize="small" />
-        <Search {...args} componentSize="medium" />
-        <Search {...args} componentSize="large" />
+        {SEARCH_SIZES.map(size => (
+          <Search {...args} label={labelText(size)} componentSize={size} />
+        ))}
       </StoryVStack>
       <StoryVStack>
-        <Search
-          {...args}
-          componentSize="small"
-          buttonProps={{ onClick: () => null, label: 'Søk' }}
-        />
-        <Search
-          {...args}
-          componentSize="medium"
-          buttonProps={{ onClick: () => null, label: 'Søk' }}
-        />
-        <Search
-          {...args}
-          componentSize="large"
-          buttonProps={{ onClick: () => null, label: 'Søk' }}
-        />
+        {SEARCH_SIZES.map(size => (
+          <Search
+            {...args}
+            label={labelText(size)}
+            componentSize={size}
+            buttonProps={{ onClick: () => null, label: 'Søk' }}
+          />
+        ))}
       </StoryVStack>
     </StoryHStack>
   ),
 };
 
-export const OverviewWithSuggestion: Story = {
+export const SizesWithSuggestions: Story = {
   render: args => (
     <StoryVStack>
-      <Search.AutocompleteWrapper data={{ array }}>
-        <Search {...args} componentSize="large" />
-      </Search.AutocompleteWrapper>
-      <Search.AutocompleteWrapper data={{ array }}>
-        <Search {...args} componentSize="medium" />
-      </Search.AutocompleteWrapper>
-      <Search.AutocompleteWrapper data={{ array }}>
-        <Search {...args} componentSize="small" />
-      </Search.AutocompleteWrapper>
+      {SEARCH_SIZES.map(size => (
+        <Search.AutocompleteWrapper data={{ array }} key={size}>
+          <Search {...args} label={labelText(size)} componentSize={size} />
+        </Search.AutocompleteWrapper>
+      ))}
+      {elementsInfo}
     </StoryVStack>
   ),
 };
@@ -125,13 +127,7 @@ export const WithSuggestions: Story = {
       <Search.AutocompleteWrapper data={{ array }}>
         <Search {...args} />
       </Search.AutocompleteWrapper>
-      <div>
-        Elementer i listen:{' '}
-        {array.map(
-          (item, index) => `${item}${index !== array.length - 1 ? ', ' : ''}`,
-        )}
-        .
-      </div>
+      {elementsInfo}
     </>
   ),
 };

--- a/packages/dds-components/src/components/Search/Search.types.tsx
+++ b/packages/dds-components/src/components/Search/Search.types.tsx
@@ -2,8 +2,9 @@ import { type ComponentPropsWithRef } from 'react';
 
 import { type ExtractStrict } from '../../types';
 import { type ButtonProps, type ButtonPurpose } from '../Button';
+import { type SEARCH_SIZES } from './Search.utils';
 
-export type SearchSize = 'small' | 'medium' | 'large';
+export type SearchSize = (typeof SEARCH_SIZES)[number];
 
 export type SearchButtonProps = {
   label?: string;

--- a/packages/dds-components/src/components/Search/Search.utils.ts
+++ b/packages/dds-components/src/components/Search/Search.utils.ts
@@ -1,8 +1,10 @@
 import { type ChangeEvent } from 'react';
 
 import { type SearchSize } from './Search.types';
+import { createSizes } from '../../types';
 import { type StaticTypographyType } from '../Typography';
 
+export const SEARCH_SIZES = createSizes('small', 'medium', 'large');
 export const typographyTypes: Record<SearchSize, StaticTypographyType> = {
   small: 'bodySmall',
   medium: 'bodyMedium',

--- a/packages/dds-components/src/components/Select/MultiSelect.stories.tsx
+++ b/packages/dds-components/src/components/Select/MultiSelect.stories.tsx
@@ -1,6 +1,12 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import { Select } from './Select';
+import {
+  categoryHtml,
+  labelText,
+  responsivePropsArgTypes,
+} from '../../storybook/helpers';
+import { INPUT_SIZES } from '../helpers/Input';
 import { CourtIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
@@ -9,14 +15,11 @@ const meta: Meta<typeof Select<Option, true>> = {
   title: 'dds-components/Components/Select/MultiSelect',
   component: Select,
   argTypes: {
-    label: { control: { type: 'text' } },
-    tip: { control: { type: 'text' } },
-    errorMessage: { control: { type: 'text' } },
-    width: { control: { type: 'text' } },
+    width: responsivePropsArgTypes.width,
     placeholder: { control: { type: 'text' } },
     isDisabled: { control: { type: 'boolean' } },
     isClearable: { control: { type: 'boolean' } },
-    required: { control: { type: 'boolean' } },
+    required: { control: { type: 'boolean' }, table: categoryHtml },
     readOnly: { control: { type: 'boolean' } },
     isLoading: { control: { type: 'boolean' } },
   },
@@ -78,18 +81,35 @@ export const Overview: Story = {
   ),
 };
 
-export const OverviewSizes: Story = {
-  args: { label: 'Label', options: options, isMulti: true },
+export const Sizes: Story = {
+  args: { options: options, isMulti: true },
   render: args => {
     return (
       <StoryHStack>
         <StoryVStack>
-          <Select {...args} />
-          <Select {...args} componentSize="small" />
+          {INPUT_SIZES.map(size =>
+            size === 'xsmall' ? null : (
+              <Select
+                {...args}
+                key={size}
+                label={labelText(size)}
+                componentSize={size}
+              />
+            ),
+          )}
         </StoryVStack>
         <StoryVStack>
-          <Select {...args} icon={CourtIcon} />
-          <Select {...args} componentSize="small" icon={CourtIcon} />
+          {INPUT_SIZES.map(size =>
+            size === 'xsmall' ? null : (
+              <Select
+                {...args}
+                key={size}
+                label={labelText(size)}
+                icon={CourtIcon}
+                componentSize={size}
+              />
+            ),
+          )}
         </StoryVStack>
       </StoryHStack>
     );

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.stories.tsx
@@ -4,9 +4,11 @@ import { fn } from 'storybook/test';
 import {
   categoryHtml,
   htmlEventArgType,
+  labelText,
   responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../../storybook/helpers';
+import { INPUT_SIZES } from '../../helpers/Input';
 import { StoryVStack } from '../../layout/Stack/utils';
 
 import { NativeSelect, NativeSelectPlaceholder } from '.';
@@ -72,16 +74,21 @@ export const Overview: Story = {
   ),
 };
 
-export const OverviewSizes: Story = {
+export const Sizes: Story = {
   args: {
     label: 'Label',
     children,
   },
   render: args => (
     <StoryVStack>
-      <NativeSelect {...args} componentSize="medium" />
-      <NativeSelect {...args} componentSize="small" />
-      <NativeSelect {...args} componentSize="xsmall" />
+      {INPUT_SIZES.map(size => (
+        <NativeSelect
+          {...args}
+          key={size}
+          label={labelText(size)}
+          componentSize={size}
+        />
+      ))}
     </StoryVStack>
   ),
 };

--- a/packages/dds-components/src/components/Select/Select.stories.tsx
+++ b/packages/dds-components/src/components/Select/Select.stories.tsx
@@ -3,12 +3,15 @@ import { useState } from 'react';
 import { fn } from 'storybook/internal/test';
 
 import {
+  categoryHtml,
   htmlEventArgType,
+  labelText,
   responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
 import { Button } from '../Button';
 import { Drawer, DrawerGroup } from '../Drawer';
+import { INPUT_SIZES } from '../helpers/Input';
 import { CourtIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { Modal, ModalBody } from '../Modal';
@@ -24,7 +27,7 @@ const meta: Meta<typeof Select> = {
     placeholder: { control: 'text' },
     isDisabled: { control: 'boolean' },
     isClearable: { control: 'boolean' },
-    required: { control: 'boolean' },
+    required: { control: 'boolean', table: categoryHtml },
     readOnly: { control: 'boolean' },
     isLoading: { control: 'boolean' },
     icon: { control: false },
@@ -116,20 +119,31 @@ export const Overview: Story = {
   },
 };
 
-export const OverviewSizes: Story = {
+export const Sizes: Story = {
   args: { options: options },
   render: args => {
     return (
       <StoryHStack>
         <StoryVStack>
-          <Select {...args} componentSize="medium" />
-          <Select {...args} componentSize="small" />
-          <Select {...args} componentSize="xsmall" />
+          {INPUT_SIZES.map(size => (
+            <Select
+              {...args}
+              key={size}
+              label={labelText(size)}
+              componentSize={size}
+            />
+          ))}
         </StoryVStack>
         <StoryVStack>
-          <Select {...args} componentSize="medium" icon={CourtIcon} />
-          <Select {...args} componentSize="small" icon={CourtIcon} />
-          <Select {...args} componentSize="xsmall" icon={CourtIcon} />
+          {INPUT_SIZES.map(size => (
+            <Select
+              {...args}
+              key={size}
+              label={labelText(size)}
+              componentSize={size}
+              icon={CourtIcon}
+            />
+          ))}
         </StoryVStack>
       </StoryHStack>
     );

--- a/packages/dds-components/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.stories.tsx
@@ -1,13 +1,11 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
+import { labelText } from '../../storybook/helpers';
+import { BUTTON_SIZES } from '../Button/Button.types';
 import { PlusCircledIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
-import {
-  SplitButton,
-  type SplitButtonPrimaryActionProps,
-  type SplitButtonProps,
-} from '.';
+import { SplitButton } from '.';
 
 export default {
   title: 'dds-components/Components/SplitButton',
@@ -44,21 +42,53 @@ export const Preview: Story = {
   },
 };
 
-export const Overview: Story = {
+export const Purposes: Story = {
   render: args => (
     <StoryHStack>
       <StoryVStack>
-        <SplitButtonVariants args={args} children="Tekst" />
-      </StoryVStack>
-      <StoryVStack>
-        <SplitButtonVariants
-          args={args}
-          children="Tekst"
-          icon={PlusCircledIcon}
+        <SplitButton
+          {...args}
+          primaryAction={{ children: 'Primary' }}
+          secondaryActions={items}
+          purpose="primary"
+        />
+        <SplitButton
+          {...args}
+          primaryAction={{ children: 'Secondary' }}
+          secondaryActions={items}
+          purpose="secondary"
         />
       </StoryVStack>
+    </StoryHStack>
+  ),
+};
+
+export const Sizes: Story = {
+  render: args => (
+    <StoryHStack>
       <StoryVStack>
-        <SplitButtonVariants args={args} children="Tekst" loading />
+        {BUTTON_SIZES.map(size => (
+          <SplitButton
+            {...args}
+            key={size}
+            primaryAction={{ children: labelText(size) }}
+            secondaryActions={items}
+            size={size}
+          />
+        ))}
+      </StoryVStack>
+      <StoryVStack>
+        {BUTTON_SIZES.map(size => (
+          <SplitButton
+            {...args}
+            primaryAction={{
+              children: labelText(size),
+              icon: PlusCircledIcon,
+            }}
+            secondaryActions={items}
+            size={size}
+          />
+        ))}
       </StoryVStack>
     </StoryHStack>
   ),
@@ -70,71 +100,3 @@ export const FullWidth: Story = {
     secondaryActions: items,
   },
 };
-
-interface SplitButtonVariantsProps {
-  args: SplitButtonProps;
-  children?: SplitButtonPrimaryActionProps['children'];
-  icon?: SplitButtonPrimaryActionProps['icon'];
-  loading?: SplitButtonPrimaryActionProps['loading'];
-}
-
-const SplitButtonVariants = ({ args, ...rest }: SplitButtonVariantsProps) => (
-  <>
-    <SplitButton
-      {...args}
-      primaryAction={{ ...rest }}
-      secondaryActions={items}
-      size="large"
-      purpose="primary"
-    />
-    <SplitButton
-      {...args}
-      primaryAction={{ ...rest }}
-      secondaryActions={items}
-      size="medium"
-      purpose="primary"
-    />
-    <SplitButton
-      {...args}
-      primaryAction={{ ...rest }}
-      secondaryActions={items}
-      size="small"
-      purpose="primary"
-    />
-    <SplitButton
-      {...args}
-      primaryAction={{ ...rest }}
-      secondaryActions={items}
-      size="xsmall"
-      purpose="primary"
-    />
-    <SplitButton
-      {...args}
-      primaryAction={{ ...rest }}
-      secondaryActions={items}
-      size="large"
-      purpose="secondary"
-    />
-    <SplitButton
-      {...args}
-      primaryAction={{ ...rest }}
-      secondaryActions={items}
-      size="medium"
-      purpose="secondary"
-    />
-    <SplitButton
-      {...args}
-      primaryAction={{ ...rest }}
-      secondaryActions={items}
-      size="small"
-      purpose="secondary"
-    />
-    <SplitButton
-      {...args}
-      primaryAction={{ ...rest }}
-      secondaryActions={items}
-      size="xsmall"
-      purpose="secondary"
-    />
-  </>
-);

--- a/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
@@ -3,13 +3,14 @@ import { useState } from 'react';
 
 import {
   commonArgTypes,
+  labelText,
   responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
 import { NotificationsIcon } from '../Icon/icons';
 import { StoryVStack } from '../layout/Stack/utils';
-import { TextArea } from '../TextArea';
-import { Paragraph } from '../Typography';
+import { Paragraph, Typography } from '../Typography';
+import { TABS_SIZES } from './Tabs';
 
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '.';
 
@@ -25,19 +26,30 @@ export default {
 
 type Story = StoryObj<typeof Tabs>;
 
+const tabList = (icon?: boolean) => {
+  const tabIcon = icon ? NotificationsIcon : undefined;
+  return (
+    <TabList>
+      <Tab icon={tabIcon}>Fane 1</Tab>
+      <Tab icon={tabIcon}>Fane 2</Tab>
+      <Tab icon={tabIcon}>Fane 3</Tab>
+    </TabList>
+  );
+};
+
+const tabPanels = (
+  <TabPanels>
+    <TabPanel>Innhold 1</TabPanel>
+    <TabPanel>Innhold 2</TabPanel>
+    <TabPanel>Innhold 3</TabPanel>
+  </TabPanels>
+);
+
 export const Preview: Story = {
   render: args => (
     <Tabs {...args}>
-      <TabList>
-        <Tab>Tab 1</Tab>
-        <Tab>Tab 2</Tab>
-        <Tab>Tab 3</Tab>
-      </TabList>
-      <TabPanels>
-        <TabPanel>Innhold 1</TabPanel>
-        <TabPanel>Innhold 2</TabPanel>
-        <TabPanel>Innhold 3</TabPanel>
-      </TabPanels>
+      {tabList()}
+      {tabPanels}
     </Tabs>
   ),
 };
@@ -45,19 +57,9 @@ export const Preview: Story = {
 export const Direction: Story = {
   render: args => (
     <StoryVStack>
-      <Tabs {...args}>
-        <TabList>
-          <Tab icon={NotificationsIcon}>Restriksjoner</Tab>
-          <Tab icon={NotificationsIcon}>Aktører</Tab>
-          <Tab icon={NotificationsIcon}>Logg</Tab>
-        </TabList>
-      </Tabs>
+      <Tabs {...args}>{tabList(true)}</Tabs>
       <Tabs {...args} tabContentDirection="column">
-        <TabList>
-          <Tab icon={NotificationsIcon}>Restriksjoner</Tab>
-          <Tab icon={NotificationsIcon}>Aktører</Tab>
-          <Tab icon={NotificationsIcon}>Logg</Tab>
-        </TabList>
+        {tabList(true)}
       </Tabs>
     </StoryVStack>
   ),
@@ -65,49 +67,23 @@ export const Direction: Story = {
 
 export const Sizes: Story = {
   render: args => (
-    <StoryVStack>
-      <Tabs {...args}>
-        <TabList>
-          <Tab>Restriksjoner</Tab>
-          <Tab>Aktører</Tab>
-          <Tab>Logg</Tab>
-        </TabList>
-      </Tabs>
-      <Tabs {...args}>
-        <TabList>
-          <Tab icon={NotificationsIcon}>Restriksjoner</Tab>
-          <Tab icon={NotificationsIcon}>Aktører</Tab>
-          <Tab icon={NotificationsIcon}>Logg</Tab>
-        </TabList>
-      </Tabs>
-      <Tabs {...args} tabContentDirection="column">
-        <TabList>
-          <Tab icon={NotificationsIcon}>Restriksjoner</Tab>
-          <Tab icon={NotificationsIcon}>Aktører</Tab>
-          <Tab icon={NotificationsIcon}>Logg</Tab>
-        </TabList>
-      </Tabs>
-      <Tabs {...args} size="medium">
-        <TabList>
-          <Tab>Restriksjoner</Tab>
-          <Tab>Aktører</Tab>
-          <Tab>Logg</Tab>
-        </TabList>
-      </Tabs>
-      <Tabs {...args} size="medium">
-        <TabList>
-          <Tab icon={NotificationsIcon}>Restriksjoner</Tab>
-          <Tab icon={NotificationsIcon}>Aktører</Tab>
-          <Tab icon={NotificationsIcon}>Logg</Tab>
-        </TabList>
-      </Tabs>
-      <Tabs {...args} size="medium" tabContentDirection="column">
-        <TabList>
-          <Tab icon={NotificationsIcon}>Restriksjoner</Tab>
-          <Tab icon={NotificationsIcon}>Aktører</Tab>
-          <Tab icon={NotificationsIcon}>Logg</Tab>
-        </TabList>
-      </Tabs>
+    <StoryVStack gap="x2.5">
+      {TABS_SIZES.map(size => (
+        <StoryVStack gap="x0.5" key={size}>
+          <Typography as="span" typographyType="labelMedium">
+            {labelText(size)}
+          </Typography>
+          <Tabs {...args} size={size}>
+            {tabList()}
+          </Tabs>
+          <Tabs {...args} size={size}>
+            {tabList(true)}
+          </Tabs>
+          <Tabs {...args} size={size} tabContentDirection="column">
+            {tabList(true)}
+          </Tabs>
+        </StoryVStack>
+      ))}
     </StoryVStack>
   ),
 };
@@ -115,16 +91,8 @@ export const Sizes: Story = {
 export const WithIcon: Story = {
   render: args => (
     <Tabs {...args}>
-      <TabList>
-        <Tab icon={NotificationsIcon}>Tab 1</Tab>
-        <Tab icon={NotificationsIcon}>Tab 2</Tab>
-        <Tab icon={NotificationsIcon}>Tab 3</Tab>
-      </TabList>
-      <TabPanels>
-        <TabPanel>Innhold 1</TabPanel>
-        <TabPanel>Innhold 2</TabPanel>
-        <TabPanel>Innhold 3</TabPanel>
-      </TabPanels>
+      {tabList(true)}
+      {tabPanels}
     </Tabs>
   ),
 };
@@ -134,19 +102,8 @@ export const ActiveTab: Story = {
     const [activeTab, setActiveTab] = useState(1);
     return (
       <Tabs {...args} activeTab={activeTab} onChange={tab => setActiveTab(tab)}>
-        <TabList>
-          <Tab>Tab 1</Tab>
-          <Tab>Tab 2</Tab>
-          <Tab>Tab 3</Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>
-            <span>Innhold 1</span>
-            <TextArea label="test" />
-          </TabPanel>
-          <TabPanel>Innhold 2</TabPanel>
-          <TabPanel>Innhold 3</TabPanel>
-        </TabPanels>
+        {tabList()}
+        {tabPanels}
       </Tabs>
     );
   },
@@ -212,16 +169,8 @@ export const WithAddTabButton: Story = {
 export const WithWidth: Story = {
   render: args => (
     <Tabs {...args} width="500px">
-      <TabList>
-        <Tab>Tab 1</Tab>
-        <Tab>Tab 2</Tab>
-        <Tab>Tab 3</Tab>
-      </TabList>
-      <TabPanels>
-        <TabPanel>Innhold 1</TabPanel>
-        <TabPanel>Innhold 2</TabPanel>
-        <TabPanel>Innhold 3</TabPanel>
-      </TabPanels>
+      {tabList()}
+      {tabPanels}
     </Tabs>
   ),
 };
@@ -239,11 +188,7 @@ export const MaxContentWidth: Story = {
           <Tab width="max-content">Restriksjoner</Tab>
           <Tab width="max-content">Vedlegg</Tab>
         </TabList>
-        <TabPanels>
-          <TabPanel>Innhold 1</TabPanel>
-          <TabPanel>Innhold 2</TabPanel>
-          <TabPanel>Innhold 3</TabPanel>
-        </TabPanels>
+        {tabPanels}
       </Tabs>
     </>
   ),
@@ -262,33 +207,8 @@ export const ResponsiveWidth: Story = {
   },
   render: args => (
     <Tabs {...args}>
-      <TabList>
-        <Tab>Tab 1</Tab>
-        <Tab>Tab 2</Tab>
-        <Tab>Tab 3</Tab>
-      </TabList>
-      <TabPanels>
-        <TabPanel>Innhold 1</TabPanel>
-        <TabPanel>Innhold 2</TabPanel>
-        <TabPanel>Innhold 3</TabPanel>
-      </TabPanels>
-    </Tabs>
-  ),
-};
-
-export const TabLongNames: Story = {
-  render: args => (
-    <Tabs {...args}>
-      <TabList>
-        <Tab>Parter</Tab>
-        <Tab>Restriksjoner</Tab>
-        <Tab>Vedlegg</Tab>
-      </TabList>
-      <TabPanels>
-        <TabPanel>Innhold 1</TabPanel>
-        <TabPanel>Innhold 2</TabPanel>
-        <TabPanel>Innhold 3</TabPanel>
-      </TabPanels>
+      {tabList()}
+      {tabPanels}
     </Tabs>
   ),
 };
@@ -297,16 +217,16 @@ export const ManyTabs: Story = {
   render: args => (
     <Tabs {...args} htmlProps={{ style: { width: '400px' } }}>
       <TabList>
-        <Tab>Tab1</Tab>
-        <Tab>Restriksjoner</Tab>
-        <Tab>Tab3</Tab>
-        <Tab>Aktører</Tab>
-        <Tab>Tab5</Tab>
-        <Tab>Restriksjoner</Tab>
-        <Tab>Tab7</Tab>
-        <Tab>Tab8</Tab>
-        <Tab>Tab9</Tab>
-        <Tab>Tab10</Tab>
+        <Tab>Fane 1</Tab>
+        <Tab>Fane 2</Tab>
+        <Tab>Fane 3</Tab>
+        <Tab>Fane 4</Tab>
+        <Tab>Fane 5</Tab>
+        <Tab>Fane 6</Tab>
+        <Tab>Fane 7</Tab>
+        <Tab>Fane 8</Tab>
+        <Tab>Fane 9</Tab>
+        <Tab>Fane 10</Tab>
       </TabList>
       <TabPanels>
         <TabPanel>Innhold 1</TabPanel>

--- a/packages/dds-components/src/components/Tabs/Tabs.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.tsx
@@ -6,13 +6,14 @@ import styles from './Tabs.module.css';
 import {
   type BaseComponentPropsWithChildren,
   type Direction,
-  type Size,
+  createSizes,
   getBaseHTMLProps,
 } from '../../types';
 import { cn } from '../../utils';
 import { Box, type ResponsiveProps } from '../layout';
 
-export type TabSize = Extract<Size, 'small' | 'medium'>;
+export const TABS_SIZES = createSizes('small', 'medium');
+export type TabSize = (typeof TABS_SIZES)[number];
 
 export type TabsProps = BaseComponentPropsWithChildren<
   HTMLDivElement,

--- a/packages/dds-components/src/components/Tabs/index.tsx
+++ b/packages/dds-components/src/components/Tabs/index.tsx
@@ -1,5 +1,5 @@
 export * from './AddTabButton';
-export * from './Tabs';
+export { type TabSize, Tabs, type TabsProps } from './Tabs';
 export * from './Tab';
 export * from './TabList';
 export * from './TabPanel';

--- a/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
@@ -4,8 +4,11 @@ import { fn } from 'storybook/test';
 import {
   categoryHtml,
   htmlEventArgType,
+  labelText,
+  responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
+import { INPUT_SIZES } from '../helpers/Input';
 import { MailIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { LocalMessage } from '../LocalMessage';
@@ -16,7 +19,7 @@ export default {
   title: 'dds-components/Components/TextInput',
   component: TextInput,
   argTypes: {
-    width: { control: { type: 'text' } },
+    width: responsivePropsArgTypes.width,
     maxLength: { control: 'number', table: categoryHtml },
     required: { control: 'boolean', table: categoryHtml },
     disabled: { control: 'boolean', table: categoryHtml },
@@ -67,18 +70,27 @@ export const Overview: Story = {
 };
 
 export const Sizes: Story = {
-  args: { label: 'Label' },
   render: args => (
     <StoryHStack>
       <StoryVStack>
-        <TextInput {...args} />
-        <TextInput {...args} componentSize="small" />
-        <TextInput {...args} componentSize="xsmall" />
+        {INPUT_SIZES.map(size => (
+          <TextInput
+            {...args}
+            key={size}
+            label={labelText(size)}
+            componentSize={size}
+          />
+        ))}
       </StoryVStack>
       <StoryVStack>
-        <TextInput {...args} icon={MailIcon} />
-        <TextInput {...args} componentSize="small" icon={MailIcon} />
-        <TextInput {...args} componentSize="xsmall" icon={MailIcon} />
+        {INPUT_SIZES.map(size => (
+          <TextInput
+            {...args}
+            label={labelText(size)}
+            componentSize={size}
+            icon={MailIcon}
+          />
+        ))}
       </StoryVStack>
     </StoryHStack>
   ),

--- a/packages/dds-components/src/components/Toggle/Toggle.stories.tsx
+++ b/packages/dds-components/src/components/Toggle/Toggle.stories.tsx
@@ -7,8 +7,10 @@ import {
   commonArgTypes,
   htmlArgType,
   htmlEventArgType,
+  labelText,
 } from '../../storybook/helpers';
 import { Button } from '../Button';
+import { TOGGLE_SIZES } from './Toggle';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 import { Toggle } from '.';
@@ -60,8 +62,11 @@ export const Overview: Story = {
 export const Sizes: Story = {
   render: args => (
     <StoryVStack>
-      <Toggle {...args} size="medium" children="Medium" />
-      <Toggle {...args} size="large" children="Large" />
+      {TOGGLE_SIZES.map(size => (
+        <Toggle {...args} key={size} size={size}>
+          {labelText(size)}
+        </Toggle>
+      ))}
     </StoryVStack>
   ),
 };

--- a/packages/dds-components/src/components/Toggle/Toggle.tsx
+++ b/packages/dds-components/src/components/Toggle/Toggle.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from '../../i18n';
 import { commonTexts } from '../../i18n/commonTexts';
 import {
   type BaseComponentProps,
-  type Size,
+  createSizes,
   getBaseHTMLProps,
 } from '../../types';
 import { cn, readOnlyClickHandler, readOnlyKeyDownHandler } from '../../utils';
@@ -17,7 +17,8 @@ import { CheckIcon, LockIcon } from '../Icon/icons';
 import { Spinner } from '../Spinner';
 import { VisuallyHidden } from '../VisuallyHidden';
 
-export type ToggleSize = Extract<Size, 'medium' | 'large'>;
+export const TOGGLE_SIZES = createSizes('medium', 'large');
+export type ToggleSize = (typeof TOGGLE_SIZES)[number];
 
 export type ToggleProps = BaseComponentProps<
   HTMLElement,

--- a/packages/dds-components/src/components/Toggle/index.ts
+++ b/packages/dds-components/src/components/Toggle/index.ts
@@ -1,1 +1,1 @@
-export * from './Toggle';
+export { Toggle, type ToggleProps, type ToggleSize } from './Toggle';

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
@@ -2,13 +2,17 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 
+import { TOGGLE_BAR_SIZES } from './ToggleBar.types';
 import {
   commonArgTypes,
+  labelText,
   responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
 import { PlusCircledIcon } from '../Icon/icons';
+import { VStack } from '../layout';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
+import { Typography } from '../Typography';
 
 import { ToggleBar, ToggleRadio } from '.';
 
@@ -25,183 +29,62 @@ export default {
 
 type Story = StoryObj<typeof ToggleBar>;
 
-export const Preview: Story = {
-  render: args => {
-    const [value, setValue] = useState<string | undefined>();
-    return (
-      <>
-        <ToggleBar
-          {...args}
-          name="test"
-          value={value}
-          onChange={(_event, value) => {
-            setValue(value);
-          }}
-        >
-          <ToggleRadio value="alt1" label="Alt" />
-          <ToggleRadio value="alt2" label="Alt" />
-          <ToggleRadio value="alt3" label="Alt" />
-        </ToggleBar>
-      </>
+const toggleRadios = (label?: boolean, icon?: boolean) => {
+  const radios = [];
+  for (let i = 1; i <= 3; i++) {
+    radios.push(
+      <ToggleRadio
+        key={i}
+        icon={icon ? PlusCircledIcon : undefined}
+        label={label ? `Alt${i}` : undefined}
+        value={`Alt${i}`}
+      />,
     );
-  },
+  }
+  return <>{radios}</>;
 };
 
-export const Overview: Story = {
+export const Preview: Story = {
+  render: args => (
+    <ToggleBar {...args} name="test">
+      <ToggleRadio label="Alt1" value="Alt1" />
+      <ToggleRadio label="Alt2" value="Alt2" />
+      <ToggleRadio label="Alt3" value="Alt3" />
+    </ToggleBar>
+  ),
+};
+
+export const Sizes: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>();
+    let name = 0;
     return (
-      <StoryHStack>
-        <StoryVStack>
-          <ToggleBar
-            {...args}
-            name="test"
-            size="xsmall"
-            value={value}
-            onChange={(_event, value) => {
-              setValue(value);
-            }}
-          >
-            <ToggleRadio label="Alt1" value="Alt1" />
-            <ToggleRadio label="Alt2" value="Alt2" />
-            <ToggleRadio label="Alt3" value="Alt3" />
-          </ToggleBar>
-
-          <ToggleBar
-            {...args}
-            name="test2"
-            size="small"
-            value={value}
-            onChange={(_event, value) => {
-              setValue(value);
-            }}
-          >
-            <ToggleRadio label="Alt1" value="Alt1" />
-            <ToggleRadio label="Alt2" value="Alt2" />
-            <ToggleRadio label="Alt3" value="Alt3" />
-          </ToggleBar>
-          <ToggleBar
-            {...args}
-            name="test4"
-            size="medium"
-            value={value}
-            onChange={(_event, value) => {
-              setValue(value);
-            }}
-          >
-            <ToggleRadio label="Alt1" value="Alt1" />
-            <ToggleRadio label="Alt2" value="Alt2" />
-            <ToggleRadio label="Alt3" value="Alt3" />
-          </ToggleBar>
-          <ToggleBar
-            {...args}
-            name="test6"
-            size="large"
-            value={value}
-            onChange={(_event, value) => {
-              setValue(value);
-            }}
-          >
-            <ToggleRadio label="Alt1" value="Alt1" />
-            <ToggleRadio label="Alt2" value="Alt2" />
-            <ToggleRadio label="Alt3" value="Alt3" />
-          </ToggleBar>
-        </StoryVStack>
-        <StoryVStack>
-          <ToggleBar
-            {...args}
-            name="test1"
-            size="xsmall"
-            value={value}
-            onChange={(_event, value) => {
-              setValue(value);
-            }}
-          >
-            <ToggleRadio icon={PlusCircledIcon} label="Alt1" value="Alt1" />
-            <ToggleRadio icon={PlusCircledIcon} label="Alt2" value="Alt2" />
-            <ToggleRadio icon={PlusCircledIcon} label="Alt3" value="Alt3" />
-          </ToggleBar>
-          <ToggleBar
-            {...args}
-            name="test3"
-            size="small"
-            value={value}
-            onChange={(_event, value) => {
-              setValue(value);
-            }}
-          >
-            <ToggleRadio icon={PlusCircledIcon} label="Alt1" value="Alt1" />
-            <ToggleRadio icon={PlusCircledIcon} label="Alt2" value="Alt2" />
-            <ToggleRadio icon={PlusCircledIcon} label="Alt3" value="Alt3" />
-          </ToggleBar>
-          <ToggleBar
-            {...args}
-            name="test5"
-            size="medium"
-            value={value}
-            onChange={(_event, value) => {
-              setValue(value);
-            }}
-          >
-            <ToggleRadio icon={PlusCircledIcon} label="Alt1" value="Alt1" />
-            <ToggleRadio icon={PlusCircledIcon} label="Alt2" value="Alt2" />
-            <ToggleRadio icon={PlusCircledIcon} label="Alt3" value="Alt3" />
-          </ToggleBar>
-
-          <ToggleBar
-            {...args}
-            name="test7"
-            size="large"
-            value={value}
-            onChange={(_event, value) => {
-              setValue(value);
-            }}
-          >
-            <ToggleRadio icon={PlusCircledIcon} label="Alt1" value="Alt1" />
-            <ToggleRadio icon={PlusCircledIcon} label="Alt2" value="Alt2" />
-            <ToggleRadio icon={PlusCircledIcon} label="Alt3" value="Alt3" />
-          </ToggleBar>
-        </StoryVStack>
-        <StoryVStack>
-          <ToggleBar
-            {...args}
-            name="icon_test"
-            size="xsmall"
-            value={value}
-            onChange={(_event, value) => {
-              setValue(value);
-            }}
-          >
-            <ToggleRadio icon={PlusCircledIcon} value="alt1" />
-            <ToggleRadio icon={PlusCircledIcon} value="alt2" />
-            <ToggleRadio icon={PlusCircledIcon} value="alt3" />
-          </ToggleBar>
-
-          <ToggleBar {...args} name="icon_test1" size="small">
-            <ToggleRadio icon={PlusCircledIcon} value="alt1" />
-            <ToggleRadio icon={PlusCircledIcon} value="alt2" />
-            <ToggleRadio icon={PlusCircledIcon} value="alt3" />
-          </ToggleBar>
-          <ToggleBar {...args} name="icon_test2" size="medium">
-            <ToggleRadio icon={PlusCircledIcon} value="alt1" />
-            <ToggleRadio icon={PlusCircledIcon} value="alt2" />
-            <ToggleRadio icon={PlusCircledIcon} value="alt3" />
-          </ToggleBar>
-
-          <ToggleBar {...args} name="icon_test3" size="large">
-            <ToggleRadio icon={PlusCircledIcon} value="alt1" />
-            <ToggleRadio icon={PlusCircledIcon} value="alt2" />
-            <ToggleRadio icon={PlusCircledIcon} value="alt3" />
-          </ToggleBar>
-        </StoryVStack>
+      <StoryHStack flexWrap="wrap">
+        {TOGGLE_BAR_SIZES.map(size => (
+          <VStack key={size} gap="x0.125">
+            <Typography as="span" typographyType="labelMedium">
+              {labelText(size)}
+            </Typography>
+            <StoryVStack>
+              <ToggleBar {...args} name={`test${name++}`} size={size}>
+                {toggleRadios(true)}
+              </ToggleBar>
+              <ToggleBar {...args} name={`test${name++}`} size={size}>
+                {toggleRadios(true, true)}
+              </ToggleBar>
+              <ToggleBar {...args} name={`test${name++}`} size={size}>
+                {toggleRadios(false, true)}
+              </ToggleBar>
+            </StoryVStack>
+          </VStack>
+        ))}
       </StoryHStack>
     );
   },
 };
 
-export const WithDefaultValue: Story = {
+export const Controlled: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>('alt1');
+    const [value, setValue] = useState<string | undefined>('Alt2');
     return (
       <>
         <ToggleBar
@@ -212,9 +95,7 @@ export const WithDefaultValue: Story = {
             setValue(value);
           }}
         >
-          <ToggleRadio value="alt1" label="Alt" />
-          <ToggleRadio value="alt2" label="Alt" />
-          <ToggleRadio value="alt3" label="Alt" />
+          {toggleRadios(true)}
         </ToggleBar>
       </>
     );
@@ -223,17 +104,9 @@ export const WithDefaultValue: Story = {
 
 export const WithLongWords: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>();
     return (
       <>
-        <ToggleBar
-          {...args}
-          name="test"
-          value={value}
-          onChange={(_event, value) => {
-            setValue(value);
-          }}
-        >
+        <ToggleBar {...args} name="test">
           <ToggleRadio value="alt1" label="Parter" />
           <ToggleRadio value="alt2" label="Slutning" />
           <ToggleRadio value="alt3" label="Vedlegg" />
@@ -245,20 +118,9 @@ export const WithLongWords: Story = {
 
 export const WithWidth: Story = {
   render: args => {
-    const [value, setValue] = useState<string | undefined>();
     return (
-      <ToggleBar
-        {...args}
-        name="test"
-        value={value}
-        onChange={(_event, value) => {
-          setValue(value);
-        }}
-        width="320px"
-      >
-        <ToggleRadio value="alt1" label="Alt" />
-        <ToggleRadio value="alt2" label="Alt" />
-        <ToggleRadio value="alt3" label="Alt" />
+      <ToggleBar {...args} name="test" width="320px">
+        {toggleRadios(true)}
       </ToggleBar>
     );
   },
@@ -276,19 +138,9 @@ export const ResponsiveWidth: Story = {
     },
   },
   render: args => {
-    const [value, setValue] = useState<string | undefined>();
     return (
-      <ToggleBar
-        {...args}
-        name="test"
-        value={value}
-        onChange={(_event, value) => {
-          setValue(value);
-        }}
-      >
-        <ToggleRadio value="alt1" label="Alt" />
-        <ToggleRadio value="alt2" label="Alt" />
-        <ToggleRadio value="alt3" label="Alt" />
+      <ToggleBar {...args} name="test">
+        {toggleRadios(true)}
       </ToggleBar>
     );
   },

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.types.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.types.tsx
@@ -1,13 +1,17 @@
 import { type ChangeEvent, type InputHTMLAttributes } from 'react';
 
-import { type BaseComponentPropsWithChildren, type Size } from '../../types';
+import { type BaseComponentPropsWithChildren, createSizes } from '../../types';
 import { type ResponsiveProps } from '../layout';
 
 export type ToggleBarValue = string | number | null | undefined;
-export type ToggleBarSize = Extract<
-  Size,
-  'xsmall' | 'small' | 'medium' | 'large'
->;
+
+export const TOGGLE_BAR_SIZES = createSizes(
+  'xsmall',
+  'small',
+  'medium',
+  'large',
+);
+export type ToggleBarSize = (typeof TOGGLE_BAR_SIZES)[number];
 
 export type ToggleBarProps<T extends string | number> =
   BaseComponentPropsWithChildren<

--- a/packages/dds-components/src/components/ToggleBar/index.ts
+++ b/packages/dds-components/src/components/ToggleBar/index.ts
@@ -1,3 +1,7 @@
 export * from './ToggleBar';
-export * from './ToggleBar.types';
+export type {
+  ToggleBarProps,
+  ToggleBarSize,
+  ToggleBarValue,
+} from './ToggleBar.types';
 export * from './ToggleRadio';

--- a/packages/dds-components/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/packages/dds-components/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -1,11 +1,13 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
+import { TOGGLE_BUTTON_SIZES } from './ToggleButton.types';
 import {
   categoryHtml,
   commonArgTypes,
   htmlArgType,
   htmlEventArgType,
+  labelText,
 } from '../../storybook/helpers';
 import { NotificationsIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
@@ -44,17 +46,25 @@ export const Sizes: Story = {
   render: args => (
     <StoryHStack>
       <StoryVStack>
-        <ToggleButton {...args} label="Small" />
-        <ToggleButton {...args} label="Xsmall" size="xsmall" />
+        {TOGGLE_BUTTON_SIZES.map(size => (
+          <ToggleButton
+            {...args}
+            key={size}
+            size={size}
+            label={labelText(size)}
+          />
+        ))}
       </StoryVStack>
       <StoryVStack>
-        <ToggleButton {...args} label="Small" icon={NotificationsIcon} />
-        <ToggleButton
-          {...args}
-          label="Xsmall"
-          icon={NotificationsIcon}
-          size="xsmall"
-        />
+        {TOGGLE_BUTTON_SIZES.map(size => (
+          <ToggleButton
+            {...args}
+            key={size}
+            size={size}
+            label={labelText(size)}
+            icon={NotificationsIcon}
+          />
+        ))}
       </StoryVStack>
     </StoryHStack>
   ),

--- a/packages/dds-components/src/components/ToggleButton/ToggleButton.types.tsx
+++ b/packages/dds-components/src/components/ToggleButton/ToggleButton.types.tsx
@@ -1,9 +1,10 @@
 import { type InputHTMLAttributes } from 'react';
 
-import { type BaseComponentProps } from '../../types';
+import { type BaseComponentProps, createSizes } from '../../types';
 import { type SvgIcon } from '../Icon/utils';
 import { type CheckboxPickedHTMLAttributes } from '../SelectionControl/Checkbox';
 
+export const TOGGLE_BUTTON_SIZES = createSizes('xsmall', 'small');
 export type ToggleButtonProps = BaseComponentProps<
   HTMLInputElement,
   {
@@ -14,7 +15,7 @@ export type ToggleButtonProps = BaseComponentProps<
     /**Størrelse.
      * @default 'small'
      */
-    size?: 'small' | 'xsmall';
+    size?: (typeof TOGGLE_BUTTON_SIZES)[number];
   } & CheckboxPickedHTMLAttributes,
   Omit<
     InputHTMLAttributes<HTMLInputElement>,

--- a/packages/dds-components/src/components/ToggleButton/index.ts
+++ b/packages/dds-components/src/components/ToggleButton/index.ts
@@ -1,3 +1,3 @@
 export * from './ToggleButton';
 export * from './ToggleButtonGroup';
-export * from './ToggleButton.types';
+export type { ToggleButtonProps } from './ToggleButton.types';

--- a/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
@@ -19,7 +19,7 @@ export const Preview: Story = {
   args: { children: 'Heading', level: 1 },
 };
 
-export const Overview: Story = {
+export const LevelDefaults: Story = {
   render: args => (
     <StoryVStack>
       <Heading {...args} level={1}>
@@ -44,7 +44,7 @@ export const Overview: Story = {
   ),
 };
 
-export const OverviewStyles: Story = {
+export const TypographyStyles: Story = {
   render: args => (
     <StoryVStack>
       <Heading {...args} level={1} typographyType="headingXxlarge">

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
@@ -13,10 +13,12 @@ import { fn } from 'storybook/test';
 import { LanguageProvider } from '../../../i18n';
 import {
   htmlEventArgType,
+  labelText,
   responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../../storybook/helpers';
 import { Button } from '../../Button';
+import { INPUT_SIZES } from '../../helpers/Input';
 import { StoryHStack, StoryVStack } from '../../layout/Stack/utils';
 import { Modal } from '../../Modal';
 import { StoryThemeProvider } from '../../ThemeProvider/utils/StoryThemeProvider';
@@ -139,12 +141,17 @@ export const Error: Story = {
   args: { label: 'Dato', errorMessage: 'Her er noe veldig galt! 😨' },
 };
 
-export const OverviewSizes: Story = {
+export const Sizes: Story = {
   render: args => (
     <StoryVStack>
-      <DatePicker {...args} componentSize="medium" label="Medium" />
-      <DatePicker {...args} componentSize="small" label="Small" />
-      <DatePicker {...args} componentSize="xsmall" label="Tiny" />
+      {INPUT_SIZES.map(size => (
+        <DatePicker
+          {...args}
+          key={size}
+          componentSize={size}
+          label={labelText(size)}
+        />
+      ))}
     </StoryVStack>
   ),
 };

--- a/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.stories.tsx
+++ b/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.stories.tsx
@@ -5,9 +5,11 @@ import { fn } from 'storybook/test';
 
 import {
   htmlEventArgType,
+  labelText,
   responsivePropsArgTypes,
 } from '../../../storybook/helpers';
 import { Button } from '../../Button';
+import { INPUT_SIZES } from '../../helpers/Input';
 import { StoryHStack, StoryVStack } from '../../layout/Stack/utils';
 
 import { TimePicker } from '.';
@@ -84,12 +86,17 @@ export const ReadOnly: Story = {
   args: { label: 'Tidspunkt', isReadOnly: true },
 };
 
-export const OverviewSizes: Story = {
+export const Sizes: Story = {
   render: args => (
     <StoryVStack>
-      <TimePicker {...args} componentSize="medium" label="Medium" />
-      <TimePicker {...args} componentSize="small" label="Small" />
-      <TimePicker {...args} componentSize="xsmall" label="Xsmall" />
+      {INPUT_SIZES.map(size => (
+        <TimePicker
+          {...args}
+          key={size}
+          componentSize={size}
+          label={labelText(size)}
+        />
+      ))}
     </StoryVStack>
   ),
 };

--- a/packages/dds-components/src/components/helpers/Input/Input.types.tsx
+++ b/packages/dds-components/src/components/helpers/Input/Input.types.tsx
@@ -1,6 +1,6 @@
 import { type ComponentPropsWithRef } from 'react';
 
-import { type Size } from '../../../types';
+import { createSizes } from '../../../types';
 import { type ResponsiveProps } from '../../layout/common/Responsive.types';
 import { type StaticTypographyType } from '../../Typography';
 
@@ -15,7 +15,8 @@ export interface CommonInputProps {
   errorMessage?: string;
 }
 
-export type InputSize = Extract<Size, 'medium' | 'small' | 'xsmall'>;
+export const INPUT_SIZES = createSizes('xsmall', 'small', 'medium');
+export type InputSize = (typeof INPUT_SIZES)[number];
 
 export type InputProps = CommonInputProps & {
   /**Størrelse på inputfeltet.

--- a/packages/dds-components/src/storybook/helpers.tsx
+++ b/packages/dds-components/src/storybook/helpers.tsx
@@ -11,6 +11,8 @@ import { getBreakpointFromScreenWidth } from '../components/layout/common/utils'
 import { Paragraph } from '../components/Typography';
 import { useWindowResize } from '../hooks';
 
+export const labelText = (t: string) => t.charAt(0).toUpperCase() + t.slice(1);
+
 export interface ArgType {
   control?: Control;
   table?: { category: string };

--- a/packages/dds-components/src/types/Size.tsx
+++ b/packages/dds-components/src/types/Size.tsx
@@ -1,7 +1,15 @@
-export type Size =
-  | 'xxlarge'
-  | 'xlarge'
-  | 'large'
-  | 'medium'
-  | 'small'
-  | 'xsmall';
+export const SIZES = [
+  'xsmall',
+  'small',
+  'medium',
+  'large',
+  'xlarge',
+  'xxlarge',
+  'inherit',
+] as const;
+
+export type Size = (typeof SIZES)[number];
+
+export function createSizes<T extends Array<Size>>(...sizes: T): T {
+  return sizes;
+}

--- a/packages/dds-components/src/types/index.ts
+++ b/packages/dds-components/src/types/index.ts
@@ -1,5 +1,5 @@
 export * from './Direction';
 export * from './BaseComponentProps';
-export * from './Size';
+export { type Size, createSizes } from './Size';
 export * from './Surface';
 export * from './utils';


### PR DESCRIPTION
## Beskrivelse


Inkluderer navn på mulige størrelser for alle relevante komponenter i deres størrelse-stories; de blir generert baset på array utledet av typen på størrelse prop. Baserer `type Size` på array `SIZES` og lager en hjelpefunksjon `createSizes()` for å få det til. På denne måten er stories selvforklarende og kan sømløst brukes i integrasjon i docs, i tillegg til mindre vedlikehold av stories grunnet genereringen. Standardiserer navn på slike stories til "Sizes" - kort og konsist.

Tar litt opprydding i stories i samme slengen, som kategorisering i noen tabeller o.l.



## Sjekkliste

### Generelt

- [ ] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [ ] I commits
  - [ ] I PR-tittelen
- [ ] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
