### PR TITLE
ELSA1-642 Chevron spacing i `<NativeSelect>`

### DIFF
--- a/.changeset/nice-tips-yawn.md
+++ b/.changeset/nice-tips-yawn.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser feil størrelse på tømmeknapp i `<NativeSelect>` og ulik ikon-spacing i `<NativeSelect>` og `<Select>`.

--- a/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
+++ b/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from 'storybook/test';
 
 import { FAVSTAR_SIZES, FavStar } from './FavStar';
 import {
+  StoryLabel,
   categoryHtml,
   commonArgTypes,
   htmlEventArgType,
@@ -17,7 +18,7 @@ import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { Checkbox } from '../SelectionControl/Checkbox';
 import { Table } from '../Table';
 import { Tooltip } from '../Tooltip';
-import { Caption, Link, Typography } from '../Typography';
+import { Caption, Link } from '../Typography';
 
 const meta: Meta<typeof FavStar> = {
   title: 'dds-components/Components/FavStar',
@@ -42,9 +43,7 @@ export const Sizes: Story = {
     <StoryHStack>
       {FAVSTAR_SIZES.map(size => (
         <StoryVStack key={size}>
-          <Typography as="span" typographyType="labelMedium">
-            {labelText(size)}
-          </Typography>
+          <StoryLabel>{labelText(size)}</StoryLabel>
           <FavStar {...args} size={size} />
         </StoryVStack>
       ))}

--- a/packages/dds-components/src/components/Icon/Icon.stories.tsx
+++ b/packages/dds-components/src/components/Icon/Icon.stories.tsx
@@ -1,9 +1,9 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import { OpenExternalIcon as OpenExternal } from './icons/openExternal';
-import { commonArgTypes, labelText } from '../../storybook/helpers';
+import { StoryLabel, commonArgTypes, labelText } from '../../storybook/helpers';
 import { StoryHStack } from '../layout/Stack/utils';
-import { Paragraph, Typography } from '../Typography';
+import { Paragraph } from '../Typography';
 import { ICON_SIZES } from './Icon';
 import { VStack } from '../layout';
 
@@ -33,9 +33,7 @@ export const Sizes: Story = {
     <StoryHStack>
       {ICON_SIZES.map(size => (
         <VStack key={size}>
-          <Typography as="span" typographyType="labelMedium">
-            {labelText(size)}
-          </Typography>
+          <StoryLabel>{labelText(size)}</StoryLabel>
           <Icon {...args} iconSize={size} />
         </VStack>
       ))}

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.module.css
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.module.css
@@ -77,17 +77,15 @@
 }
 
 .icon {
-  position: absolute;
-  top: 50%;
-  transform: translate(-150%, -50%);
+  right: var(--dds-spacing-x0-5);
   align-self: center;
   pointer-events: none;
 }
 
 .clear-button--small {
-  right: calc(var(--dds-spacing-x0-75) + var(--dds-icon-size-small));
+  right: calc(var(--dds-spacing-x0-5) + var(--dds-icon-size-small));
 }
 
 .clear-button--medium {
-  right: calc(var(--dds-spacing-x0-75) + var(--dds-icon-size-medium));
+  right: calc(var(--dds-spacing-x0-5) + var(--dds-icon-size-medium));
 }

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.tsx
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.tsx
@@ -22,6 +22,7 @@ import {
 import inputStyles from '../../helpers/Input/Input.module.css';
 import { focusable } from '../../helpers/styling/focus.module.css';
 import { scrollbar } from '../../helpers/styling/utilStyles.module.css';
+import utilStyles from '../../helpers/styling/utilStyles.module.css';
 import { Icon } from '../../Icon';
 import { ChevronDownIcon } from '../../Icon/icons';
 import { renderInputMessage } from '../../InputMessage';
@@ -110,7 +111,7 @@ export const NativeSelect = ({
     onChange?.(clearChangeEvent);
   };
 
-  const iconSize = componentSize === 'xsmall' ? 'small' : 'medium';
+  const iconSize = componentSize === 'medium' ? 'medium' : 'small';
 
   return (
     <div className={className} style={style}>
@@ -164,14 +165,14 @@ export const NativeSelect = ({
             aria-label={t(commonTexts.clearSelect)}
             onClick={clearInput}
             size={iconSize}
-            className={cn(styles[`clear-button--${iconSize}`])}
+            className={styles[`clear-button--${iconSize}`]}
           />
         )}
         {!multiple && (
           <Icon
             icon={ChevronDownIcon}
             iconSize={iconSize}
-            className={styles.icon}
+            className={cn(utilStyles['center-absolute-y'], styles.icon)}
           />
         )}
       </Box>

--- a/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
@@ -2,6 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 import {
+  StoryLabel,
   commonArgTypes,
   labelText,
   responsivePropsArgTypes,
@@ -9,7 +10,7 @@ import {
 } from '../../storybook/helpers';
 import { NotificationsIcon } from '../Icon/icons';
 import { StoryVStack } from '../layout/Stack/utils';
-import { Paragraph, Typography } from '../Typography';
+import { Paragraph } from '../Typography';
 import { TABS_SIZES } from './Tabs';
 
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '.';
@@ -70,9 +71,7 @@ export const Sizes: Story = {
     <StoryVStack gap="x2.5">
       {TABS_SIZES.map(size => (
         <StoryVStack gap="x0.5" key={size}>
-          <Typography as="span" typographyType="labelMedium">
-            {labelText(size)}
-          </Typography>
+          <StoryLabel>{labelText(size)}</StoryLabel>
           <Tabs {...args} size={size}>
             {tabList()}
           </Tabs>

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from 'storybook/test';
 
 import { TOGGLE_BAR_SIZES } from './ToggleBar.types';
 import {
+  StoryLabel,
   commonArgTypes,
   labelText,
   responsivePropsArgTypes,
@@ -12,7 +13,6 @@ import {
 import { PlusCircledIcon } from '../Icon/icons';
 import { VStack } from '../layout';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
-import { Typography } from '../Typography';
 
 import { ToggleBar, ToggleRadio } from '.';
 
@@ -61,9 +61,7 @@ export const Sizes: Story = {
       <StoryHStack flexWrap="wrap">
         {TOGGLE_BAR_SIZES.map(size => (
           <VStack key={size} gap="x0.125">
-            <Typography as="span" typographyType="labelMedium">
-              {labelText(size)}
-            </Typography>
+            <StoryLabel>{labelText(size)}</StoryLabel>
             <StoryVStack>
               <ToggleBar {...args} name={`test${name++}`} size={size}>
                 {toggleRadios(true)}

--- a/packages/dds-components/src/components/helpers/Input/Input.module.css
+++ b/packages/dds-components/src/components/helpers/Input/Input.module.css
@@ -112,7 +112,7 @@
 :where(.input-group__absolute-element) {
   position: absolute;
   top: 50%;
-  transform: translate(0, -50%);
+  transform: translateY(-50%);
   z-index: var(--dds-zindex-absolute-element);
   color: var(--dds-color-icon-default);
 }

--- a/packages/dds-components/src/storybook/helpers.tsx
+++ b/packages/dds-components/src/storybook/helpers.tsx
@@ -8,11 +8,14 @@ import {
   type ResponsiveStackProps,
 } from '../components/layout/common/Responsive.types';
 import { getBreakpointFromScreenWidth } from '../components/layout/common/utils';
-import { Paragraph } from '../components/Typography';
+import { Paragraph, Typography } from '../components/Typography';
 import { useWindowResize } from '../hooks';
 
 export const labelText = (t: string) => t.charAt(0).toUpperCase() + t.slice(1);
 
+export const StoryLabel = (props: { children: ReactNode }) => (
+  <Typography {...props} as="span" typographyType="labelMedium" />
+);
 export interface ArgType {
   control?: Control;
   table?: { category: string };

--- a/stories/Playground/FormComponentsTesting.stories.tsx
+++ b/stories/Playground/FormComponentsTesting.stories.tsx
@@ -1,109 +1,76 @@
-import { type ReactNode } from 'react';
+import { type Meta } from '@storybook/react-vite';
 
+import { LocalMessage } from '../../packages/dds-components/dist/index.mjs';
+import { type InputSize } from '../../packages/dds-components/src/components/helpers/Input';
 import { StoryThemeProvider } from '../../packages/dds-components/src/components/ThemeProvider/utils/StoryThemeProvider';
 import {
   DatePicker,
   HStack,
   MailIcon,
+  NativeSelect,
   Search,
   Select,
   TextInput,
   TimePicker,
   VStack,
 } from '../../packages/dds-components/src/index';
+import { StoryLabel } from '../../packages/dds-components/src/storybook/helpers';
 
-export default {
+const meta: Meta = {
   title: 'Playground/Testing',
   decorators: [
-    (Story: ReactNode) => (
+    Story => (
       <StoryThemeProvider>
         <Story />
       </StoryThemeProvider>
     ),
   ],
 };
+export default meta;
+
+const icon = MailIcon;
+
+function renderInputs(size: InputSize) {
+  return (
+    <>
+      <TextInput componentSize={size} icon={icon} />
+      <DatePicker componentSize={size} />
+      <TimePicker componentSize={size} />
+      {size !== 'xsmall' && <Search componentSize={size} />}
+      <Select
+        componentSize={size}
+        icon={icon}
+        options={[{ label: 'a', value: 'a' }]}
+        value={{ label: 'a', value: 'a' }}
+      />
+      <NativeSelect componentSize={size} value="a" clearable>
+        <option value=""></option>
+        <option value="a">a</option>
+      </NativeSelect>
+    </>
+  );
+}
 
 export const FormComponents = () => {
   return (
-    <VStack align="start" gap="x1">
-      <HStack align="start" gap="x1">
-        <VStack align="start" gap="x1">
-          <TextInput />
-          <TextInput componentSize="small" />
-          <TextInput componentSize="xsmall" />
+    <VStack gap="x1.5">
+      <LocalMessage message="Her tester vi om skjemakomponenter ser likt ut." />
+      <VStack gap="x0.25">
+        <StoryLabel>Horisontal plassering på ikonene</StoryLabel>
+        <VStack gap="x1">
+          {renderInputs('medium')}
+          {renderInputs('small')}
+          {renderInputs('xsmall')}
         </VStack>
-        <VStack align="start" gap="x1">
-          <TextInput icon={MailIcon} />
-          <Search />
-          <DatePicker componentSize="medium" />
-          <TimePicker componentSize="medium" />
-          <Select icon={MailIcon} options={[{ label: 'a', value: 'a' }]} />
-          <TextInput componentSize="small" icon={MailIcon} />
-          <Search componentSize="small" />
-          <DatePicker componentSize="small" />
-          <TimePicker componentSize="small" />
-          <Select
-            icon={MailIcon}
-            options={[{ label: 'a', value: 'a' }]}
-            componentSize="small"
-          />
-          <TextInput componentSize="xsmall" icon={MailIcon} />
-          <DatePicker componentSize="xsmall" />
-          <TimePicker componentSize="xsmall" />
-          <Select
-            icon={MailIcon}
-            options={[{ label: 'a', value: 'a' }]}
-            componentSize="xsmall"
-          />
+      </VStack>
+      <VStack gap="x0.25">
+        <StoryLabel> Høyde og vertikal plassering på ikonene</StoryLabel>
+        <VStack gap="x1">
+          <HStack>{renderInputs('medium')}</HStack>
+          <HStack>{renderInputs('small')}</HStack>
+          <HStack>{renderInputs('xsmall')}</HStack>
         </VStack>
-      </HStack>
-      <HStack align="start" gap={0}>
-        <TextInput componentSize="medium" icon={MailIcon} />
-        <Search componentSize="medium" />
-        <DatePicker componentSize="medium" />
-        <Select
-          icon={MailIcon}
-          options={[{ label: 'a', value: 'a' }]}
-          componentSize="medium"
-        />
-        <Select
-          icon={MailIcon}
-          options={[{ label: 'a', value: 'a' }]}
-          componentSize="medium"
-          isMulti
-        />
-      </HStack>
-      <HStack align="start" gap={0}>
-        <TextInput componentSize="small" icon={MailIcon} />
-        <Search componentSize="small" />
-        <DatePicker componentSize="small" />
-        <Select
-          icon={MailIcon}
-          options={[{ label: 'a', value: 'a' }]}
-          componentSize="small"
-        />
-        <Select
-          icon={MailIcon}
-          options={[{ label: 'a', value: 'a' }]}
-          componentSize="small"
-          isMulti
-        />
-      </HStack>
-      <HStack align="start" gap={0}>
-        <TextInput componentSize="xsmall" icon={MailIcon} />
-        <DatePicker componentSize="xsmall" />
-        <Select
-          icon={MailIcon}
-          options={[{ label: 'a', value: 'a' }]}
-          componentSize="xsmall"
-        />
-        <Select
-          icon={MailIcon}
-          options={[{ label: 'a', value: 'a' }]}
-          componentSize="xsmall"
-          isMulti
-        />
-      </HStack>
+      </VStack>
     </VStack>
   );
 };


### PR DESCRIPTION
## Beskrivelse

Fikser spacing slik den er lik `<Select>` og størrelse på tømmeknapp. Refaktorerer også story for testing om komponenter ser likt ut, gjør den mer selvforklarende.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
