### PR TITLE
ELSA1-664 Støtte for tømmeknapp i `<DatePicker>`

### DIFF
--- a/.changeset/bumpy-spoons-sort.md
+++ b/.changeset/bumpy-spoons-sort.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for `clearable` prop i `<DatePicker>`. Angir om brukeren kan tømme verdi (inkludert delvis verdi) med en tømmeknapp.

--- a/.changeset/dark-olives-share.md
+++ b/.changeset/dark-olives-share.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser spacing i `<DatePicker>` og `<TimePicker>` mellom elementer og i kalenderknapp.

--- a/.changeset/lemon-laws-find.md
+++ b/.changeset/lemon-laws-find.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Bytter til monospace font i `<DatePicker>` slik at tegn har samme bredde og bredden på hele komponenten ikke hopper.

--- a/.changeset/polite-webs-repair.md
+++ b/.changeset/polite-webs-repair.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser manglende oversettelse i `<Search>`.

--- a/.changeset/purple-geckos-beam.md
+++ b/.changeset/purple-geckos-beam.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<NativeSelect>` fikk tømmeknapp selv om komponenten var `disabled` eller `readOnly`.

--- a/packages/dds-components/src/components/Search/Search.tsx
+++ b/packages/dds-components/src/components/Search/Search.tsx
@@ -223,7 +223,7 @@ export const Search = ({
               onClick={onClick}
               {...otherButtonProps}
             >
-              {buttonLabel ?? 'Søk'}
+              {buttonLabel ?? t(texts.search)}
             </Button>
           </Grid>
         ) : (
@@ -243,6 +243,12 @@ const texts = createTexts({
     no: 'Tøm søk',
     nn: 'Tøm søk',
     en: 'Clear search',
+  },
+  search: {
+    nb: 'Søk',
+    no: 'Søk',
+    nn: 'Søk',
+    en: 'Search',
   },
   useArrowKeys: {
     nb: 'Bruk piltastene for å navigere i forslagene når listen er utvidet',

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.tsx
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.tsx
@@ -31,7 +31,7 @@ import { Label } from '../../Typography';
 import typographyStyles from '../../Typography/typographyStyles.module.css';
 
 export type NativeSelectProps = {
-  /** Om verdien til `<select>` kan tømmes. */
+  /** Om brukeren kan fjerne verdien med en tømmeknapp. */
   clearable?: boolean;
   /** Implementerer `readOnly` oppførsel etter standard for `<input>` og setter `readOnly` styling. */
   readOnly?: InputProps['readOnly'];
@@ -114,6 +114,7 @@ export const NativeSelect = ({
   };
 
   const iconSize = componentSize === 'medium' ? 'medium' : 'small';
+  const showClearButton = clearable && hasValue && !readOnly && !rest.disabled;
 
   return (
     <div className={className} style={style}>
@@ -162,7 +163,7 @@ export const NativeSelect = ({
         >
           {children}
         </select>
-        {hasValue && clearable && (
+        {showClearButton && (
           <ClearButton
             aria-label={t(commonTexts.clearSelect)}
             onClick={clearInput}

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DateField/CalendarButton.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DateField/CalendarButton.tsx
@@ -3,8 +3,8 @@ import { useRef } from 'react';
 
 import type { DateFieldProps } from './DateField';
 import { cn } from '../../../../utils';
+import { InlineIconButton } from '../../../helpers/InlineIconButton';
 import { focusable } from '../../../helpers/styling/focus.module.css';
-import { Icon } from '../../../Icon';
 import { CalendarIcon } from '../../../Icon/icons';
 import styles from '../../common/DateInput.module.css';
 
@@ -24,21 +24,18 @@ export function CalendarButton({
   const size = componentSize === 'xsmall' ? 'small' : 'medium';
 
   return (
-    <button
+    <InlineIconButton
       {...buttonProps}
       ref={ref}
       type="button"
       className={cn(
         buttonProps.className,
-        styles['icon-wrapper'],
-        styles[`icon-wrapper--${size}`],
         styles['popover-button'],
         isReadOnly && styles['popover-button--readonly'],
         !props.isDisabled && focusable,
-        props.isDisabled && 'disabled',
       )}
-    >
-      <Icon icon={CalendarIcon} iconSize={size} />
-    </button>
+      icon={CalendarIcon}
+      size={size}
+    />
   );
 }

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.spec.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.spec.tsx
@@ -1,14 +1,15 @@
+import { CalendarDate } from '@internationalized/date';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { DatePicker } from './DatePicker';
+import { DatePicker, type DatePickerProps } from './DatePicker';
 import { HStack } from '../../layout';
 import { TextInput } from '../../TextInput';
 import { ThemeProvider } from '../../ThemeProvider';
 
-const WrappedDatePicker = () => (
+const WrappedDatePicker = (props: DatePickerProps) => (
   <ThemeProvider>
-    <DatePicker />
+    <DatePicker {...props} />
   </ThemeProvider>
 );
 
@@ -63,5 +64,19 @@ describe('<DatePicker>', () => {
     const spinbuttons = screen.getAllByRole('spinbutton');
     expect(spinbuttons[0]).toHaveAttribute('aria-valuemax');
     expect(spinbuttons[1]).toHaveAttribute('aria-valuemax', '12');
+  });
+  it('clear button is not rendered if no value', () => {
+    render(<WrappedDatePicker clearable />);
+
+    const clearButton = screen.queryByRole('button', { name: /Tøm dato/i });
+    expect(clearButton).not.toBeInTheDocument();
+  });
+  it('clear button is rendered if there is value', () => {
+    render(
+      <WrappedDatePicker clearable value={new CalendarDate(2023, 8, 28)} />,
+    );
+
+    const clearButton = screen.queryByRole('button', { name: /Tøm dato/i });
+    expect(clearButton).toBeInTheDocument();
   });
 });

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.stories.tsx
@@ -41,6 +41,9 @@ const meta: Meta<typeof DatePicker> = {
   },
   argTypes: {
     width: responsivePropsArgTypes.width,
+    isDisabled: { control: 'boolean' },
+    isReadOnly: { control: 'boolean' },
+    isRequired: { control: 'boolean' },
     onBlur: htmlEventArgType,
     onChange: htmlEventArgType,
     onFocus: htmlEventArgType,
@@ -71,6 +74,10 @@ type Story = StoryObj<typeof DatePicker>;
 
 export const Preview: Story = {
   args: { label: 'Dato' },
+};
+
+export const Clearable: Story = {
+  args: { label: 'Dato', clearable: true },
 };
 
 export const Overview: Story = {

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.tsx
@@ -42,6 +42,11 @@ export interface DatePickerProps
    * Brekkpunkt for å vise versjon for liten skjerm.
    */
   smallScreenBreakpoint?: Breakpoint;
+  /**
+   * Om brukeren kan fjerne valgt dato med en tømmeknapp, inkludert delvis utfylte verdier (f.eks. kun måned).
+   * @default false
+   */
+  clearable?: boolean;
 }
 
 const refIsFocusable = (ref: Ref<unknown>): ref is FocusableRef => {
@@ -56,6 +61,7 @@ export function DatePicker({
   width,
   smallScreenBreakpoint,
   showWeekNumbers = true,
+  clearable = false,
   ref,
   ...props
 }: DatePickerProps) {
@@ -88,6 +94,7 @@ export function DatePicker({
             buttonProps={buttonProps}
             style={style}
             width={width}
+            clearable={clearable}
           />
         </CalendarPopoverAnchor>
         <CalendarPopoverContent smallScreenBreakpoint={smallScreenBreakpoint}>

--- a/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.stories.tsx
+++ b/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.stories.tsx
@@ -19,6 +19,9 @@ const meta: Meta<typeof TimePicker> = {
   component: TimePicker,
   argTypes: {
     width: responsivePropsArgTypes.width,
+    isDisabled: { control: 'boolean' },
+    isReadOnly: { control: 'boolean' },
+    isRequired: { control: 'boolean' },
     className: { table: { disable: true } },
     onBlur: htmlEventArgType,
     onChange: htmlEventArgType,

--- a/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.tsx
+++ b/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.tsx
@@ -53,16 +53,15 @@ export function TimePicker({
       labelProps={labelProps}
       fieldProps={fieldProps}
       prefix={
-        <span
+        <Icon
+          icon={TimeIcon}
+          iconSize={iconSize}
           className={cn(
-            styles['icon-wrapper'],
+            styles.icon,
             disabled && styles['icon-wrapper--disabled'],
             props.isReadOnly && styles['icon-wrapper--readonly'],
-            styles[`icon-wrapper--${iconSize}`],
           )}
-        >
-          <Icon icon={TimeIcon} iconSize={iconSize} />
-        </span>
+        />
       }
     >
       {state.segments.map((segment, i) => (

--- a/packages/dds-components/src/components/date-inputs/common/DateInput.module.css
+++ b/packages/dds-components/src/components/date-inputs/common/DateInput.module.css
@@ -2,22 +2,19 @@
   display: inline-flex;
   flex-direction: row;
   align-items: center;
-  gap: var(--dds-spacing-x0-25);
+  gap: var(--dds-spacing-x0-5);
 }
 
-.date-input--medium {
-  padding-inline-start: var(--dds-spacing-x0-5);
-  padding-inline-end: var(--dds-spacing-x1);
-}
-
-.date-input--small {
-  padding-inline-start: var(--dds-spacing-x0-5);
-  padding-inline-end: var(--dds-spacing-x0-75);
-}
-
-.date-input--xsmall {
-  padding-inline-start: var(--dds-spacing-x0-25);
+.date-input--medium--clearable {
   padding-inline-end: var(--dds-spacing-x0-5);
+}
+
+.date-input--small--clearable {
+  padding-inline-end: var(--dds-spacing-x0-5);
+}
+
+.date-input--xsmall--clearable {
+  padding-inline-end: var(--dds-spacing-x0-25);
 }
 
 .date-segment-container {
@@ -31,6 +28,7 @@
   width: max-content;
   font-variant-numeric: tabular-nums;
   outline: none;
+  font-family: var(--dds-font-family-monospace);
 
   &:focus {
     background-color: var(--dds-color-surface-action-selected);
@@ -43,6 +41,7 @@
   width: 100%;
   font-variant-numeric: tabular-nums;
   pointer-events: none;
+  font-family: var(--dds-font-family-monospace);
 
   .segment:focus & {
     color: var(--dds-color-text-on-action);
@@ -55,33 +54,32 @@
   width: 0;
 }
 
-/**------------------------------------------------------------------------
- * Ikon-wrapper ved siden av input
- * Gjelder både dato og tid
- *------------------------------------------------------------------------*/
-
-.icon-wrapper {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--dds-spacing-x0-25);
-  color: var(--dds-color-icon-default);
+.clear-button {
+  align-self: center;
 }
 
-.icon-wrapper--disabled {
+.clear-button--inactive {
+  visibility: hidden;
+}
+
+/**------------------------------------------------------------------------
+* Ikon ved siden av input
+* Gjelder både dato og tid
+*------------------------------------------------------------------------*/
+
+.icon,
+.popover-button {
+  margin-block: -3px;
+}
+
+.icon-wrapper--disabled,
+.popover-button:disabled {
   color: var(--dds-color-icon-subtle);
 }
 
-.icon-wrapper--readonly {
+.icon-wrapper--readonly,
+.popover-button--readonly:disabled {
   color: var(--dds-color-icon-medium);
-}
-
-.icon-wrapper--small {
-  margin-block: calc(0px - var(--dds-icon-size-medium));
-}
-
-.icon-wrapper--medium {
-  margin-block: calc(0px - var(--dds-icon-size-small));
 }
 
 /**------------------------------------------------------------------------
@@ -89,28 +87,8 @@
  *------------------------------------------------------------------------*/
 
 .popover-button {
-  cursor: pointer;
-  border: 0;
-  transition: 0.2s;
-  background: transparent;
-  border-radius: var(--dds-border-radius-button);
-
-  &:not(:disabled):not(.disabled):hover,
-  &:not(:disabled):not(.disabled):active {
-    background-color: var(--dds-color-surface-hover-default);
-    color: var(--dds-color-icon-action-hover);
-  }
-
-  &:disabled,
-  &.disabled {
-    cursor: not-allowed;
-    outline: none;
-    color: var(--dds-color-text-subtle);
-  }
-}
-
-.popover-button--readonly:disabled {
-  color: var(--dds-color-text-medium);
+  padding: 1px;
+  margin-inline-start: -1px;
 }
 
 .popover {

--- a/packages/dds-components/src/components/date-inputs/common/DateInput.tsx
+++ b/packages/dds-components/src/components/date-inputs/common/DateInput.tsx
@@ -9,6 +9,7 @@ import focusStyles from '../../helpers/styling/focus.module.css';
 import { InputMessage } from '../../InputMessage';
 import { Box } from '../../layout';
 import { Label } from '../../Typography';
+import { type DatePickerProps } from '../DatePicker';
 import { CalendarPopoverContext } from '../DatePicker/CalendarPopover';
 
 export type DateInputProps = {
@@ -16,9 +17,12 @@ export type DateInputProps = {
   active?: boolean;
   children: ReactNode;
   prefix?: ReactNode;
+  suffix?: ReactNode;
   label?: ReactNode;
   internalRef: Ref<HTMLDivElement>;
   groupProps?: ReturnType<typeof useDatePicker>['groupProps'];
+  ref?: Ref<HTMLDivElement>;
+  clearable?: DatePickerProps['clearable'];
 } & Pick<ReturnType<typeof useDateField>, 'fieldProps' | 'labelProps'> &
   Pick<
     InputProps,
@@ -30,9 +34,7 @@ export type DateInputProps = {
     | 'required'
     | 'readOnly'
     | 'width'
-  > & {
-    ref?: Ref<HTMLDivElement>;
-  };
+  >;
 
 export function DateInput({
   errorMessage,
@@ -47,10 +49,12 @@ export function DateInput({
   required,
   children,
   prefix: button,
+  suffix: suffixEl,
   labelProps,
   fieldProps,
   groupProps,
   width,
+  clearable,
   ref,
   ...props
 }: DateInputProps) {
@@ -89,7 +93,7 @@ export function DateInput({
           inputStyles[`input--${componentSize}`],
           hasErrorMessage && inputStyles['input--stateful-danger'],
           styles['date-input'],
-          styles[`date-input--${componentSize}`],
+          clearable && styles[`date-input--${componentSize}--clearable`],
           focusStyles['focusable-within'],
           isOpen && focusStyles.focused,
           disabled && 'disabled',
@@ -101,6 +105,7 @@ export function DateInput({
       >
         {button}
         <div className={styles['date-segment-container']}>{children}</div>
+        {suffixEl}
       </Box>
       {hasMessage && (
         <InputMessage

--- a/packages/dds-components/src/components/helpers/ClearButton/ClearButton.tsx
+++ b/packages/dds-components/src/components/helpers/ClearButton/ClearButton.tsx
@@ -8,12 +8,19 @@ import {
   type InlineIconButtonProps,
 } from '../InlineIconButton';
 
-type ClearButtonProps = ComponentPropsWithRef<'button'> &
+type ClearButtonProps = {
+  /**Om knappen bruker `position:absolute` med standard  styling. */
+  absolute?: boolean;
+} & ComponentPropsWithRef<'button'> &
   Pick<InlineIconButtonProps, 'size'>;
 
-export const ClearButton = ({ className, ...rest }: ClearButtonProps) => (
+export const ClearButton = ({
+  className,
+  absolute = true,
+  ...rest
+}: ClearButtonProps) => (
   <InlineIconButton
-    className={cn(className, utilStyles['center-absolute-y'])}
+    className={cn(className, absolute && utilStyles['center-absolute-y'])}
     icon={CloseSmallIcon}
     {...rest}
   />

--- a/packages/dds-components/src/components/helpers/InlineIconButton/InlineIconButton.module.css
+++ b/packages/dds-components/src/components/helpers/InlineIconButton/InlineIconButton.module.css
@@ -3,9 +3,16 @@
   border-radius: var(--dds-border-radius-button);
   color: var(--dds-color-icon-default);
 
-  &:hover {
+  &:hover:not(:disabled) {
     background-color: var(--dds-color-surface-hover-default);
     color: var(--dds-color-icon-action-hover);
+  }
+  &:not(:focus-visible) {
+    outline: none;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
   }
 
   @media (prefers-reduced-motion: no-preference) {


### PR DESCRIPTION
## Beskrivelse

Tømmeknapp som dukker opp ved `clearable` prop; fjerner både fulle verdi og delvis verdi. Usynlig og inaktiv knapp tar plass selv uten verdi slik at bredden ikke hopper.

<img width="321" height="144" alt="image" src="https://github.com/user-attachments/assets/5978ad21-f1ce-4a5a-8dcf-8459c08ef289" />

Fikser i samme slengen:

- At tømmeknapp i `<NativeSelect>` ikke vises ved `disabled` eller `readOnly`.
- Docs: Manglende props i docs props-tabell for `<DatePicker>` og `<TimePicker>`.
- Docs: Bedre JSDoc for `<NativeSelect>` sin `clearable` prop.
- Bytter font til monospace i `<DatePicker>` og `<TimePicker>`, slik at bredden ikke hopper når verdi velges.
- Refaktorerer `<CalendarButton>` til å bruke `<InlineIconButton>` og samtidig standardiserer spacing i `<DatePicker>` og `<TimePicker>`. Fikser små ting som ikke stemte med skissene, som for stor trykkeflate i `<CalendarButton>`.
- Fikser manglende oversettelse i `<Search>`.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
