### PR TITLE
ELSA1-662 Fikser RadioButtonGroup docs bug

### DIFF
--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
@@ -34,7 +34,7 @@ let counter = 0;
 const name = () => `test${counter++}`;
 
 export const Preview: Story = {
-  args: { label: 'Label', children },
+  args: { label: 'Label', children, name: 'test' },
 };
 
 export const Overview: Story = {


### PR DESCRIPTION
## Beskrivelse

Preview story fungerte ikke grunnet manglende `name` prop.


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
