### PR TITLE
ELSA1-676 Storybook: Fjerne info om støtte for HTML-attributter

### DIFF
--- a/packages/dds-components/src/components/BackLink/BackLink.mdx
+++ b/packages/dds-components/src/components/BackLink/BackLink.mdx
@@ -21,8 +21,6 @@ import * as BackLinkStories from './BackLink.stories';
 <Canvas of={BackLinkStories.Preview} />
 <Controls of={BackLinkStories.Preview} />
 
-I tillegg støttes native props `href` og `onClick`.
-
 ## Med `react-router`
 
 Bruk hooks tilgjengelige i `react-router` for å returnere Elsa `<BackLink>` som custom lenke:

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumb.stories.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumb.stories.tsx
@@ -21,13 +21,20 @@ export default {
 
 type Story = StoryObj<typeof Breadcrumb>;
 
-export const BreadcrumbPreview: Story = {
+export const Preview: Story = {
+  args: {
+    children: 'Side',
+    href: '/',
+  },
+};
+
+export const CurrentPage: Story = {
   args: {
     children: 'Side',
   },
 };
 
-export const BreadcrumbOverview: Story = {
+export const Overview: Story = {
   render: args => (
     <StoryVStack>
       <Breadcrumb {...args} href="#">

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -28,12 +28,10 @@ Komponenten kan være responsiv hvis et brekkepunkt er spesifisert.
 
 ### Breadcrumbs
 
-<Canvas of={BreadcrumbsStories.Preview} />
-<Controls of={BreadcrumbsStories.Preview} />
-
 Selve brødsmulestien. Skal ha `<Breadcrumb>` som barn.
 
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLElement>`-interface i `htmlProps`.
+<Canvas of={BreadcrumbsStories.Preview} />
+<Controls of={BreadcrumbsStories.Preview} />
 
 ### Breadcrumb
 
@@ -41,7 +39,8 @@ Brødsmule. Returnerer `<a>` hvis `href`-prop er oppgitt eller `<span>` hvis ikk
 
 **OBS!** Alle `<Breadcrumb>`-komponenter bør være lenker bortsett fra den siste som tilsvarer siden brukeren er inne på.
 
-<Canvas of={BreadcrumbStories.BreadcrumbPreview} />
+<Canvas of={BreadcrumbStories.Preview} />
+<Controls of={BreadcrumbStories.Preview} />
 
 Den støtter alle native HTML-attributter som er en del av `AnchorHTMLAttributes<HTMLAnchorElement>` eller `HTMLAttributes<HTMLSpanElement>` -interface.
 

--- a/packages/dds-components/src/components/Pagination/Pagination.mdx
+++ b/packages/dds-components/src/components/Pagination/Pagination.mdx
@@ -24,8 +24,6 @@ import * as PaginationStories from './Pagination.stories';
 <Canvas of={PaginationStories.Preview} />
 <Controls of={PaginationStories.Preview} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLElement>`-interface i `htmlProps`.
-
 ### Types
 
 <Source

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.mdx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.mdx
@@ -32,8 +32,6 @@ Ytterste container som styrer hvilket steg skal vises via indeks. Har to eller f
 <Canvas of={ProgressTrackerStories.Preview} />
 <Controls of={ProgressTrackerStories.Preview} />
 
-I tillegg støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface i `htmlProps`.
-
 ### ProgressTracker.Item
 
 Et steg.

--- a/packages/dds-components/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/dds-components/src/components/TextArea/TextArea.stories.tsx
@@ -5,6 +5,7 @@ import { TextArea } from './TextArea';
 import {
   categoryHtml,
   htmlEventArgType,
+  responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
@@ -13,7 +14,7 @@ export default {
   title: 'dds-components/Components/TextArea',
   component: TextArea,
   argTypes: {
-    width: { control: 'text' },
+    width: responsivePropsArgTypes.width,
     maxLength: { control: 'number', table: categoryHtml },
     required: { control: 'boolean', table: categoryHtml },
     disabled: { control: 'boolean', table: categoryHtml },


### PR DESCRIPTION

## Beskrivelse

JSDoc blir hentet mer riktig i propstabell i Storybook; kan fjerne overflødig info om støtte for standard attributter under `htmlProps` o.l.


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
