### PR TITLE
ELSA1-686 Ledende 0 bug i `<DatePicker>`

### DIFF
--- a/.changeset/brave-jokes-press.md
+++ b/.changeset/brave-jokes-press.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der man ikke kunne skrive ledende 0 i `<DatePicker>` for dag og måned.

--- a/packages/dds-components/src/components/date-inputs/common/DateInput.tsx
+++ b/packages/dds-components/src/components/date-inputs/common/DateInput.tsx
@@ -82,9 +82,7 @@ export function DateInput({
         </Label>
       )}
       <Box
-        {...fieldProps}
         style={style}
-        ref={internalRef}
         width={getInputWidth(width, 'fit-content')}
         className={cn(
           inputStyles.input,
@@ -104,7 +102,13 @@ export function DateInput({
         )}
       >
         {button}
-        <div className={styles['date-segment-container']}>{children}</div>
+        <div
+          {...fieldProps}
+          ref={internalRef}
+          className={styles['date-segment-container']}
+        >
+          {children}
+        </div>
         {suffixEl}
       </Box>
       {hasMessage && (


### PR DESCRIPTION
## Beskrivelse

Segment for dag og måned aksepterte ikke ledende 0, og da kunne bruker ikke skrive f.eks. "01" for å få januar måned.

Feilen var at `fieldProps` og `ref` ble satt på feil wrapper; flytter de til fordelderen til segmentene.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
