### PR TITLE
ELSA1-681 Fikser feil spacing i `<TextInput>`

### DIFF
--- a/.changeset/heavy-results-dress.md
+++ b/.changeset/heavy-results-dress.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser spacing mellom tekst og ikon i `<TextInput>`.

--- a/.changeset/solid-ways-dream.md
+++ b/.changeset/solid-ways-dream.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der affikser overlappet med tekst i `<TextInput>`.

--- a/packages/dds-components/src/components/TextInput/TextInput.mdx
+++ b/packages/dds-components/src/components/TextInput/TextInput.mdx
@@ -1,6 +1,7 @@
 import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as TextInputStories from './TextInput.stories';
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
 <Meta of={TextInputStories} />
 
@@ -13,18 +14,47 @@ import * as TextInputStories from './TextInput.stories';
   storybookHref="https://domstolene.github.io/designsystem/?path=/story/dds-components-components-textinput--default"
 />
 
-## Props
+## Eksempler
 
-<Canvas of={TextInputStories.Preview} />
-<Controls of={TextInputStories.Preview} />
+<Tabs>
+  <TabList>
+    <Tab>Preview</Tab>
+    <Tab>Tilsander</Tab>
+    <Tab>Størrelser</Tab>
+    <Tab>maxLength</Tab>
+    <Tab>Ikon</Tab>
+    <Tab>Affiks</Tab>
+    <Tab>Responsiv</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      <Canvas of={TextInputStories.Preview} />
+      <Controls of={TextInputStories.Preview} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={TextInputStories.States} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={TextInputStories.Sizes} />
+    </TabPanel>
+    <TabPanel>
+      Når native attributtet `maxLength` brukes dukker det opp en tegnteller til høyre under inputfeltet:
+      For å ikke vise tegntelleren sett `withCharacterCounter=false`.
 
-### maxLength
+      <Canvas of={TextInputStories.WithCharacterCount} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={TextInputStories.WithIcon} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={TextInputStories.WithAffixes} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={TextInputStories.ResponsiveWidth} />
+    </TabPanel>
 
-Når native attributtet `maxLength` brukes dukker det opp en tegnteller til høyre under inputfeltet:
-
-<Canvas of={TextInputStories.WithCharacterCount} />
-
-For å ikke vise tegntelleren sett `withCharacterCounter=false`.
+  </TabPanels>
+</Tabs>
 
 ## Retningslinjer
 

--- a/packages/dds-components/src/components/TextInput/TextInput.module.css
+++ b/packages/dds-components/src/components/TextInput/TextInput.module.css
@@ -19,13 +19,13 @@
   }
   &.with-icon--small {
     padding-left: calc(
-      var(--dds-spacing-x0-75) + var(--dds-icon-size-small) +
+      var(--dds-spacing-x0-75) + var(--dds-icon-size-medium) +
         var(--dds-spacing-x0-5)
     );
   }
   &.with-icon--xsmall {
     padding-left: calc(
-      var(--dds-spacing-x0-5) + var(--dds-icon-size-medium) +
+      var(--dds-spacing-x0-5) + var(--dds-icon-size-small) +
         var(--dds-spacing-x0-25)
     );
   }

--- a/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
@@ -24,7 +24,6 @@ export default {
     required: { control: 'boolean', table: categoryHtml },
     disabled: { control: 'boolean', table: categoryHtml },
     readOnly: { control: 'boolean', table: categoryHtml },
-    prefix: { control: { type: 'text' } },
     icon: { control: { disable: true } },
     onChange: htmlEventArgType,
   },
@@ -37,33 +36,23 @@ export const Preview: Story = {
   args: { label: 'Label' },
 };
 
-export const Overview: Story = {
+export const States: Story = {
   args: { label: 'Label' },
   render: args => (
     <StoryHStack>
       <StoryVStack>
-        <TextInput {...args} />
-        <TextInput {...args} disabled value="Disabled inputfelt" />
+        <TextInput {...args} disabled value="Disabled" />
+        <TextInput {...args} readOnly value="Readonly" />
+        <TextInput {...args} required value="Påkrevd" />
+      </StoryVStack>
+      <StoryVStack>
+        <TextInput {...args} tip={args.tip ?? 'Dette er en hjelpetekst'} />
         <TextInput
           {...args}
           errorMessage={
             args.errorMessage ?? 'Dette er en feilmelding ved valideringsfeil'
           }
         />
-        <TextInput {...args} icon={MailIcon} />
-        <TextInput {...args} prefix="Prefix" />
-      </StoryVStack>
-      <StoryVStack>
-        <TextInput {...args} required value="Påkrevd inputfelt" />
-        <TextInput {...args} readOnly value="Readonly inputfelt" />
-        <TextInput {...args} tip={args.tip ?? 'Dette er en hjelpetekst'} />
-        <TextInput
-          {...args}
-          autoComplete="off"
-          tip={args.tip ?? 'Dette er en hjelpetekst med en tegnteller'}
-          maxLength={20}
-        />
-        <TextInput {...args} suffix="Suffix" />
       </StoryVStack>
     </StoryHStack>
   ),
@@ -86,6 +75,7 @@ export const Sizes: Story = {
         {INPUT_SIZES.map(size => (
           <TextInput
             {...args}
+            key={size}
             label={labelText(size)}
             componentSize={size}
             icon={MailIcon}
@@ -96,8 +86,11 @@ export const Sizes: Story = {
   ),
 };
 
+export const WithIcon: Story = {
+  args: { label: 'Label', icon: MailIcon },
+};
+
 export const WithAffixes: Story = {
-  args: { label: 'Label' },
   render: args => (
     <StoryVStack>
       <LocalMessage purpose="tips">

--- a/packages/dds-components/src/components/TextInput/TextInput.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.tsx
@@ -50,12 +50,14 @@ export const TextInput = ({
   const [suffixLength, setSuffixLength] = useState(0);
 
   useLayoutEffect(() => {
-    if (prefixRef.current) {
-      setPrefixLength(prefixRef.current.offsetWidth);
-    }
-    if (suffixRef.current) {
-      setSuffixLength(suffixRef.current.offsetWidth);
-    }
+    requestAnimationFrame(() => {
+      if (prefixRef.current) {
+        setPrefixLength(prefixRef.current.offsetWidth);
+      }
+      if (suffixRef.current) {
+        setSuffixLength(suffixRef.current.offsetWidth);
+      }
+    });
   }, [prefix, suffix]);
 
   const onChangeHandler: React.ChangeEventHandler<HTMLInputElement> = (
@@ -117,7 +119,7 @@ export const TextInput = ({
 
   const showRequiredStyling = !!(required || ariaRequired);
 
-  const preffixPaddingInlineStart: Property.PaddingInlineStart | undefined =
+  const prefixPaddingInlineStart: Property.PaddingInlineStart | undefined =
     prefixLength
       ? `calc(var(--dds-spacing-x1) + ${prefixLength}px)`
       : undefined;
@@ -132,16 +134,14 @@ export const TextInput = ({
   if (hasIcon) {
     extendedInput = (
       <Box className={inputStyles['input-group']} width={inputWidth}>
-        {
-          <Icon
-            icon={icon}
-            iconSize={getFormInputIconSize(componentSize)}
-            className={cn(
-              inputStyles['input-group__absolute-element'],
-              styles[`icon--${componentSize}`],
-            )}
-          />
-        }
+        <Icon
+          icon={icon}
+          iconSize={getFormInputIconSize(componentSize)}
+          className={cn(
+            inputStyles['input-group__absolute-element'],
+            styles[`icon--${componentSize}`],
+          )}
+        />
         <StatefulInput
           className={cn(
             styles.input,
@@ -175,7 +175,7 @@ export const TextInput = ({
         )}
         <StatefulInput
           style={{
-            paddingInlineStart: preffixPaddingInlineStart,
+            paddingInlineStart: prefixPaddingInlineStart,
             paddingInlineEnd: suffixPaddingInlineEnd,
           }}
           className={styles['input--extended']}

--- a/packages/dds-components/src/components/TextInput/TextInput.types.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.types.tsx
@@ -1,7 +1,7 @@
 import { type InputProps } from '../helpers/Input';
 import { type SvgIcon } from '../Icon/utils';
 
-export type TextInputProps = InputProps & {
+export type TextInputProps = Omit<InputProps, 'prefix'> & {
   /** Spesifiserer om tegntelleren skal vises ved bruk av `maxLength` attributt. */
   withCharacterCounter?: boolean;
   /** Ikonet som vises i komponenten. */

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DateField/CalendarButton.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DateField/CalendarButton.tsx
@@ -2,7 +2,7 @@ import { type AriaButtonProps, useButton } from '@react-aria/button';
 import { useRef } from 'react';
 
 import type { DateFieldProps } from './DateField';
-import { cn } from '../../../../utils';
+import { cn, getFormInputIconSize } from '../../../../utils';
 import { InlineIconButton } from '../../../helpers/InlineIconButton';
 import { focusable } from '../../../helpers/styling/focus.module.css';
 import { CalendarIcon } from '../../../Icon/icons';
@@ -14,14 +14,12 @@ interface CalendarButtonProps extends AriaButtonProps {
 }
 
 export function CalendarButton({
-  componentSize,
+  componentSize = 'medium',
   isReadOnly,
   ...props
 }: CalendarButtonProps) {
   const ref = useRef<HTMLButtonElement>(null);
   const { buttonProps } = useButton(props, ref);
-
-  const size = componentSize === 'xsmall' ? 'small' : 'medium';
 
   return (
     <InlineIconButton
@@ -35,7 +33,7 @@ export function CalendarButton({
         !props.isDisabled && focusable,
       )}
       icon={CalendarIcon}
-      size={size}
+      size={getFormInputIconSize(componentSize)}
     />
   );
 }

--- a/packages/dds-components/src/utils/icon.ts
+++ b/packages/dds-components/src/utils/icon.ts
@@ -1,7 +1,13 @@
 import { type InputSize } from '../components/helpers/Input';
-import { type IconSize } from '../components/Icon';
+import { createSizes } from '../types';
 
-export const getFormInputIconSize = (componentSize: InputSize): IconSize => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const INPUT_ICON_SIZES = createSizes('large', 'medium', 'small');
+type InputIconSize = (typeof INPUT_ICON_SIZES)[number];
+
+export const getFormInputIconSize = (
+  componentSize: InputSize,
+): InputIconSize => {
   switch (componentSize) {
     case 'medium':
       return 'medium';


### PR DESCRIPTION
## Beskrivelse

Fikser feil spacing mellom ikon og tekst.

Før: 
<img width="427" height="90" alt="image" src="https://github.com/user-attachments/assets/19ab434c-c5ab-474d-8205-55db48cd0757" />

Etter:
<img width="435" height="92" alt="image" src="https://github.com/user-attachments/assets/16d87523-c415-4705-8fa5-a30a36c3fb7b" />

I samme slengen:
- Fikser bug der prefiks og suffiks overlappet med tekst i `<TextInput>`.
- Ekskluderer native HTML attributt `prefix` fra `type TextInputProps`. Den er ikke relevant, og da krangler den ikke med custom  `prefix` prop i args-tabellen i docs.
- Migrerer `TextInput.mdx` til å bruke `<Tabs>` med relevante eksempler. Skal gradvis migrere alle relevante komponenter.
- Fikser typo i `const prefixPaddingInlineStart`.
- Refaktorerer `getFormInputIconSize()` for bedre gjenbruk; tar den i bruk i `<DatePicker>`.


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
