### PR TITLE
ELSA1-643 Støtte for `color` prop i `<InlineButton>`

### DIFF
--- a/.changeset/sour-ducks-drum.md
+++ b/.changeset/sour-ducks-drum.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for `color` prop i `<InlineButton>`. Fungerer som i typografikomponenter; støtter alle tekstfarger fra `@dds-design-tokens` i kebab-case, eller custom.

--- a/packages/dds-components/src/components/InlineButton/InlineButton.mdx
+++ b/packages/dds-components/src/components/InlineButton/InlineButton.mdx
@@ -1,6 +1,8 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as InlineButtontories from './InlineButton.stories';
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
+import { LocalMessage } from '../LocalMessage';
 
 <Meta of={InlineButtontories} />
 
@@ -16,11 +18,22 @@ import * as InlineButtontories from './InlineButton.stories';
 
 **OBS!** Ikke bruk komponenten som en lenke.
 
-## Props
-
-<Canvas of={InlineButtontories.Preview} />
-<Controls of={InlineButtontories.Preview} />
-
-## Eksempel
-
-<Canvas of={InlineButtontories.Example} />
+<Tabs>
+  <TabList>
+    <Tab>Preview</Tab>
+    <Tab>Tekstfarge</Tab>
+    <Tab>I liste</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      <Canvas of={InlineButtontories.Preview} />
+      <Controls of={InlineButtontories.Preview} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={InlineButtontories.WithColor} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={InlineButtontories.Example} />
+    </TabPanel>
+  </TabPanels>
+</Tabs>

--- a/packages/dds-components/src/components/InlineButton/InlineButton.stories.tsx
+++ b/packages/dds-components/src/components/InlineButton/InlineButton.stories.tsx
@@ -26,6 +26,13 @@ export const Preview: Story = {
   },
 };
 
+export const WithColor: Story = {
+  args: {
+    children: 'Vis mer',
+    color: 'text-subtle',
+  },
+};
+
 export const Example: Story = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: args => {

--- a/packages/dds-components/src/components/InlineButton/InlineButton.tsx
+++ b/packages/dds-components/src/components/InlineButton/InlineButton.tsx
@@ -4,17 +4,24 @@ import styles from './InlineButton.module.css';
 import { cn } from '../../utils';
 import { StylelessButton } from '../helpers';
 import focusStyles from '../helpers/styling/focus.module.css';
+import { type BaseTypographyProps, getColorCn } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
-export type InlineButtonProps = ComponentPropsWithRef<'button'>;
+export type InlineButtonProps = Pick<BaseTypographyProps, 'color'> &
+  Omit<ComponentPropsWithRef<'button'>, 'color'>;
 
-export const InlineButton = ({ className, ...rest }: InlineButtonProps) => (
+export const InlineButton = ({
+  className,
+  color,
+  ...rest
+}: InlineButtonProps) => (
   <StylelessButton
     className={cn(
       className,
       focusStyles.focusable,
       typographyStyles.a,
       styles.button,
+      getColorCn(color),
     )}
     {...rest}
   />


### PR DESCRIPTION
## Beskrivelse

Støtter farger fra `@dds-design-tokens` + custom. Migrerer `<InlineButton>` Storybook docs til `<Tabs>`-visning.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
