### PR TITLE
ELSA1-678 Fikser feilplassert ikon i `<InlineEditTextArea>`

### DIFF
--- a/.changeset/calm-signs-yell.md
+++ b/.changeset/calm-signs-yell.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der redigeringsikonet var plassert feil i `<InlineEditTextArea>`.

--- a/packages/dds-components/src/components/InlineEdit/InlineEdit.module.css
+++ b/packages/dds-components/src/components/InlineEdit/InlineEdit.module.css
@@ -56,6 +56,15 @@
   z-index: var(--dds-zindex-absolute-element);
 }
 
+/* Sentrerer ikonet i forhold til første linjen med tekst */
+.edit-icon-textarea {
+  position: absolute;
+  top: calc(
+    ((var(--dds-font-lineheight-x1) * 1em - var(--dds-icon-size-small)) / 2) +
+      var(--dds-spacing-x0-25)
+  );
+}
+
 .chevron {
   right: var(--dds-spacing-x0-25);
   pointer-events: none;

--- a/packages/dds-components/src/components/InlineEdit/InlineField.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineField.tsx
@@ -91,7 +91,12 @@ export function InlineField<T extends EditElementTag>(
       <Icon
         iconSize={iconSize}
         icon={icon}
-        className={cn(className, utilStyles['center-absolute-y'])}
+        className={cn(
+          className,
+          elementType === 'textarea'
+            ? styles['edit-icon-textarea']
+            : utilStyles['center-absolute-y'],
+        )}
       />
     );
   }


### PR DESCRIPTION
## Beskrivelse

Ikonet ble ved uhell vertikalt sentrert i alle InlineEdit-komponenter; det er riktig for alle unntatt `<InlineEditTextArea>`, siden der skal ikonet sentreres i forhold til første linja med tekst. Legger inn egen CSS for det.


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
