### PR TITLE
ELSA1-674 Venstrejustert `<Caption>`

### DIFF
--- a/.changeset/tidy-rings-sit.md
+++ b/.changeset/tidy-rings-sit.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Justerer på `<Caption>` slik at den er venstrejustert over tabell, og ikke sentrert.

--- a/packages/dds-components/src/components/Typography/Caption/Caption.mdx
+++ b/packages/dds-components/src/components/Typography/Caption/Caption.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
+import { Tabs, Tab, TabPanel, TabPanels, TabList } from '../../Tabs';
 import * as CaptionStories from './Caption.stories';
 
 <Meta of={CaptionStories} />
@@ -16,7 +17,20 @@ import * as CaptionStories from './Caption.stories';
 
 `<Caption>` er en komponent som returnerer `<caption>` HTML tag - tittel for en tabell.
 
-## Props
+## Eksempler
 
-<Canvas of={CaptionStories.Preview} />
-<Controls of={CaptionStories.Preview} />
+<Tabs>
+  <TabList>
+    <Tab>Demo</Tab>
+    <Tab>I tabell</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      <Canvas of={CaptionStories.Preview} />
+      <Controls of={CaptionStories.Preview} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={CaptionStories.WithTable} />
+    </TabPanel>
+  </TabPanels>
+</Tabs>

--- a/packages/dds-components/src/components/Typography/Caption/Caption.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Caption/Caption.stories.tsx
@@ -1,5 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
+import { Table } from '../../Table';
 import { storyTypographyHtmlAttrs } from '../storyUtils';
 
 import { Caption } from '.';
@@ -16,4 +17,25 @@ type Story = StoryObj<typeof Caption>;
 
 export const Preview: Story = {
   args: { children: 'Caption' },
+};
+
+export const WithTable: Story = {
+  args: { children: 'Caption', withMargins: true },
+  render: args => (
+    <Table>
+      <Caption {...args} />
+      <Table.Head>
+        <Table.Row>
+          <Table.Cell>Header</Table.Cell>
+          <Table.Cell>Header</Table.Cell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        <Table.Row>
+          <Table.Cell>Body</Table.Cell>
+          <Table.Cell>Body</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+    </Table>
+  ),
 };

--- a/packages/dds-components/src/components/Typography/Typography/Typography.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.tsx
@@ -113,6 +113,7 @@ export const Typography = (props: TypographyProps) => {
           typographyStyles[typographyCn],
           withMargins && typographyStyles[`${typographyCn}--margins`],
           isLegend(as) && typographyStyles.legend,
+          isCaption(as) && typographyStyles.caption,
           isCaption(as) &&
             withMargins &&
             typographyStyles['caption--withMargins'],

--- a/packages/dds-components/src/components/Typography/typographyStyles.module.css
+++ b/packages/dds-components/src/components/Typography/typographyStyles.module.css
@@ -243,6 +243,10 @@
   padding-inline: 0;
 }
 
+:where(.caption) {
+  text-align: left;
+}
+
 :where(.caption--withMargins) {
   display: table-caption;
 }


### PR DESCRIPTION
## Beskrivelse

Default CSS sentrerer den, men vi vil mest sannsynligvis alltid ha den til venstre. Endrer på det; legger til story som viser det og oppdaterer docs med eksempelet.

## Sjekkliste

### Generelt

- [ ] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [ ] I commits
  - [ ] I PR-tittelen
- [ ] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
