### PR TITLE
ELSA1-379 `<LocalMessage>` Storybook eksempel med ekstra knapp

### DIFF
--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.mdx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.mdx
@@ -1,6 +1,7 @@
 import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as LocalMessageStories from './LocalMessage.stories';
+import { Tabs, Tab, TabList, TabPanels, TabPanel } from '../Tabs';
 
 <Meta of={LocalMessageStories} />
 
@@ -11,9 +12,40 @@ import * as LocalMessageStories from './LocalMessage.stories';
   figmaHref="https://www.figma.com/file/ewqSDmkgqDQ5PyOsRp4V5b/?node-id=155%3A39"
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/LocalMessage"
   storybookHref="https://domstolene.github.io/designsystem/?path=/story/dds-components-components-localmessage--default"
+  withBottomSpacing
 />
 
-## Props
-
-<Canvas of={LocalMessageStories.Preview} />
-<Controls of={LocalMessageStories.Preview} />
+<Tabs>
+  <TabList>
+    <Tab>Preview</Tab>
+    <Tab>Closable</Tab>
+    <Tab>Vertical</Tab>
+    <Tab>Extra button</Tab>
+    <Tab>Complex</Tab>
+    <Tab>Responsive</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      <Canvas of={LocalMessageStories.Preview} />
+      <Controls of={LocalMessageStories.Preview} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={LocalMessageStories.Closable} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={LocalMessageStories.Vertical} />
+    </TabPanel>
+    <TabPanel>
+      Knappen skal stilles ved siden av lukkeknappen, ha samme størrelse som den
+      og `'secondary'` som formål. Bruk gjerne layout primitives for å oppnå
+      dette oppsettet.
+      <Canvas of={LocalMessageStories.WithExtraButton} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={LocalMessageStories.ComplexContent} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={LocalMessageStories.ResponsiveWidth} />
+    </TabPanel>
+  </TabPanels>
+</Tabs>

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
@@ -7,6 +7,8 @@ import {
   responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
+import { Button } from '../Button';
+import { HStack } from '../layout';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { List, ListItem } from '../List';
 import { Heading, Paragraph } from '../Typography';
@@ -58,6 +60,33 @@ export const Overview: Story = {
 export const Closable: Story = {
   args: {
     children: 'Dette er en lokal melding',
+    closable: true,
+  },
+};
+
+export const Vertical: Story = {
+  args: {
+    children: 'Dette er en lokal melding',
+    layout: 'vertical',
+  },
+  render: args => (
+    <StoryHStack>
+      <LocalMessage {...args} />
+      <LocalMessage {...args} closable />
+    </StoryHStack>
+  ),
+};
+
+export const WithExtraButton: Story = {
+  args: {
+    children: (
+      <HStack justifyContent="space-between" gap="x0.75">
+        <span>Dette er en melding</span>
+        <Button size="xsmall" purpose="secondary">
+          Angre
+        </Button>
+      </HStack>
+    ),
     closable: true,
   },
 };


### PR DESCRIPTION
## Beskrivelse

Lager et eksempel som bygger opp riktig layout. Migrerer `<LocalMessage>` til `<Tabs>` visning i samme slengen.

<img width="1209" height="108" alt="image" src="https://github.com/user-attachments/assets/15c7f676-7c9d-4b9a-b3d1-37042576f6d3" />


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
