### PR TITLE
ELSA1-685 Refaktorerer styling i `<ProgressTracker>`

### DIFF
--- a/.changeset/neat-plants-film.md
+++ b/.changeset/neat-plants-film.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Endrer farge på standard tekst i `<ProgressTracker>`. Fjerner custom lenke-styling og gjenbruker standard.

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.mdx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.mdx
@@ -1,10 +1,12 @@
 import { ArgTypes, Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as ProgressTrackerStories from './ProgressTracker.stories';
+import * as ProgressTrackerFormStories from './ProgressTrackerForm.stories';
 import { ProgressTracker, ProgressTrackerItem } from '.';
 import {
   Source,
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
 <Meta of={ProgressTrackerStories} />
 
@@ -18,44 +20,97 @@ import {
   withBottomSpacing
 />
 
-Komponenten består av:
+## Delkomponenter
 
-- `<ProgressTracker>` - ytterste container for andre subkomponenter. Håndterer oppførsel og eventuelt litt styling. Har to eller flere `<ProgressTracker.Item>` som barn.
-- `<ProgressTracker.Item>` - et steg. Ikke-compound variant er også støttet: `<ProgressTrackerItem>`.
+<Tabs>
+  <TabList>
+    <Tab>ProgressTracker</Tab>
+    <Tab>ProgressTracker.Item</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      Ytterste container som styrer hvilket steg skal vises via indeks. Har to eller flere `<ProgressTracker.Item>` som barn. Håndterer oppførsel og eventuelt litt styling.
+      <Canvas of={ProgressTrackerStories.Preview} />
+      <Controls of={ProgressTrackerStories.Preview} />
+    </TabPanel>
+    <TabPanel>
+      Et steg. Ikke-compound variant er også støttet: `<ProgressTrackerItem>`.
 
-## Props
+      <ArgTypes of={ProgressTrackerItem} />
+    </TabPanel>
 
-### ProgressTracker
-
-Ytterste container som styrer hvilket steg skal vises via indeks. Har to eller flere `<ProgressTracker.Item>` som barn.
-
-<Canvas of={ProgressTrackerStories.Preview} />
-<Controls of={ProgressTrackerStories.Preview} />
-
-### ProgressTracker.Item
-
-Et steg.
-
-<ArgTypes of={ProgressTrackerItem} />
+  </TabPanels>
+</Tabs>
 
 ## Bruk
 
 <Source
-  code={`import { ProgressTracker } from '.';
+  code={`
+const [activeStep, setActiveStep] = useState(0);
+const [completedSteps, setCompletedSteps] = useState(new Set());
 
-function handleProgressTrackerItemClick(index: number) {
-console.log(index)
+function handleCompleted() {
+// ...din kode for fullført steg...
+setCompletedSteps(s => new Set([...s, activeStep]));
 }
 
-<ProgressTracker activeStep={activeStep}>
-  <ProgressTracker.Item completed onClick={handleProgressTrackerItemClick}>
-    Parter
-  </ProgressTracker.Item>
-  <ProgressTracker.Item active onClick={handleProgressTrackerItemClick}>
-    Slutning
-  </ProgressTracker.Item>
-  <ProgressTracker.Item onClick={handleProgressTrackerItemClick}>
-    Vedlegg
-  </ProgressTracker.Item>
-</ProgressTracker>
-`} />
+function onStepChange(index: number) {
+handleCompleted();
+setActiveStep(index);
+}
+
+return (
+
+<div>
+  <ProgressTracker
+    activeStep={activeStep}
+    onStepChange={step => onStepChange(step)}
+  >
+    <ProgressTracker.Item completed={completedSteps.has(0)}>
+      Steg 1
+    </ProgressTracker.Item>
+    <ProgressTracker.Item completed={completedSteps.has(1)}>
+      Steg 2
+    </ProgressTracker.Item>
+    <ProgressTracker.Item> Sammendrag </ProgressTracker.Item>
+  </ProgressTracker>
+  <div>
+    {activeStep === 0 && <div> Steg 1 </div>}
+    {activeStep === 1 && <div> Steg 2 </div>}
+    {activeStep === 2 && <div> Sammendrag </div>}
+  </div>
+</div>
+) `} />
+
+## Eksempler
+
+<Tabs>
+  <TabList>
+    <Tab>Med ikoner</Tab>
+    <Tab>Horisontal</Tab>
+    <Tab>Liten skjerm</Tab>
+    <Tab>Skjema</Tab>
+    <Tab>Skjema custom grid</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      <Canvas of={ProgressTrackerStories.WithIcons} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={ProgressTrackerStories.Horisontal} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={ProgressTrackerStories.SmallScreen} />
+    </TabPanel>
+    <TabPanel>
+      Se detaljer i [Patterns |
+      Form](https://domstolene.github.io/designsystem/?path=/docs/patterns-form--docs).
+      <Canvas of={ProgressTrackerFormStories.FormWithSteps} />
+    </TabPanel>
+    <TabPanel>
+      Se detaljer i [Patterns |
+      Form](https://domstolene.github.io/designsystem/?path=/docs/patterns-form--docs).
+      <Canvas of={ProgressTrackerFormStories.FormWithStepsCustomGrid} />
+    </TabPanel>
+  </TabPanels>
+</Tabs>

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.module.css
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.module.css
@@ -1,6 +1,10 @@
 .list {
   --dds-progress-tracker-connector-width: 1px;
   --dds-progress-tracker-item-number-size: 1.75rem;
+  --dds-progress-tracker-item-margin: calc(
+    (var(--dds-progress-tracker-item-number-size) / 2) -
+      (var(--dds-progress-tracker-connector-width) / 2)
+  );
 }
 
 .list-item:not(:first-child)::before {
@@ -13,10 +17,7 @@
     var(--dds-color-border-default);
   width: var(--dds-progress-tracker-connector-width);
   height: 1.125rem;
-  margin-left: calc(
-    (var(--dds-progress-tracker-item-number-size) / 2) -
-      (var(--dds-progress-tracker-connector-width) / 2)
-  );
+  margin-left: var(--dds-progress-tracker-item-margin);
   margin-bottom: var(--dds-spacing-x0-125);
 }
 
@@ -25,24 +26,12 @@
     var(--dds-color-border-default);
   height: var(--dds-progress-tracker-connector-width);
   width: 1.875rem;
-  margin-top: calc(
-    (var(--dds-progress-tracker-item-number-size) / 2) -
-      (var(--dds-progress-tracker-connector-width) / 2)
-  );
+  margin-top: var(--dds-progress-tracker-item-margin);
   margin-right: var(--dds-spacing-x0-5);
 }
 
 .item-button {
-  background: none;
-  border: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
   grid-template-columns: var(--dds-progress-tracker-item-number-size) 1fr;
-  justify-content: flex-start;
-  align-items: center;
-  font-family: inherit;
-  gap: var(--dds-spacing-x0-5);
   cursor: pointer;
 
   @media (prefers-reduced-motion: no-preference) {
@@ -66,18 +55,6 @@
     background-color: var(--dds-color-surface-action-hover);
     border-color: var(--dds-color-border-action-hover);
     color: var(--dds-color-icon-on-action);
-  }
-
-  &:hover > .item-text--active-completed,
-  &:hover > .item-text--active-incomplete {
-    color: var(--dds-color-text-action-resting);
-    text-decoration-color: transparent;
-  }
-
-  &:hover > .item-text--inactive-completed,
-  &:hover > .item-text--inactive-incomplete {
-    color: var(--dds-color-text-action-hover);
-    text-decoration-color: var(--dds-color-text-action-hover);
   }
 
   &:disabled {
@@ -126,24 +103,9 @@
 }
 
 .item-text {
-  text-decoration: underline;
   text-align: start;
-  transition: text-decoration-color 0.2s;
 }
 
-.item-text--disabled {
-  color: var(--dds-color-text-subtle);
+.item-text--inactive-link {
   text-decoration-color: transparent;
-}
-
-.item-text--active-completed,
-.item-text--active-incomplete {
-  color: var(--dds-color-text-action-resting);
-  text-decoration-color: transparent;
-}
-
-.item-text--inactive-completed,
-.item-text--inactive-incomplete {
-  color: var(--dds-color-text-medium);
-  text-decoration-color: var(--dds-color-text-medium);
 }

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
@@ -47,13 +47,13 @@ export const Preview: Story = {
           htmlProps={{ style: { maxWidth: '800px' } }}
         >
           <ProgressTracker.Item completed={completedSteps.has(0)}>
-            Parter
+            Steg 1
           </ProgressTracker.Item>
           <ProgressTracker.Item completed={completedSteps.has(1)}>
-            Slutning
+            Steg 2
           </ProgressTracker.Item>
           <ProgressTracker.Item completed={completedSteps.has(2)}>
-            Vedlegg
+            Steg 3
           </ProgressTracker.Item>
           <ProgressTracker.Item completed={completedSteps.has(3)} disabled>
             Sammendrag
@@ -64,7 +64,7 @@ export const Preview: Story = {
           {activeStep === 0 && <div>Steg 1</div>}
           {activeStep === 1 && <div>Steg 2</div>}
           {activeStep === 2 && <div>Steg 3</div>}
-          {activeStep === 3 && <div>Steg 4</div>}
+          {activeStep === 3 && <div>Sammendrag</div>}
         </div>
 
         <Button
@@ -100,19 +100,19 @@ export const WithIcons: Story = {
             icon={PersonIcon}
             completed={completedSteps.has(0)}
           >
-            Parter
+            Steg 1
           </ProgressTracker.Item>
           <ProgressTracker.Item
             icon={GavelIcon}
             completed={completedSteps.has(1)}
           >
-            Slutning
+            Steg 2
           </ProgressTracker.Item>
           <ProgressTracker.Item
             icon={AttachmentIcon}
             completed={completedSteps.has(2)}
           >
-            Vedlegg
+            Steg 3
           </ProgressTracker.Item>
           <ProgressTracker.Item
             icon={ChecklistIcon}
@@ -159,13 +159,13 @@ export const Horisontal: Story = {
           onStepChange={step => setActiveStep(step)}
         >
           <ProgressTracker.Item completed={completedSteps.has(0)}>
-            Parter
+            Steg 1
           </ProgressTracker.Item>
           <ProgressTracker.Item completed={completedSteps.has(1)}>
-            Slutning
+            Steg 2
           </ProgressTracker.Item>
           <ProgressTracker.Item completed={completedSteps.has(2)}>
-            Vedlegg
+            Steg 3
           </ProgressTracker.Item>
           <ProgressTracker.Item completed={completedSteps.has(3)} disabled>
             Sammendrag
@@ -223,19 +223,19 @@ export const FutureStepsDisabled: Story = {
             disabled={isDisabled(0)}
             completed={completedSteps.has(0)}
           >
-            Parter
+            Steg 1
           </ProgressTracker.Item>
           <ProgressTracker.Item
             disabled={isDisabled(1)}
             completed={completedSteps.has(1)}
           >
-            Slutning
+            Steg 2
           </ProgressTracker.Item>
           <ProgressTracker.Item
             disabled={isDisabled(2)}
             completed={completedSteps.has(2)}
           >
-            Vedlegg
+            Steg 3
           </ProgressTracker.Item>
         </ProgressTracker>
         <div>
@@ -290,13 +290,13 @@ export const SmallScreen: Story = {
                 }}
               >
                 <ProgressTracker.Item completed={completedSteps.has(0)}>
-                  Parter med lang tekst
+                  Steg 1 med lang tekst
                 </ProgressTracker.Item>
                 <ProgressTracker.Item completed={completedSteps.has(1)}>
-                  Slutning
+                  Steg 2
                 </ProgressTracker.Item>
                 <ProgressTracker.Item completed={completedSteps.has(2)}>
-                  Vedlegg
+                  Steg 3
                 </ProgressTracker.Item>
                 <ProgressTracker.Item
                   completed={completedSteps.has(3)}

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTrackerForm.stories.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTrackerForm.stories.tsx
@@ -1,0 +1,12 @@
+export {
+  FormWithSteps,
+  FormWithStepsCustomGrid,
+} from '../../../stories/patterns/Form/Form.stories';
+
+export default {
+  title: 'dds-components/Components/ProgressTracker',
+  parameters: {
+    layout: 'fullscreen',
+    docs: { canvas: { inline: false } },
+  },
+};

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTrackerItem.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTrackerItem.tsx
@@ -7,12 +7,14 @@ import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../types';
-import { cn } from '../../utils';
+import { type TextColor, cn } from '../../utils';
+import { StylelessButton } from '../helpers';
 import { focusable } from '../helpers/styling/focus.module.css';
 import { Icon } from '../Icon';
 import { CheckIcon } from '../Icon/icons';
 import { type SvgIcon } from '../Icon/utils';
 import { Box } from '../layout';
+import { Typography } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 import { VisuallyHidden } from '../VisuallyHidden';
 
@@ -126,6 +128,13 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
     return index + 1;
   }, [completed, icon, index]);
 
+  function getTextColor(): TextColor | undefined {
+    if (disabled) return 'text-subtle';
+    if (active) return 'text-action-resting';
+  }
+
+  const isInactiveLink = disabled || active;
+
   const stepContent = (
     <>
       <Box
@@ -141,19 +150,21 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
       >
         {stepNumberContent}
       </Box>
-      <div
+      <Typography
+        as="div"
         className={cn(
           styles['item-text'],
-          styles[`item-text--${itemStateCn[itemState]}`],
-          typographyStyles['body-medium'],
+          typographyStyles['a--nested__child'],
+          isInactiveLink && styles['item-text--inactive-link'],
         )}
+        color={getTextColor()}
       >
         <VisuallyHidden>{t(texts.stepTextBefore(index + 1))}</VisuallyHidden>
         {children}
         <VisuallyHidden>
           {completed ? t(texts.completed) : t(texts.uncompleted)}
         </VisuallyHidden>
-      </div>
+      </Typography>
     </>
   );
 
@@ -165,10 +176,20 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
       className={cn(styles['list-item'], styles[`list-item--${direction}`])}
     >
       {handleStepChange ? (
-        <button
+        <Box
+          as={StylelessButton}
+          display="grid"
+          alignItems="center"
+          justifyContent="flex-start"
+          gap="x0.5"
           {...getBaseHTMLProps(
             id,
-            cn(className, styles['item-button'], focusable),
+            cn(
+              className,
+              styles['item-button'],
+              typographyStyles['a--nested__parent'],
+              focusable,
+            ),
             htmlProps as ComponentPropsWithRef<'button'>,
             rest,
           )}
@@ -176,7 +197,7 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
           disabled={disabled}
         >
           {stepContent}
-        </button>
+        </Box>
       ) : (
         <div
           {...getBaseHTMLProps(

--- a/packages/dds-components/src/components/Typography/typographyStyles.module.css
+++ b/packages/dds-components/src/components/Typography/typographyStyles.module.css
@@ -23,7 +23,8 @@
   --dds-color-icon-action-hover-inversable: var(--dds-color-icon-on-inverse);
 }
 
-:where(.a) {
+:where(.a),
+:where(.a--nested__parent .a--nested__child) {
   font: inherit;
   color: var(--dds-color-text-link);
   width: fit-content;


### PR DESCRIPTION
## Beskrivelse

- Fjerner custom styling for lenke og gjenbruker standard.
- Fikser tekstfarge.
- Migrerer `ProgressTracker.mdx` til visning med `<Tabs>`.
- Inkluderer Form-mønsteret i eksempler.

Før:
<img width="259" height="310" alt="image" src="https://github.com/user-attachments/assets/5f546c98-dbe5-457f-9413-69aa1e5a6ca6" />

Etter:
<img width="297" height="331" alt="image" src="https://github.com/user-attachments/assets/2d7bd478-4d0a-4915-a627-a02a512a6209" />

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
