### PR TITLE
ELSA1-675 Fikser feilplassert bullet i `<List>`

### DIFF
--- a/.changeset/heavy-hairs-accept.md
+++ b/.changeset/heavy-hairs-accept.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser plasseringen på bullet i `<List>`.

--- a/packages/dds-components/src/components/List/List.module.css
+++ b/packages/dds-components/src/components/List/List.module.css
@@ -17,6 +17,7 @@
   padding-left: calc(
     var(--dds-spacing-x2) - (var(--dds-list-ul-li-padding-left))
   );
+  --dds-list-bullet-size: 1em;
 
   li {
     position: relative;
@@ -26,10 +27,13 @@
     &:before {
       content: '';
       display: inline-block;
-      height: 1em;
-      width: 1em;
+      height: var(--dds-list-bullet-size);
+      width: var(--dds-list-bullet-size);
       position: absolute;
-      top: calc((2.5em / 2) - 0.5em);
+      top: calc(
+        (var(--dds-font-lineheight-list) * 1em) / 2 -
+          var(--dds-list-bullet-size) / 2
+      );
       left: 0;
       background: var(--dds-color-text-body);
       mask-size: 100%;

--- a/packages/dds-components/src/components/List/List.stories.tsx
+++ b/packages/dds-components/src/components/List/List.stories.tsx
@@ -47,11 +47,11 @@ export const Overview: Story = {
             <ListItem>Item</ListItem>
             <ListItem>
               Item
-              <List>
+              <List typographyType={typographyType} listType={listType}>
                 <ListItem>Item</ListItem>
                 <ListItem>
                   Item
-                  <List>
+                  <List typographyType={typographyType} listType={listType}>
                     <ListItem>Item</ListItem>
                     <ListItem>Item</ListItem>
                   </List>
@@ -108,29 +108,20 @@ export const Example: Story = {
   render: args => (
     <div style={{ maxWidth: '700px' }}>
       <Typography withMargins>
-        Første gang du gjør tjeneste som arbeidslivskyndig meddommer, vil
-        rettens leder be deg om:
+        Dette er et eksempelsetning som viser hvordan komponenten ser ut i
+        mengdetekst. Her er listen:
       </Typography>
       <List {...args}>
-        <ListItem>å følge nøye med i forhandlingen</ListItem>
-        <ListItem>
-          merke deg forklaringene som blir gitt og bevisene som blir fremlagt
-        </ListItem>
-        <ListItem>
-          å gi uttrykk for hvordan du vurderer saken etter at bevisene er lagt
-          frem
-        </ListItem>
-        <ListItem>
-          å ikke legge vekt på andre forhold enn bevisene som er ført i saken
-        </ListItem>
+        <ListItem>første punkt i listen</ListItem>
+        <ListItem>andre punkt i listen er her</ListItem>
+        <ListItem>og så tredje punkt</ListItem>
+        <ListItem>til slutt kommer fjerde punkt</ListItem>
       </List>
       <Typography withMargins>
-        Første gang du er i retten må du også avgi en forsikring. Den sier at du
-        både i den aktuelle saken og i fremtidige saker vil gi vel akt på alt
-        som fremkommer gjennom forhandlingene i retten, og at du vil dømme slik
-        du finner sannest å rettest å være etter loven og sakens bevisligheter.
-        På oppfordring fra dommeren, skal du til dette svare: «Det forsikrer
-        jeg.»
+        Eksempeltekst under listen. Den skal være litt lengre for å få mer
+        realistisk inntrykk; gjerne over minst to linjer, men helst tre. Derfor
+        trenger vi en ekstra setning i dette avsnittet. Og gjerne enda en for å
+        være helt sikker.
       </Typography>
     </div>
   ),


### PR DESCRIPTION
## Beskrivelse


Linjehøyden ble endret for en stund siden, men posisjoneringen til bullets har vært hardkodet; fikser det.

Gjør om eksempel-story til å ikke bruke ekte tekster i samme slengen.


## Sjekkliste

### Generelt

- [ ] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [ ] I commits
  - [ ] I PR-tittelen
- [ ] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
