### PR TITLE
ELSA1-671 Fikser `width` prop i `<Tabs>` som ikke funker

### DIFF
--- a/.changeset/fruity-grapes-greet.md
+++ b/.changeset/fruity-grapes-greet.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `width` prop i `<Tabs>` hadde ingen effekt.

--- a/packages/dds-components/src/components/Tabs/Tabs.module.css
+++ b/packages/dds-components/src/components/Tabs/Tabs.module.css
@@ -1,7 +1,3 @@
-.tabs {
-  width: var(--dds-tabs-width);
-}
-
 .tab-row {
   display: grid;
   overflow-x: auto;

--- a/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
@@ -167,11 +167,15 @@ export const WithAddTabButton: Story = {
 };
 
 export const WithWidth: Story = {
+  args: { width: '500px' },
   render: args => (
-    <Tabs {...args} width="500px">
-      {tabList()}
-      {tabPanels}
-    </Tabs>
+    <>
+      <Paragraph withMargins>Bredde: {args.width?.toString()}</Paragraph>
+      <Tabs {...args}>
+        {tabList()}
+        {tabPanels}
+      </Tabs>
+    </>
   ),
 };
 

--- a/packages/dds-components/src/components/Tabs/Tabs.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.tsx
@@ -2,14 +2,12 @@ import { type HTMLAttributes, useEffect, useId, useRef, useState } from 'react';
 
 import { type AddTabButtonProps } from './AddTabButton';
 import { TabsContext } from './Tabs.context';
-import styles from './Tabs.module.css';
 import {
   type BaseComponentPropsWithChildren,
   type Direction,
   createSizes,
   getBaseHTMLProps,
 } from '../../types';
-import { cn } from '../../utils';
 import { Box, type ResponsiveProps } from '../layout';
 
 export const TABS_SIZES = createSizes('small', 'medium');
@@ -82,12 +80,7 @@ export const Tabs = ({
       }}
     >
       <Box
-        {...getBaseHTMLProps(
-          uniqueId,
-          cn(className, styles.tabs),
-          htmlProps,
-          rest,
-        )}
+        {...getBaseHTMLProps(uniqueId, className, htmlProps, rest)}
         width={width}
       >
         {children}


### PR DESCRIPTION
## Beskrivelse

Wrapper i komponenten ble migrert til `<Box>`, og gamle måten å håndtere bredde på ble ikke fjernet fra CSS. Resulterte i overskriving.
Fjerner gammel kode og utbedrer WithWidth-story.

## Sjekkliste

### Generelt

- [ ] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [ ] I commits
  - [ ] I PR-tittelen
- [ ] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
