### PR TITLE
ELSA1-684 Small screen spacing i `<DetailList>`

### DIFF
--- a/.changeset/shy-chicken-float.md
+++ b/.changeset/shy-chicken-float.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser spacing i `<DetailList>` i variant for mindre skjermer.

--- a/packages/dds-components/src/components/DetailList/DetailList.mdx
+++ b/packages/dds-components/src/components/DetailList/DetailList.mdx
@@ -5,6 +5,7 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as DetailListStories from './DetailList.stories';
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
 <Meta of={DetailListStories} />
 
@@ -18,34 +19,61 @@ import * as DetailListStories from './DetailList.stories';
   withBottomSpacing
 />
 
-Detaljert liste er en beskrivelsesliste formatert som en tabell. Den bygges med følgende subkomponenter:
+Detaljert liste er en beskrivelsesliste formatert som en tabell.
 
-- **`<DetailList>`**: tilsvarer `<dl>`, hele listen.
-- **`<DetailListRow>`**: en rad. Oppfører seg som en tabellrad.
-- **`<DetailListTerm>`**: tilsvarer `<dt>`, uttrykk eller ledetekst. Oppfører seg som en tabellcelle.
-- **`<DetailListDesc>`**: tilsvarer `<dd>`, verdi, beskrivelse, knapp eller lenke relatert til `<DetailListTerm>`. Oppfører seg som en tabellcelle.
+## Delkomponenter
 
-## Props
+<Tabs>
+  <TabList>
+    <Tab>DetailList</Tab>
+    <Tab>DetailListRow</Tab>
+    <Tab>DetailListTerm</Tab>
+    <Tab>DetailListDesc</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      Tilsvarer `<dl>`.
 
-### DetailList
+      <Canvas of={DetailListStories.Preview} sourceState="shown" />
+      <Controls of={DetailListStories.Preview} />
+    </TabPanel>
+    <TabPanel>
+      Subkomponent som grupperer `<DetailListTerm>` og `<DetailListDesc>` i en rad. Reurnerer `<div>`. Oppfører seg som en tabellrad. Støtter native props.
+    </TabPanel>
+    <TabPanel>
+      Tilsvarer `<dt>`. Oppfører seg som en tabellcelle. Støtter native props.
+    </TabPanel>
+    <TabPanel>
+      Tilsvarer `<dd>`. Oppfører seg som en tabellcelle. Støtter native props.
+    </TabPanel>
 
-Tilsvarer `<dl>`.
+  </TabPanels>
+</Tabs>
 
-<Canvas of={DetailListStories.Preview} sourceState="shown" />
-<Controls of={DetailListStories.Preview} />
+## Eksempler
 
-### DetailListTerm
-
-Tilsvarer `<dt>`. Oppfører seg som en tabellcelle. Støtter native props.
-
-### DetailListDesc
-
-Tilsvarer `<dd>`. Oppfører seg som en tabellcelle. Støtter native props.
-
-### DetailListRow
-
-Subkomponent som grupperer `<DetailListTerm>` og `<DetailListDesc>` i en rad. Oppfører seg som en tabellrad. Støtter native props.
-
+<Tabs>
+  <TabList>
+    <Tab>Small</Tab>
+    <Tab>Large</Tab>
+    <Tab>SmallScreen</Tab>
+    <Tab>Responsive</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      <Canvas of={DetailListStories.Small} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={DetailListStories.Large} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={DetailListStories.SmallScreen} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={DetailListStories.Responsive} />
+    </TabPanel>
+  </TabPanels>
+</Tabs>
 ## Retningslinjer
 
 ### Layout

--- a/packages/dds-components/src/components/DetailList/DetailList.module.css
+++ b/packages/dds-components/src/components/DetailList/DetailList.module.css
@@ -40,7 +40,8 @@
 .list--small {
   font: var(--dds-font-body-small);
   letter-spacing: var(--dds-font-body-small-letter-spacing);
-  .cell {
+  dt,
+  dd {
     padding: var(--dds-spacing-x0-5);
   }
 }
@@ -48,7 +49,8 @@
 .list--medium {
   font: var(--dds-font-body-medium);
   letter-spacing: var(--dds-font-body-medium-letter-spacing);
-  .cell {
+  dt,
+  dd {
     padding: var(--dds-spacing-x0-75);
   }
 }
@@ -56,7 +58,8 @@
 .list--large {
   font: var(--dds-font-body-medium);
   letter-spacing: var(--dds-font-body-medium-letter-spacing);
-  .cell {
+  dt,
+  dd {
     padding-block: var(--dds-spacing-x1-5);
     padding-inline: var(--dds-spacing-x0-75);
   }
@@ -67,6 +70,17 @@
   dd {
     margin-inline-start: 0;
     text-align: left;
+  }
+  dt {
+    padding-block-end: var(--dds-spacing-x0-125);
+  }
+
+  dd:not(:last-of-type) {
+    padding-block: var(--dds-spacing-x0-125);
+  }
+
+  dd:last-of-type {
+    padding-block-start: var(--dds-spacing-x0-125);
   }
 }
 

--- a/packages/dds-components/src/components/DetailList/DetailList.stories.tsx
+++ b/packages/dds-components/src/components/DetailList/DetailList.stories.tsx
@@ -11,6 +11,14 @@ export default {
   argTypes: {
     ...commonArgTypes,
   },
+  decorators: [
+    Story => (
+      <>
+        <Story />
+        <style>{styling}</style>
+      </>
+    ),
+  ],
 } satisfies Meta<typeof DetailList>;
 
 type Story = StoryObj<typeof DetailList>;
@@ -77,26 +85,10 @@ const children = [
 ];
 
 export const Preview: Story = {
-  decorators: [
-    Story => (
-      <>
-        <Story />
-        <style>{styling}</style>
-      </>
-    ),
-  ],
   render: args => <DetailList {...args}>{children}</DetailList>,
 };
 
 export const Small: Story = {
-  decorators: [
-    Story => (
-      <>
-        <Story />
-        <style>{styling}</style>
-      </>
-    ),
-  ],
   render: args => (
     <DetailList {...args} size="small">
       {children}
@@ -105,16 +97,16 @@ export const Small: Story = {
 };
 
 export const Large: Story = {
-  decorators: [
-    Story => (
-      <>
-        <Story />
-        <style>{styling}</style>
-      </>
-    ),
-  ],
   render: args => (
     <DetailList {...args} size="large">
+      {children}
+    </DetailList>
+  ),
+};
+
+export const SmallScreen: Story = {
+  render: args => (
+    <DetailList {...args} smallScreenBreakpoint="xl">
       {children}
     </DetailList>
   ),
@@ -124,10 +116,7 @@ export const Responsive: Story = {
   decorators: [
     Story =>
       windowWidthDecorator(
-        <>
-          <Story />
-          <style>{styling}</style>
-        </>,
+        <Story />,
         'Versjonen for liten skjerm vises ved sm brekkpunkt og nedover.',
       ),
   ],


### PR DESCRIPTION
## Beskrivelse

Fikser spacing slik at den blir tettere. Migrerer komponenten til `<Tabs>` visning i Storybook docs i samme slengen.

Før:
<img width="235" height="927" alt="image" src="https://github.com/user-attachments/assets/00b09268-bce2-4fda-9315-b56b0b6f83c1" />


Etter:
<img width="211" height="667" alt="image" src="https://github.com/user-attachments/assets/4b8da982-beac-4a36-a836-79e6a59427d2" />


## Sjekkliste

### Generelt

- [ ] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [ ] I commits
  - [ ] I PR-tittelen
- [ ] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
