### PR TITLE
ELSA1-598 Standardisering av spacing mellom ledetekst og input

### DIFF
--- a/.changeset/all-clocks-watch.md
+++ b/.changeset/all-clocks-watch.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Endrer effekten av `withMargins` prop i `<Label>`. Den får ikke lenger margin `1em` topp og bunn, men `dds-spacing-x0-125` kun bunn. Kan resultere i endringer i layout.

--- a/.changeset/four-poems-juggle.md
+++ b/.changeset/four-poems-juggle.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Standardiserer spacing mellom ledetekst og input på tvers av komponenter. Påvirker `<TextInput>`, `<TextArea>`, `<DatePicker>`, `<TimePicker>`, `<Select>`, `<NativeSelect>`, `<CheckboxGroup>`, `<RadioButtonGroup>`, `<ToggleButtonGroup>`, `<ProgressBar>`, `<Search>`, `<FileUploader>`, `<InputStepper>`, `<PhoneInput>`.

--- a/.changeset/purple-owls-post.md
+++ b/.changeset/purple-owls-post.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Utbedrer usynlige ledetekster i knapper i `<InputStepper>`.

--- a/packages/dds-components/src/components/FileUploader/FileUploader.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.tsx
@@ -16,7 +16,7 @@ import { StylelessList } from '../helpers';
 import { UploadIcon } from '../Icon/icons';
 import { InputMessage } from '../InputMessage';
 import { Box, type ResponsiveProps, VStack } from '../layout';
-import { Label } from '../Typography';
+import { renderLabel } from '../Typography/Label/Label.utils';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 import { VisuallyHidden } from '../VisuallyHidden';
 
@@ -96,7 +96,6 @@ export const FileUploader = (props: FileUploaderProps) => {
   const hasLabel = label !== undefined;
   const hasTip = tip !== undefined;
   const hasRootErrors = rootErrors.length > 0;
-  const showRequiredMarker = required;
 
   const labelId = derivativeIdGenerator(uniqueId, 'label');
   const tipId = derivativeIdGenerator(uniqueId, 'tip');
@@ -147,15 +146,12 @@ export const FileUploader = (props: FileUploaderProps) => {
       width={width}
       {...rest}
     >
-      {hasLabel && (
-        <Label
-          id={labelId}
-          showRequiredStyling={showRequiredMarker}
-          htmlFor={inputId}
-        >
-          {label}
-        </Label>
-      )}
+      {renderLabel({
+        label,
+        id: labelId,
+        showRequiredStyling: required,
+        htmlFor: inputId,
+      })}
       {hasTip && <InputMessage id={tipId} message={tip} messageType="tip" />}
       {withDragAndDrop ? (
         <VStack

--- a/packages/dds-components/src/components/InputStepper/InputStepper.module.css
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.module.css
@@ -10,12 +10,12 @@
     z-index: 1;
   }
 }
-.stepButton--left {
+.stepButton--plus {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
   margin-right: -1px;
 }
-.stepButton--right {
+.stepButton--minus {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   margin-left: -1px;

--- a/packages/dds-components/src/components/InputStepper/InputStepper.spec.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.spec.tsx
@@ -33,8 +33,8 @@ describe('<InputStepper />', () => {
     const label = 'label';
     render(<InputStepper label={label} maxValue={5} />);
     const buttonElements = screen.getAllByRole('button');
-    expect(buttonElements[0]).toHaveAccessibleName(`Trekk fra ${label}`);
-    expect(buttonElements[1]).toHaveAccessibleName(`Legg til ${label}`);
+    expect(buttonElements[0]).toHaveAccessibleName(`Reduser ${label} med 1`);
+    expect(buttonElements[1]).toHaveAccessibleName(`Øk ${label} med 1`);
   });
   it('should have label assosiated with input', () => {
     const label = 'label';
@@ -63,7 +63,9 @@ describe('<InputStepper />', () => {
     render(<InputStepper label={label} defaultValue={1} maxValue={5} />);
     const inputField = screen.getByRole('textbox');
     expect(inputField).toHaveValue('1');
-    const button = screen.getByRole('button', { name: /Legg til Label/i });
+    const button = screen.getByRole('button', {
+      name: new RegExp(`Øk ${label} med 1`, 'i'),
+    });
     await userEvent.click(button);
     expect(inputField).toHaveValue('2');
   });
@@ -72,7 +74,9 @@ describe('<InputStepper />', () => {
     render(<InputStepper label={label} defaultValue={1} maxValue={5} />);
     const inputField = screen.getByRole('textbox');
     expect(inputField).toHaveValue('1');
-    const button = screen.getByRole('button', { name: /Trekk fra Label/i });
+    const button = screen.getByRole('button', {
+      name: new RegExp(`Reduser ${label} med 1`, 'i'),
+    });
     await userEvent.click(button);
     expect(inputField).toHaveValue('0');
   });
@@ -81,7 +85,9 @@ describe('<InputStepper />', () => {
     render(<InputStepper label={label} defaultValue={1} maxValue={3} />);
     const inputField = screen.getByRole('textbox');
     expect(inputField).toHaveValue('1');
-    const button = screen.getByRole('button', { name: /Legg til Label/i });
+    const button = screen.getByRole('button', {
+      name: new RegExp(`Øk ${label} med 1`, 'i'),
+    });
     await userEvent.click(button);
     expect(inputField).toHaveValue('2');
     await userEvent.click(button);
@@ -96,7 +102,9 @@ describe('<InputStepper />', () => {
     );
     const inputField = screen.getByRole('textbox');
     expect(inputField).toHaveValue('3');
-    const button = screen.getByRole('button', { name: /Trekk fra Label/i });
+    const button = screen.getByRole('button', {
+      name: new RegExp(`Reduser ${label} med 1`, 'i'),
+    });
     await userEvent.click(button);
     expect(inputField).toHaveValue('2');
     await userEvent.click(button);

--- a/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
@@ -71,6 +71,7 @@ export const Overview: Story = {
           <InputStepper {...args} label="Hjelpetekst" tip="Hjelpetekst" />
         </StoryVStack>
         <StoryVStack>
+          <InputStepper {...args} label="Required" required />
           <InputStepper {...args} label="ReadOnly" readOnly />
           <InputStepper {...args} label="Disabled" disabled />
         </StoryVStack>

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.tsx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.tsx
@@ -29,7 +29,7 @@ import { renderInputMessage } from '../InputMessage';
 import { Box, type Breakpoint } from '../layout';
 import { styleUpToBreakpoint } from '../layout/common/utils';
 import { NativeSelect } from '../Select';
-import { Label } from '../Typography';
+import { renderLabel } from '../Typography/Label/Label.utils';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 export interface PhoneInputValue {
@@ -170,7 +170,6 @@ export const PhoneInput = ({
 
   const hasErrorMessage = !!errorMessage;
   const hasTip = !!tip;
-  const hasLabel = !!label;
   const hasMessage = hasErrorMessage || hasTip;
 
   const tipId = derivativeIdGenerator(phoneInputId, 'tip');
@@ -265,16 +264,12 @@ export const PhoneInput = ({
 
   return (
     <div className={cn(className, inputStyles.container)} style={style}>
-      {hasLabel && (
-        <Label
-          htmlFor={phoneNumberId}
-          showRequiredStyling={showRequiredStyling}
-          className={inputStyles.label}
-          readOnly={readOnly}
-        >
-          {label}
-        </Label>
-      )}
+      {renderLabel({
+        label,
+        htmlFor: phoneNumberId,
+        showRequiredStyling,
+        readOnly,
+      })}
       <Box
         display="flex"
         flexDirection={styleUpToBreakpoint('column', bp, 'row')}

--- a/packages/dds-components/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/dds-components/src/components/ProgressBar/ProgressBar.tsx
@@ -1,7 +1,6 @@
 import { type ComponentPropsWithRef, useId } from 'react';
 
 import { createSizes } from '../../types';
-import { Label } from '../Typography';
 import utilStyles from './../helpers/styling/utilStyles.module.css';
 import styles from './ProgressBar.module.css';
 import {
@@ -12,6 +11,7 @@ import {
 import { type CommonInputProps, getInputWidth } from '../helpers/Input';
 import { renderInputMessage } from '../InputMessage';
 import { Box } from '../layout';
+import { renderLabel } from '../Typography/Label/Label.utils';
 
 export const PROGRESS_BAR_SIZES = createSizes('small', 'medium');
 export type ProgressBarSize = (typeof PROGRESS_BAR_SIZES)[number];
@@ -56,7 +56,6 @@ export const ProgressBar = ({
   const uniqueId = id ?? `${generatedId}-searchInput`;
   const hasErrorMessage = !!errorMessage;
   const hasTip = !!tip;
-  const hasLabel = !!label;
   const hasValidMax = !!max && max > 0;
 
   /**
@@ -75,7 +74,7 @@ export const ProgressBar = ({
   const isIndeterminate = !hasValidValue && !hasErrorMessage;
   return (
     <Box width="100%" className={className} style={style}>
-      {hasLabel ? <Label htmlFor={uniqueId}>{label}</Label> : undefined}
+      {renderLabel({ label, htmlFor: uniqueId })}
       <progress
         id={uniqueId}
         className={utilStyles['visually-hidden']}

--- a/packages/dds-components/src/components/Search/Search.tsx
+++ b/packages/dds-components/src/components/Search/Search.tsx
@@ -25,8 +25,9 @@ import inputStyles from '../helpers/Input/Input.module.css';
 import { Icon, type IconSize } from '../Icon';
 import { SearchIcon } from '../Icon/icons';
 import { renderInputMessage } from '../InputMessage';
-import { Box, Grid, HStack, type ResponsiveProps, VStack } from '../layout';
-import { Label, getTypographyCn } from '../Typography';
+import { Box, Grid, HStack, type ResponsiveProps } from '../layout';
+import { getTypographyCn } from '../Typography';
+import { renderLabel } from '../Typography/Label/Label.utils';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 import { VisuallyHidden } from '../VisuallyHidden';
 
@@ -97,7 +98,6 @@ export const Search = ({
 }: SearchProps) => {
   const generatedId = useId();
   const uniqueId = id ?? `${generatedId}-searchInput`;
-  const hasLabel = !!label;
   const tipId = derivativeIdGenerator(uniqueId, 'tip');
   const suggestionsId = derivativeIdGenerator(uniqueId, 'suggestions');
   const suggestionsDescriptionId = derivativeIdGenerator(
@@ -204,8 +204,8 @@ export const Search = ({
     </HStack>
   );
   return (
-    <VStack gap="x0.125">
-      {hasLabel && <Label htmlFor={uniqueId}>{label}</Label>}
+    <div>
+      {renderLabel({ htmlFor: uniqueId, label })}
       <div>
         {showSearchButton ? (
           <Grid
@@ -231,7 +231,7 @@ export const Search = ({
         )}
         {renderInputMessage(tip, tipId)}
       </div>
-    </VStack>
+    </div>
   );
 };
 

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.tsx
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.tsx
@@ -27,7 +27,7 @@ import { Icon } from '../../Icon';
 import { ChevronDownIcon } from '../../Icon/icons';
 import { renderInputMessage } from '../../InputMessage';
 import { Box } from '../../layout';
-import { Label } from '../../Typography';
+import { renderLabel } from '../../Typography/Label/Label.utils';
 import typographyStyles from '../../Typography/typographyStyles.module.css';
 
 export type NativeSelectProps = {
@@ -89,7 +89,6 @@ export const NativeSelect = ({
 
   const hasErrorMessage = !!errorMessage;
   const hasTip = !!tip;
-  const hasLabel = !!label;
 
   const tipId = derivativeIdGenerator(uniqueId, 'tip');
   const errorMessageId = derivativeIdGenerator(uniqueId, 'errorMessage');
@@ -118,16 +117,12 @@ export const NativeSelect = ({
 
   return (
     <div className={className} style={style}>
-      {hasLabel && (
-        <Label
-          className={inputStyles.label}
-          htmlFor={uniqueId}
-          showRequiredStyling={showRequiredStyling}
-          readOnly={readOnly}
-        >
-          {label}
-        </Label>
-      )}
+      {renderLabel({
+        label,
+        htmlFor: uniqueId,
+        showRequiredStyling,
+        readOnly,
+      })}
       <Box position="relative" width={inputWidth}>
         <select
           ref={useCombinedRef(ref, selectRef)}

--- a/packages/dds-components/src/components/Select/Select.tsx
+++ b/packages/dds-components/src/components/Select/Select.tsx
@@ -42,12 +42,11 @@ import {
 } from '../../utils';
 import { readOnlyKeyDownHandler } from '../../utils/readonlyEventHandlers';
 import { type InputSize, getInputWidth } from '../helpers/Input';
-import inputStyles from '../helpers/Input/Input.module.css';
 import { type SvgIcon } from '../Icon/utils';
 import { renderInputMessage } from '../InputMessage';
 import { Box, type ResponsiveProps } from '../layout';
 import { ThemeContext } from '../ThemeProvider';
-import { Label } from '../Typography';
+import { renderLabel } from '../Typography/Label/Label.utils';
 
 export interface SelectOption<TValue = unknown> {
   label: string | number;
@@ -109,7 +108,6 @@ export function Select<Option = unknown, IsMulti extends boolean = false>({
   componentSize = 'medium',
   errorMessage,
   tip,
-  required,
   'aria-required': ariaRequired,
   readOnly,
   options,
@@ -146,10 +144,9 @@ export function Select<Option = unknown, IsMulti extends boolean = false>({
   const uniqueId = id ?? `${generatedId}-select`;
 
   const singleValueId = !isMulti ? `${uniqueId}-singleValue` : undefined;
-  const hasLabel = !!label;
   const hasErrorMessage = !!errorMessage;
   const hasIcon = !!icon;
-  const showRequiredStyling = !!(required || ariaRequired);
+  const showRequiredStyling = !!(rest.required || ariaRequired);
 
   const tipId = derivativeIdGenerator(uniqueId, 'tip');
   const errorMessageId = derivativeIdGenerator(uniqueId, 'errorMessage');
@@ -279,7 +276,6 @@ export function Select<Option = unknown, IsMulti extends boolean = false>({
       Control: customControl,
     },
     'aria-invalid': hasErrorMessage ? true : undefined,
-    required,
     onKeyDown: readOnlyKeyDownHandler('select', readOnly, onKeyDown),
     openMenuOnClick: readOnly
       ? false
@@ -301,16 +297,12 @@ export function Select<Option = unknown, IsMulti extends boolean = false>({
       )}
       style={style}
     >
-      {hasLabel && (
-        <Label
-          htmlFor={uniqueId}
-          showRequiredStyling={showRequiredStyling}
-          className={inputStyles.label}
-          readOnly={readOnly}
-        >
-          {label}
-        </Label>
-      )}
+      {renderLabel({
+        label,
+        htmlFor: uniqueId,
+        showRequiredStyling,
+        readOnly,
+      })}
       <ReactSelect {...reactSelectProps} ref={ref} />
       {renderInputMessage(tip, tipId, errorMessage, errorMessageId)}
     </Box>

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.tsx
@@ -13,7 +13,7 @@ import { cn, derivativeIdGenerator } from '../../../utils';
 import { renderInputMessage } from '../../InputMessage';
 import { type SelectionControlGroupCommonProps } from '../common/SelectionControl.types';
 import styles from '../SelectionControl.module.css';
-import { GroupLabel } from '../SelectionControl.styles';
+import { renderGroupLabel } from '../SelectionControl.styles';
 
 export type CheckboxGroupProps = BaseComponentPropsWithChildren<
   HTMLDivElement,
@@ -45,7 +45,7 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
   const generatedId = useId();
   const uniqueGroupId = groupId ?? `${generatedId}-checkboxGroup`;
   const hasErrorMessage = !!errorMessage;
-  const showRequiredMarker =
+  const showRequiredStyling =
     required || convertBooleanishToBoolean(ariaRequired);
 
   const errorMessageId = derivativeIdGenerator(uniqueGroupId, 'errorMessage');
@@ -69,15 +69,12 @@ export const CheckboxGroup = (props: CheckboxGroupProps) => {
         rest,
       )}
     >
-      {label !== undefined ? (
-        <GroupLabel
-          id={uniqueGroupId}
-          readOnly={readOnly}
-          showRequiredMarker={showRequiredMarker}
-        >
-          {label}
-        </GroupLabel>
-      ) : null}
+      {renderGroupLabel({
+        label,
+        id: uniqueGroupId,
+        readOnly,
+        showRequiredStyling,
+      })}
       {renderInputMessage(tip, tipId)}
       <CheckboxGroupContext value={{ ...contextProps }}>
         <div

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.tsx
@@ -14,7 +14,7 @@ import { cn } from '../../../utils';
 import { renderInputMessage } from '../../InputMessage';
 import { type SelectionControlGroupCommonProps } from '../common/SelectionControl.types';
 import styles from '../SelectionControl.module.css';
-import { GroupLabel } from '../SelectionControl.styles';
+import { renderGroupLabel } from '../SelectionControl.styles';
 
 export type RadioButtonGroupProps<T extends string | number> =
   BaseComponentPropsWithChildren<
@@ -68,7 +68,7 @@ export const RadioButtonGroup = <T extends string | number = string>({
   });
 
   const hasErrorMessage = !!errorMessage;
-  const showRequiredMarker =
+  const showRequiredStyling =
     required || convertBooleanishToBoolean(ariaRequired);
 
   const tipId = tip && `${uniqueGroupId}-tip`;
@@ -95,15 +95,12 @@ export const RadioButtonGroup = <T extends string | number = string>({
         rest,
       )}
     >
-      {label !== undefined ? (
-        <GroupLabel
-          id={uniqueGroupId}
-          readOnly={readOnly}
-          showRequiredMarker={showRequiredMarker}
-        >
-          {label}
-        </GroupLabel>
-      ) : null}
+      {renderGroupLabel({
+        label,
+        id: uniqueGroupId,
+        readOnly,
+        showRequiredStyling,
+      })}
       {renderInputMessage(tip, tipId)}
       <RadioButtonGroupContext value={{ ...contextProps }}>
         <div

--- a/packages/dds-components/src/components/SelectionControl/SelectionControl.styles.tsx
+++ b/packages/dds-components/src/components/SelectionControl/SelectionControl.styles.tsx
@@ -65,32 +65,36 @@ export const Label = ({
 
 interface SelectionControlGroupLabelProps {
   id?: string;
-  showRequiredMarker?: boolean;
+  showRequiredStyling?: boolean;
   readOnly?: boolean;
-  children?: string;
+  label?: string;
 }
 
-export const GroupLabel = ({
+export const renderGroupLabel = ({
   id,
-  showRequiredMarker,
+  showRequiredStyling,
   readOnly,
-  children,
+  label,
 }: SelectionControlGroupLabelProps) => {
-  return (
-    <Typography
-      as="span"
-      typographyType="labelMedium"
-      id={id}
-      className={readOnly ? labelStyles['read-only'] : undefined}
-    >
-      {readOnly && (
-        <Icon
-          icon={LockIcon}
-          className={labelStyles['read-only__icon']}
-          iconSize="small"
-        />
-      )}
-      {children} {showRequiredMarker && <RequiredMarker />}
-    </Typography>
-  );
+  const hasLabel = !!label;
+  if (hasLabel)
+    return (
+      <Typography
+        as="span"
+        typographyType="labelMedium"
+        id={id}
+        className={readOnly ? labelStyles['read-only'] : undefined}
+        withMargins
+      >
+        {readOnly && (
+          <Icon
+            icon={LockIcon}
+            className={labelStyles['read-only__icon']}
+            iconSize="small"
+          />
+        )}
+        {label} {showRequiredStyling && <RequiredMarker />}
+      </Typography>
+    );
+  else return null;
 };

--- a/packages/dds-components/src/components/TextArea/TextArea.tsx
+++ b/packages/dds-components/src/components/TextArea/TextArea.tsx
@@ -24,7 +24,7 @@ import { focusable } from '../helpers/styling/focus.module.css';
 import { scrollbar } from '../helpers/styling/utilStyles.module.css';
 import { renderInputMessage } from '../InputMessage';
 import { Box } from '../layout';
-import { Label } from '../Typography';
+import { renderLabel } from '../Typography/Label/Label.utils';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 export type TextAreaProps = CommonInputProps & {
@@ -81,7 +81,6 @@ export const TextArea = ({
 
   const hasErrorMessage = !!errorMessage;
   const hasMessage = hasErrorMessage || !!tip;
-  const hasLabel = !!label;
   const tipId = derivativeIdGenerator(uniqueId, 'tip');
   const errorMessageId = derivativeIdGenerator(uniqueId, 'errorMessage');
   const characterCounterId = derivativeIdGenerator(
@@ -94,16 +93,7 @@ export const TextArea = ({
 
   return (
     <div className={cn(className, inputStyles.container)} style={{ ...style }}>
-      {hasLabel && (
-        <Label
-          showRequiredStyling={showRequiredStyling}
-          htmlFor={uniqueId}
-          className={inputStyles.label}
-          readOnly={readOnly}
-        >
-          {label}
-        </Label>
-      )}
+      {renderLabel({ label, htmlFor: uniqueId, readOnly, showRequiredStyling })}
       <Box
         as="textarea"
         width={inputWidth}

--- a/packages/dds-components/src/components/TextInput/TextInput.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.tsx
@@ -15,7 +15,7 @@ import inputStyles from '../helpers/Input/Input.module.css';
 import { Icon } from '../Icon';
 import { renderInputMessage } from '../InputMessage';
 import { Box } from '../layout';
-import { Label } from '../Typography';
+import { renderLabel } from '../Typography/Label/Label.utils';
 
 export const TextInput = ({
   label,
@@ -75,7 +75,6 @@ export const TextInput = ({
 
   const hasErrorMessage = !!errorMessage;
   const hasTip = !!tip;
-  const hasLabel = !!label;
   const hasMessage = hasErrorMessage || hasTip;
   const hasBottomContainer = hasErrorMessage || hasTip || !!maxLength;
   const hasIcon = !!icon;
@@ -209,17 +208,7 @@ export const TextInput = ({
       )}
       style={style}
     >
-      {hasLabel && (
-        <Box
-          as={Label}
-          display="block"
-          htmlFor={uniqueId}
-          showRequiredStyling={showRequiredStyling}
-          readOnly={readOnly}
-        >
-          {label}
-        </Box>
-      )}
+      {renderLabel({ label, htmlFor: uniqueId, showRequiredStyling, readOnly })}
       {extendedInput ? (
         extendedInput
       ) : (

--- a/packages/dds-components/src/components/ToggleButton/ToggleButtonGroup.tsx
+++ b/packages/dds-components/src/components/ToggleButton/ToggleButtonGroup.tsx
@@ -4,8 +4,8 @@ import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../types';
-import { Box, VStack } from '../layout';
-import { Typography } from '../Typography';
+import { Box } from '../layout';
+import { renderGroupLabel } from '../SelectionControl/SelectionControl.styles';
 
 type Direction = 'row' | 'column';
 
@@ -39,21 +39,16 @@ export const ToggleButtonGroup = (props: ToggleButtonGroupProps) => {
   const uniqueLabelId = labelId ?? `${generatedId}-ToggleButtonGroupLabel`;
 
   return (
-    <VStack
-      gap="x0.5"
+    <div
       {...getBaseHTMLProps(id, className, htmlProps, rest)}
       role="group"
       aria-labelledby={label ? uniqueLabelId : undefined}
     >
-      {!!label && (
-        <Typography as="span" typographyType="labelMedium" id={uniqueLabelId}>
-          {label}
-        </Typography>
-      )}
+      {renderGroupLabel({ label, id: uniqueLabelId })}
       <Box display="flex" flexWrap="wrap" gap="x0.75" flexDirection={direction}>
         {children}
       </Box>
-    </VStack>
+    </div>
   );
 };
 

--- a/packages/dds-components/src/components/Typography/Label/Label.utils.tsx
+++ b/packages/dds-components/src/components/Typography/Label/Label.utils.tsx
@@ -1,0 +1,19 @@
+import { type ReactNode } from 'react';
+
+import { Label, type LabelProps } from './Label';
+
+type RenderLabelProps = {
+  label?: ReactNode;
+} & Omit<LabelProps, 'withMargins' | 'children'>;
+
+export function renderLabel(props: RenderLabelProps) {
+  const { label, ...rest } = props;
+  const hasLabel = !!label;
+  if (hasLabel)
+    return (
+      <Label {...rest} withMargins>
+        {label}
+      </Label>
+    );
+  return null;
+}

--- a/packages/dds-components/src/components/Typography/typographyStyles.module.css
+++ b/packages/dds-components/src/components/Typography/typographyStyles.module.css
@@ -236,8 +236,7 @@
 
 :where(.label-medium--margins) {
   display: block;
-  margin-top: var(--dds-font-label-medium-paragraph-spacing);
-  margin-bottom: var(--dds-font-label-medium-paragraph-spacing);
+  margin-bottom: var(--dds-spacing-x0-125);
 }
 
 :where(.legend) {

--- a/packages/dds-components/src/components/date-inputs/common/DateInput.tsx
+++ b/packages/dds-components/src/components/date-inputs/common/DateInput.tsx
@@ -8,7 +8,7 @@ import inputStyles from '../../helpers/Input/Input.module.css';
 import focusStyles from '../../helpers/styling/focus.module.css';
 import { InputMessage } from '../../InputMessage';
 import { Box } from '../../layout';
-import { Label } from '../../Typography';
+import { renderLabel } from '../../Typography/Label/Label.utils';
 import { type DatePickerProps } from '../DatePicker';
 import { CalendarPopoverContext } from '../DatePicker/CalendarPopover';
 
@@ -60,7 +60,6 @@ export function DateInput({
 }: DateInputProps) {
   const hasErrorMessage = !!errorMessage;
   const hasTip = !!tip;
-  const hasLabel = props.label != null;
   const hasMessage = hasErrorMessage || hasTip;
 
   const { isOpen } = useContext(CalendarPopoverContext);
@@ -71,16 +70,12 @@ export function DateInput({
       className={cn(className, inputStyles.container)}
       ref={ref}
     >
-      {hasLabel && (
-        <Label
-          {...labelProps}
-          showRequiredStyling={required}
-          className={inputStyles.label}
-          readOnly={readOnly}
-        >
-          {props.label}
-        </Label>
-      )}
+      {renderLabel({
+        ...labelProps,
+        label: props.label,
+        showRequiredStyling: required,
+        readOnly,
+      })}
       <Box
         style={style}
         width={getInputWidth(width, 'fit-content')}

--- a/packages/dds-components/src/components/helpers/Input/Input.module.css
+++ b/packages/dds-components/src/components/helpers/Input/Input.module.css
@@ -105,10 +105,6 @@
   gap: var(--dds-spacing-x1);
 }
 
-:where(.label) {
-  display: block;
-}
-
 :where(.input-group__absolute-element) {
   position: absolute;
   top: 50%;


### PR DESCRIPTION
## Beskrivelse

Implementasjonen var ulik og rotete på tvers, lager en render-funksjon som gjør det likt overalt.

- Endrer effekten av `withMargins` prop i `<Label>`. Den får ikke lenger margin `1em` topp og bunn, men `dds-spacing-x0-125` kun bunn. Kan resultere i endringer i layout.
- Standardiserer spacing mellom ledetekst og input på tvers av komponenter. Påvirker `<TextInput>`, `<TextArea>`, `<DatePicker>`, `<TimePicker>`, `<Select>`, `<NativeSelect>`, `<CheckboxGroup>`, `<RadioButtonGroup>`, `<ToggleButtonGroup>`, `<ProgressBar>`, `<Search>`, `<FileUploader>`, `<InputStepper>`, `<PhoneInput>`.
- I samme slengen: refaktorerer `<InputStepper>` og utbedrer usynlige ledetekster.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
