### PR TITLE
ELSA1-679 Oppdaterer skjemamaler

### DIFF
--- a/.changeset/gold-clouds-fetch.md
+++ b/.changeset/gold-clouds-fetch.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for resposive props i `<Tabs>`-delkomponenter: `padding`, `paddingInline` og `paddingBlock` i `TabPanels`; `padding` i `<TabPanel>` med default som fra før av. Gir mer fleksibilitet med tanke på spacing rundt innholdet.

--- a/packages/dds-components/src/components/Tabs/Tab.tsx
+++ b/packages/dds-components/src/components/Tabs/Tab.tsx
@@ -44,7 +44,7 @@ export type TabProps = BaseComponentPropsWithChildren<
     setFocus?: Dispatch<SetStateAction<number>>;
     /** Indeksen til `<Tab>`. **OBS!** settes automatisk av forelder.*/
     index?: number;
-    /** Bredden til `<Tab>`. Her er det støtte for de samme enhetene som du kan bruke i `grid-template-columns`.
+    /** Bredden til `<Tab>`. Støtter samme enheter som `grid-template-columns`.
      * @default "1fr"
      */
     width?: CSS.Properties['width'];

--- a/packages/dds-components/src/components/Tabs/TabPanel.tsx
+++ b/packages/dds-components/src/components/Tabs/TabPanel.tsx
@@ -4,13 +4,17 @@ import {
 } from '../../types';
 import { cn } from '../../utils';
 import { focusable } from '../helpers/styling/focus.module.css';
-import { Box } from '../layout';
+import { Box, type ResponsiveProps } from '../layout';
 
 export type TabPanelProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
   {
     /** Spesifiserer om panelet skal vises basert på aktiv fane. */
     active?: boolean;
+    /** CSS `padding`. Støtter standardverdier og dds spacing tokens skala, per brekkpunkt eller samme for alle skjermstørrelser.
+     * @default 'x0.25'
+     */
+    padding?: ResponsiveProps['padding'];
   }
 >;
 
@@ -20,10 +24,11 @@ export const TabPanel = ({
   id,
   className,
   htmlProps,
+  padding = 'x0.25',
   ...rest
 }: TabPanelProps) => (
   <Box
-    padding="x0.25"
+    padding={padding}
     {...getBaseHTMLProps(id, cn(className, focusable), htmlProps, rest)}
     tabIndex={0}
     role="tabpanel"

--- a/packages/dds-components/src/components/Tabs/TabPanels.tsx
+++ b/packages/dds-components/src/components/Tabs/TabPanels.tsx
@@ -8,8 +8,13 @@ import {
 import { type TabPanelProps } from './TabPanel';
 import { useTabsContext } from './Tabs.context';
 import { useCombinedRef } from '../../hooks';
+import { Box, type ResponsiveProps } from '../layout';
 
-export type TabPanelsProps = ComponentPropsWithRef<'div'>;
+export type TabPanelsProps = Pick<
+  ResponsiveProps,
+  'padding' | 'paddingBlock' | 'paddingInline'
+> &
+  ComponentPropsWithRef<'div'>;
 
 export const TabPanels = ({ children, ref, ...rest }: TabPanelsProps) => {
   const { activeTab, tabsId, tabPanelsRef } = useTabsContext();
@@ -31,9 +36,9 @@ export const TabPanels = ({ children, ref, ...rest }: TabPanelsProps) => {
   });
 
   return (
-    <div ref={combinedRef} {...rest}>
+    <Box ref={combinedRef} {...rest}>
       {panelChildren}
-    </div>
+    </Box>
   );
 };
 

--- a/packages/dds-components/src/components/Tabs/Tabs.mdx
+++ b/packages/dds-components/src/components/Tabs/Tabs.mdx
@@ -5,7 +5,7 @@ import {
   Story,
   Controls,
 } from '@storybook/addon-docs/blocks';
-import { Tab, TabPanel, TabList } from '.';
+import { Tabs, Tab, TabPanel, TabPanels, TabList } from '.';
 import {
   Source,
   ComponentLinkRow,
@@ -24,80 +24,76 @@ import * as TabsStories from './Tabs.stories';
   withBottomSpacing
 />
 
-Komponenten består av flere subkomponenter:
+## Delkomponenter
 
-- `<Tabs>` - ytterste container for andre subkomponenter. Håndterer oppførsel og eventuelt litt styling. Har `<TabList>` og `<TabPanels>` som barn.
-- `<Tab>` - en fane.
-- `<TabList>` - liste med faner. Håndterer ARIA-attributter og `id` for barna.
-- `<TabPanel>` - panel med innhold som hører til en spesifikk fane.
-- `<TabPanels>` - liste med paneler. Håndterer ARIA-attributter og `id` for barna.
+<Tabs>
+  <TabList>
+    <Tab>Tabs</Tab>
+    <Tab>TabList</Tab>
+    <Tab>Tab</Tab>
+    <Tab>TabPanels</Tab>
+    <Tab>TabPanel</Tab>
+  </TabList>
+  <TabPanels paddingBlock='x1.5 0'>
+    <TabPanel>
+      Ytterste container for andre delkomponenter. Håndterer oppførsel og eventuelt litt styling. Har `<TabList>` og `<TabPanels>` som barn.
 
-## Props
+      <Canvas of={TabsStories.Preview} />
+      <Controls of={TabsStories.Preview} />
+    </TabPanel>
+    <TabPanel>
+      En liste med `<Tab>`. Setter ARIA-attributter som `aria-controls` og roving focus for barna. `<TabList>` skal ha `<Tab>` som barn i samme rekkefølge som tilhørende paneler i `<TabPanels>`.
 
-### Tabs
+      Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface.
+    </TabPanel>
+    <TabPanel>
+      En fane. Tilhørende `<TabPanel>` vises ved museklikk. Har `type="button"` som default.
 
-Ytterste container som styrer hvilket panel skal vises via indeks. Har `<TabList>` og `<TabPanels>` som barn.
+      <ArgTypes of={Tab} />
+    </TabPanel>
+    <TabPanel>
+      En liste med `<TabPanel>`. Setter attributter som `aria-labelledby` for barna. `<TabPanels>` skal ha `<TabPanel>` som barn i samme rekkefølge som tilhørende paneler i `<TabList>`.
 
-<Canvas of={TabsStories.Preview} />
+      <ArgTypes of={TabPanels} />
 
-<Controls of={TabsStories.Preview} />
+      Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface.
+    </TabPanel>
+    <TabPanel>
+      Panel med innhold. Vises ved museklikk på tilhørende `<Tab>`.
 
-### Tab
+      <ArgTypes of={TabPanel} />
+    </TabPanel>
 
-En fane. Tilhørende `<TabPanel>` vises ved museklikk. Har `type="button"` som default.
-
-<ArgTypes of={Tab} />
-
-#### Bredde
-
-For å endre på bredden til tabs kan du bruke `width`-attributtet. Her støttes alle de samme enhetene som i `grid-template-columns` i CSS.
-
-<Source
-  code={`import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@norges-domstoler/dds-components';
-  <Tabs>
-    <TabList>
-      <Tab width="max-content">Tab 1</Tab>
-      <Tab width="8rem">Tab 2</Tab>
-      <Tab width="1fr">Tab 3</Tab>
-    </TabList>
-    <TabPanels>
-      <TabPanel>Innhold 1</TabPanel>
-      <TabPanel>Innhold 2</TabPanel>
-      <TabPanel>Innhold 3</TabPanel>
-    </TabPanels>
-  </Tabs>
-
-`}
-/>
-
-### TabList
-
-En liste med `<Tab>`. Setter attributter som `aria-controls` og roving focus for barna. `<TabList>` skal ha `<Tab>` som barn i samme rekkefølge som tilhørende paneler i `<TabPanels>`.
-
-Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface.
-
-### TabPanel
-
-Panel med innhold. Vises ved museklikk på tilhørende `<Tab>`.
-
-<ArgTypes of={TabPanel} />
-
-### TabPanels
-
-En liste med `<TabPanel>`. Setter attributter som `aria-labelledby` for barna. `<TabPanels>` skal ha `<TabPanel>` som barn i samme rekkefølge som tilhørende paneler i `<TabList>`.
-
-Det støttes alle native HTML-attributter som er en del av `HTMLAttributes<HTMLDivElement>`-interface.
+  </TabPanels>
+</Tabs>
 
 ## Eksempler
 
-### Aktiv fane
+<Tabs>
+  <TabList>
+    <Tab>Aktiv fane</Tab>
+    <Tab>Med ikon</Tab>
+    <Tab>Bredde</Tab>
+    <Tab>Med "Legg til"-knapp</Tab>
+    <Tab>Overflow</Tab>
+  </TabList>
+  <TabPanels paddingBlock="x1.5 0">
+    <TabPanel>
+      <Canvas of={TabsStories.ActiveTab} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={TabsStories.WithIcon} />
+    </TabPanel>
+    <TabPanel>
 
-<Canvas of={TabsStories.ActiveTab} />
+      <Canvas of={TabsStories.DifferentWidths} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={TabsStories.WithAddTabButton} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={TabsStories.TabOverflow} sourceState="hidden" />
+    </TabPanel>
 
-### Med legg til-knapp
-
-<Canvas of={TabsStories.WithAddTabButton} />
-
-### Mange faner
-
-<Canvas of={TabsStories.ManyTabs} sourceState="hidden" />
+  </TabPanels>
+</Tabs>

--- a/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
@@ -139,6 +139,10 @@ export const WithAddTabButton: Story = {
 
     return (
       <>
+        <Paragraph withMargins>
+          Legg til-knapp inkluderes direkte i fanerekka. Husk å begrense antall
+          faner, slik at brukeren ikke kan legge til uendelig mange.
+        </Paragraph>
         {tooManyText}
         <Tabs
           {...args}
@@ -179,25 +183,6 @@ export const WithWidth: Story = {
   ),
 };
 
-export const MaxContentWidth: Story = {
-  render: args => (
-    <>
-      <Paragraph withMargins>
-        Dette er et eksempel på hvordan du kan sette egne bredder på hver tab.
-        Her er alle tabs satt til å ha bredde "<code>max-content</code>".
-      </Paragraph>
-      <Tabs {...args} htmlProps={{ style: { width: '400px' } }}>
-        <TabList>
-          <Tab width="max-content">Aktører</Tab>
-          <Tab width="max-content">Restriksjoner</Tab>
-          <Tab width="max-content">Vedlegg</Tab>
-        </TabList>
-        {tabPanels}
-      </Tabs>
-    </>
-  ),
-};
-
 export const ResponsiveWidth: Story = {
   decorators: [Story => windowWidthDecorator(<Story />)],
   args: {
@@ -217,33 +202,49 @@ export const ResponsiveWidth: Story = {
   ),
 };
 
-export const ManyTabs: Story = {
+export const DifferentWidths: Story = {
   render: args => (
-    <Tabs {...args} htmlProps={{ style: { width: '400px' } }}>
-      <TabList>
-        <Tab>Fane 1</Tab>
-        <Tab>Fane 2</Tab>
-        <Tab>Fane 3</Tab>
-        <Tab>Fane 4</Tab>
-        <Tab>Fane 5</Tab>
-        <Tab>Fane 6</Tab>
-        <Tab>Fane 7</Tab>
-        <Tab>Fane 8</Tab>
-        <Tab>Fane 9</Tab>
-        <Tab>Fane 10</Tab>
-      </TabList>
-      <TabPanels>
-        <TabPanel>Innhold 1</TabPanel>
-        <TabPanel>Innhold 2</TabPanel>
-        <TabPanel>Innhold 3</TabPanel>
-        <TabPanel>Innhold 4</TabPanel>
-        <TabPanel>Innhold 5</TabPanel>
-        <TabPanel>Innhold 6</TabPanel>
-        <TabPanel>Innhold 7</TabPanel>
-        <TabPanel>Innhold 8</TabPanel>
-        <TabPanel>Innhold 9</TabPanel>
-        <TabPanel>Innhold 10</TabPanel>
-      </TabPanels>
-    </Tabs>
+    <>
+      <Paragraph withMargins>
+        Dette er et eksempel på hvordan du kan sette egne bredder på hver tab
+        med <code>width</code>-attributtet. Det støttes de samme enhetene som i
+        <code>grid-template-columns</code> i CSS.
+      </Paragraph>
+      <Tabs {...args}>
+        <TabList>
+          <Tab width="max-content">Fane 1</Tab>
+          <Tab width="8rem">Fane 2</Tab>
+          <Tab width="1fr">Fane 3</Tab>
+        </TabList>
+        {tabPanels}
+      </Tabs>
+    </>
+  ),
+};
+
+export const TabOverflow: Story = {
+  render: args => (
+    <>
+      <Paragraph withMargins>
+        Hvis den totale bredden til fanene går utover tilgjengelig bredde vil
+        horisontal scrollbar vises.
+      </Paragraph>
+      <Tabs {...args} htmlProps={{ style: { width: '200px' } }}>
+        <TabList>
+          <Tab>Fane 1</Tab>
+          <Tab>Fane 2</Tab>
+          <Tab>Fane 3</Tab>
+          <Tab>Fane 4</Tab>
+          <Tab>Fane 5</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>Innhold 1</TabPanel>
+          <TabPanel>Innhold 2</TabPanel>
+          <TabPanel>Innhold 3</TabPanel>
+          <TabPanel>Innhold 4</TabPanel>
+          <TabPanel>Innhold 5</TabPanel>
+        </TabPanels>
+      </Tabs>
+    </>
   ),
 };

--- a/packages/dds-components/stories/patterns/Form/Form.mdx
+++ b/packages/dds-components/stories/patterns/Form/Form.mdx
@@ -3,6 +3,13 @@ import {
   ComponentLinkRow,
   Source,
 } from '@norges-domstoler/storybook-components';
+import {
+  Tabs,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+} from '../../../src/components/Tabs';
 import * as FormStories from './Form.stories';
 
 <Meta of={FormStories} />
@@ -12,10 +19,8 @@ import * as FormStories from './Form.stories';
 <ComponentLinkRow
   docsHref="https://design.domstol.no/987b33f71/p/30227e-useonkeydown"
   githubHref="https://github.com/domstolene/designsystem/blob/main/packages/dds-components/src/hooks/Form/Form.tsx"
-  withBottomSpacing
+  storybookHref="https://domstolene.github.io/designsystem/?path=/docs/patterns-form--docs"
 />
-
-**OBS!** Se demoer/stories utenfor Docs for riktig responsiv layout.
 
 ## Hvordan implementere?
 
@@ -38,28 +43,41 @@ Skjema-mønsteret bruker gjerne en del komponenter, layout primitives og props f
 - **Tekstfarge**: det meste av tekst skal ha standardisert farge, men ikke alt. Info om markering av påkrevde felt og påkrevd-markør skal bruke fargene `dds-color-text-subtle` og `dds-color-text-requiredfield`; disse kan settes med `color` prop i typografikomponeter.
 - **Størrelse på `<Legend>`**: hvis du bruker flere overskrifter på skjemasiden kan det hende du trenger å tilpasse størrelsen på din `<Legend>`. Bruk `typographyType` prop ved behov.
 
-## Vanlig
+## Maler
 
-<Canvas of={FormStories.Form} />
+**OBS!** For layout for større brekkpunkter se demoer/stories utenfor Docs.
 
-## Med steg
+<Tabs>
+  <TabList>
+    <Tab>Vanlig</Tab>
+    <Tab>Med steg</Tab>
+    <Tab>Med steg custom grid</Tab>
+    <Tab>Forlate skjema</Tab>
+  </TabList>
+  <TabPanels paddingBlock='var(--dds-spacing-x1-5) 0'>
+    <TabPanel>
+      Enkelt skjema som får plass på én side.
+      <Canvas of={FormStories.Form} />
+    </TabPanel>
+    <TabPanel>
+      Hvis skjema har steg bruker du i tillegg:
 
-Hvis skjema har steg bruker du i tillegg:
+      - **`<ProgressTracker>`**: til høyre for skjema.
+      - **`<ShowHide>` for mobilversjon av `<ProgressTracker>`**. Den tilgjenngeligjøres via `<Drawer>`, `<NativeSelect>` e.l. på mindre skjerm. Hvis du bruker `<Drawer>` trenger utløserknappen en tilgjengelig tekst; for eksempel, hvis knappeteksten er "Steg 1 av 2" med chevron-ikon vil seende brukere forstå hva den gjør. Du kan utvide denne med `<VisuallyHidden>` og usynlig tekst som "Vis stegnavigasjon" for assisterende verktøy.
 
-- **`<ProgressTracker>`**: til høyre for skjema.
-- **`<ShowHide>` for mobilversjon av `<ProgressTracker>`**. Den tilgjenngeligjøres via `<Drawer>`, `<NativeSelect>` e.l. på mindre skjerm. Hvis du bruker `<Drawer>` trenger utløserknappen en tilgjengelig tekst; for eksempel, hvis knappeteksten er "Steg 1 av 2" med chevron-ikon vil seende brukere forstå hva den gjør. Du kan utvide denne med `<VisuallyHidden>` og usynlig tekst som "Vis stegnavigasjon" for assisterende verktøy.
+      <Canvas of={FormStories.FormWithSteps} />
+    </TabPanel>
+    <TabPanel>
+      Istedenfor å bruke default kolonner i vårt `<Grid>` kan du f.eks. bruke to kolonner, der selve skjema har opptil spesifisert bredde og `<ProgressTracker>` tar resten.
+      Default CSS for `margin-inline` fra `<Grid>` er riktig her, men pass på spacing mellom kolonnene.
 
-<Canvas of={FormStories.FormWithSteps} />
+      <Canvas of={FormStories.FormWithStepsCustomGrid} />
+    </TabPanel>
+    <TabPanel>
+      Implementer advarsel for når brukeren prøver å forlate påbegynt skjema, slik at de kan ombestemme seg og bli på siden. `<Modal>` kan være en slik advarsel.
 
-## Med steg - custom grid
+      <Canvas of={FormStories.ExitForm} />
+    </TabPanel>
 
-Istedenfor å bruke default kolonner i vårt `<Grid>` kan du f.eks. bruke to kolonner, der selve skjema har opptil spesifisert bredde og `<ProgressTracker>` tar resten.
-Default CSS for `margin-inline` fra `<Grid>` er riktig her, men pass på spacing mellom kolonnene.
-
-<Canvas of={FormStories.FormWithStepsCustomGrid} />
-
-## Forlate skjema
-
-Implementer advarsel for når brukeren prøver å forlate påbegynt skjema, slik at de kan ombestemme seg og bli på siden. `<Modal>` kan være en slik advarsel.
-
-<Canvas of={FormStories.ExitForm} />
+  </TabPanels>
+</Tabs>

--- a/packages/dds-components/stories/patterns/Form/Form.stories.tsx
+++ b/packages/dds-components/stories/patterns/Form/Form.stories.tsx
@@ -35,6 +35,7 @@ const meta: Meta = {
   title: 'Patterns/Form',
   parameters: {
     layout: 'fullscreen',
+    docs: { canvas: { inline: false } },
   },
 };
 
@@ -59,8 +60,8 @@ export const Form = () => {
             Navn på skjema
           </Heading>
           <Paragraph withMargins typographyType="leadMedium">
-            Dette er et avsnitt/ingress. Bruk "body" og "lead" i meg. Lead er
-            ingress og body er vanlig mengdetekst.
+            Dette er et eksempel på en ingress. Den består ofte av et par
+            setninger. En setning til.
           </Paragraph>
           <Paragraph withMargins typographyType="bodySmall" color="text-subtle">
             Obligatoriske felter er merket med{' '}
@@ -123,7 +124,6 @@ export const Form = () => {
 
             <HStack gap="x1.5" paddingBlock="x1.5">
               <Button>Send inn</Button>
-              <Button purpose="tertiary">Avbryt og forkast</Button>
             </HStack>
           </VStack>
         </GridChild>
@@ -226,7 +226,6 @@ export const FormWithSteps = () => {
         </Fieldset>
         <HStack gap="x1.5" paddingBlock="x1.5">
           <Button>Neste</Button>
-          <Button purpose="tertiary">Avbryt og forkast</Button>
         </HStack>
       </VStack>
     </Fragment>,
@@ -271,7 +270,6 @@ export const FormWithSteps = () => {
         </Fieldset>
         <HStack gap="x1.5" paddingBlock="x1 0">
           <Button>Send inn</Button>
-          <Button purpose="tertiary">Avbryt og forkast</Button>
         </HStack>
       </VStack>
     </Fragment>,
@@ -302,8 +300,8 @@ export const FormWithSteps = () => {
             Navn på skjema
           </Heading>
           <Paragraph typographyType="leadMedium" withMargins>
-            Dette er et avsnitt/ingress. Bruk "body" og "lead" i meg. Lead er
-            ingress og body er vanlig mengdetekst.
+            Dette er et eksempel på en ingress. Den består ofte av et par
+            setninger. En setning til.
           </Paragraph>
           <Paragraph typographyType="bodySmall" color="text-subtle" withMargins>
             Obligatoriske felter er merket med{' '}
@@ -462,7 +460,6 @@ export const FormWithStepsCustomGrid = () => {
           </Fieldset>
           <HStack gap="x1.5" paddingBlock="x1.5">
             <Button>Neste</Button>
-            <Button purpose="tertiary">Avbryt og forkast</Button>
           </HStack>
         </VStack>
       </form>
@@ -504,7 +501,6 @@ export const FormWithStepsCustomGrid = () => {
         </Fieldset>
         <HStack gap="x1.5" paddingBlock="x1.5">
           <Button>Send inn</Button>
-          <Button purpose="tertiary">Avbryt og forkast</Button>
         </HStack>
       </form>
     </Fragment>,
@@ -526,8 +522,8 @@ export const FormWithStepsCustomGrid = () => {
           <VStack gap="x1">
             <Heading level={1}>Navn på skjema</Heading>
             <Paragraph typographyType="leadMedium">
-              Dette er et avsnitt/ingress. Bruk "body" og "lead" i meg. Lead er
-              ingress og body er vanlig mengdetekst.
+              Dette er et eksempel på en ingress. Den består ofte av et par
+              setninger. En setning til.
             </Paragraph>
             <Paragraph typographyType="bodySmall" color="text-subtle">
               Obligatoriske felter er merket med{' '}
@@ -610,18 +606,14 @@ export const ExitForm = () => {
           {isFormPage ? (
             <>
               <Box marginBlock="x1">
-                <BackLink
-                  label="Tilbake"
-                  href="//"
-                  onClick={() => setShowModal(true)}
-                />
+                <BackLink label="Tilbake" onClick={() => setShowModal(true)} />
               </Box>
               <Heading level={1} withMargins>
                 Navn på skjema
               </Heading>
               <Paragraph withMargins typographyType="leadMedium">
-                Dette er et avsnitt/ingress. Bruk "body" og "lead" i meg. Lead
-                er ingress og body er vanlig mengdetekst.
+                Dette er et eksempel på en ingress. Den består ofte av et par
+                setninger. En setning til.
               </Paragraph>
               <Paragraph
                 withMargins
@@ -649,7 +641,6 @@ export const ExitForm = () => {
                 </Fieldset>
                 <HStack gap="x1.5" paddingBlock="x1.5">
                   <Button>Send inn</Button>
-                  <Button purpose="tertiary">Avbryt og forkast</Button>
                 </HStack>
               </VStack>
             </>


### PR DESCRIPTION
## Beskrivelse

Fikser små ting i malene: 
- Fjerner tertiary-knapp og oppdaterer ingresstekst. 
- Fikser at stories ikke er inline i docs, slik at responsive layout blir riktig; embedded story er alltid ganske smal.
- Fjerner lenke fra `<BackLink>` for bedre showcase av onClick-oppførsel.

Implementerer visning med `<Tabs>` for alle malene. Revamper docs for `<Tabs>`-komponenten med lignende visning i samme slengen.

Preview skjemamønster docs: https://elsa1-679-form-pattern-adj.designsystem.pages.dev/?path=/docs/patterns-form--docs
Preview Tabs docs: https://elsa1-679-form-pattern-adj.designsystem.pages.dev/?path=/docs/dds-components-components-tabs--docs

Utvider `<TabPanel>` og `<TabPanels>` med støtte for responsive padding-props for fleksibilitet.


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
