### PR TITLE
ELSA1-691: Sett type til "button" for ClearButton og InlineIconButton

### DIFF
--- a/.changeset/fuzzy-bobcats-obey.md
+++ b/.changeset/fuzzy-bobcats-obey.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Sett type til "button" for ClearButton i DatePicker

--- a/packages/dds-components/src/components/helpers/ClearButton/ClearButton.tsx
+++ b/packages/dds-components/src/components/helpers/ClearButton/ClearButton.tsx
@@ -22,6 +22,7 @@ export const ClearButton = ({
   <InlineIconButton
     className={cn(className, absolute && utilStyles['center-absolute-y'])}
     icon={CloseSmallIcon}
+    type="button"
     {...rest}
   />
 );

--- a/packages/dds-components/src/components/helpers/InlineIconButton/InlineIconButton.tsx
+++ b/packages/dds-components/src/components/helpers/InlineIconButton/InlineIconButton.tsx
@@ -24,6 +24,7 @@ export const InlineIconButton = ({
   <StylelessButton
     className={cn(className, styles.button, focusable)}
     {...rest}
+    type="button"
   >
     <Icon icon={icon} iconSize={size} color={color} />
   </StylelessButton>


### PR DESCRIPTION
Default er "submit", noe som gjør at skjema blir submitted når ClearButton trykkes

## Beskrivelse

_Denne PRen endrer..._

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
