### PR TITLE
ELSA1-677 JSDoc for `readOnly` i `NativeSelect`

### DIFF
--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.tsx
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.tsx
@@ -30,10 +30,12 @@ import { Label } from '../../Typography';
 import typographyStyles from '../../Typography/typographyStyles.module.css';
 
 export type NativeSelectProps = {
-  /**Om verdien til `<select>` kan tømmes. */
+  /** Om verdien til `<select>` kan tømmes. */
   clearable?: boolean;
+  /** Implementerer `readOnly` oppførsel etter standard for `<input>` og setter `readOnly` styling. */
+  readOnly?: InputProps['readOnly'];
 } & CommonInputProps &
-  Pick<InputProps, 'componentSize' | 'readOnly'> &
+  Pick<InputProps, 'componentSize'> &
   ComponentPropsWithRef<'select'>;
 
 export const NativeSelect = ({


### PR DESCRIPTION

## Beskrivelse

HTML-attributtet `read-only` er ikke standard for enkelte elementer som `<select>`, men vi implementerer standard oppførsel for slike skjemaelementer; oppdaterer JSDoc slik at den gjenspeiler det, samt viser propen riktig i tabellen i Storybook docs.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
