### PR TITLE
ELSA1-688 Vise theme-avhengige tokens i `<Tabs>`

### DIFF
--- a/stories/Tokens/Tokens.stories.tsx
+++ b/stories/Tokens/Tokens.stories.tsx
@@ -10,9 +10,16 @@ import {
   ShadowsGenerator,
   SpacingGenerator,
   TypographyGenerator,
-  wrapperStyle,
+  Wrapper,
 } from './utils';
 import { ZIndexGenerator } from './utils/ZIndexGenerator';
+import {
+  Tabs,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+} from '../../packages/dds-components/src';
 
 const meta: Meta = {
   title: 'dds-design-tokens/Tokens',
@@ -24,54 +31,66 @@ export default meta;
 
 export const BorderRadius = () => {
   return (
-    <div style={wrapperStyle}>
-      <h2>Core</h2>
-      {BorderRadiusGenerator('core')}
-      <h2>Public</h2>
-      {BorderRadiusGenerator('public')}
-    </div>
+    <Wrapper>
+      <Tabs>
+        <TabList>
+          <Tab>Core</Tab>
+          <Tab>Public</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>{BorderRadiusGenerator('core')}</TabPanel>
+          <TabPanel>{BorderRadiusGenerator('public')}</TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Wrapper>
   );
 };
 
 export const Breakpoints = () => {
-  return <div style={wrapperStyle}> {BreakpointsGenerator()}</div>;
+  return <Wrapper> {BreakpointsGenerator()}</Wrapper>;
 };
 
 export const Colors = () => {
-  return <div style={wrapperStyle}> {ColorsGenerator()}</div>;
+  return <Wrapper> {ColorsGenerator()}</Wrapper>;
 };
 
 export const ColorsDataVisualisation = () => {
-  return <div style={wrapperStyle}> {DataColorsGenerator()}</div>;
+  return <Wrapper> {DataColorsGenerator()}</Wrapper>;
 };
 
 export const Grid = () => {
-  return <div style={wrapperStyle}> {GridGenerator()}</div>;
+  return <Wrapper> {GridGenerator()}</Wrapper>;
 };
 
 export const IconSizes = () => {
-  return <div style={wrapperStyle}> {IconSizesGenerator()}</div>;
+  return <Wrapper> {IconSizesGenerator()}</Wrapper>;
 };
 
 export const Shadows = () => {
-  return <div style={wrapperStyle}> {ShadowsGenerator()}</div>;
+  return <Wrapper> {ShadowsGenerator()}</Wrapper>;
 };
 
 export const Spacing = () => {
-  return <div style={wrapperStyle}> {SpacingGenerator()}</div>;
+  return <Wrapper> {SpacingGenerator()}</Wrapper>;
 };
 
 export const Typography = () => {
   return (
-    <div style={{ maxWidth: '120ch', marginInline: 'auto' }}>
-      <h2>Core</h2>
-      {TypographyGenerator('core')}
-      <h2>Public</h2>
-      {TypographyGenerator('public')}
-    </div>
+    <Wrapper maxWidth="120ch">
+      <Tabs>
+        <TabList>
+          <Tab>Core</Tab>
+          <Tab>Public</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>{TypographyGenerator('core')}</TabPanel>
+          <TabPanel>{TypographyGenerator('public')}</TabPanel>
+        </TabPanels>
+      </Tabs>
+    </Wrapper>
   );
 };
 
 export const ZIndex = () => {
-  return <div style={wrapperStyle}> {ZIndexGenerator()}</div>;
+  return <Wrapper> {ZIndexGenerator()}</Wrapper>;
 };

--- a/stories/Tokens/utils/functions.tsx
+++ b/stories/Tokens/utils/functions.tsx
@@ -2,7 +2,11 @@ import React from 'react';
 
 import { copyButton } from './CopyButton';
 import { type TokenGenericJsonObject } from './Tokens.types';
-import { Table } from '../../../packages/dds-components/src';
+import {
+  Box,
+  type BoxProps,
+  Table,
+} from '../../../packages/dds-components/src';
 
 export function splitReferenceKeys(v: string): Array<string> {
   return v.replace(/\{|\}/g, '').split('.');
@@ -15,6 +19,12 @@ export function isReferencedValue(v: string): boolean {
 export function underscoreToDash(v: string): string {
   return v.replace('_', '-');
 }
+
+export const Wrapper = (props: BoxProps) => (
+  <Box maxWidth={props.maxWidth ? props.maxWidth : '90ch'} marginInline="auto">
+    {props.children}
+  </Box>
+);
 
 export const tableStyle = {
   marginBottom: 'var(--dds-spacing-x1-5)',


### PR DESCRIPTION
## Beskrivelse


Gjør visningen av tokens i Storybook oversiktlig ved å bruke `<Tabs>`. Gjelder `borderRadius` og `typography`.

Ser slik ut:

<img width="1345" height="709" alt="image" src="https://github.com/user-attachments/assets/223adf45-73d6-4adf-b2f8-6d8b0a106fdd" />


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
