### PR TITLE
ELSA1-702 Støtte for locale i `<DatePicker>` og `<TimePicker>`

### DIFF
--- a/.changeset/all-schools-sin.md
+++ b/.changeset/all-schools-sin.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for locale i `<DatePicker>` og `<TimePicker>` - språk hentes fra `<DdsProvider>`, bruker 'nb-NO' som standard. Tar hånd om oversettelser mens datoformatet alltid er norsk.

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DateField/DateField.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DateField/DateField.tsx
@@ -13,6 +13,7 @@ import { useDateFieldState } from '@react-stately/datepicker';
 import { type Ref, useRef } from 'react';
 
 import { CalendarButton } from './CalendarButton';
+import { formatDateFieldSegments } from './DateField.utils';
 import { DateSegment } from './DateSegment';
 import { createTexts, useTranslation } from '../../../../i18n';
 import { cn } from '../../../../utils';
@@ -71,6 +72,8 @@ export function DateField({
     state.setValue(null);
   };
 
+  const formattedSegments = formatDateFieldSegments(state.segments);
+
   return (
     <DateInput
       {...props}
@@ -109,7 +112,7 @@ export function DateField({
       labelProps={labelProps}
       fieldProps={fieldProps}
     >
-      {state.segments.map((segment, i) => (
+      {formattedSegments.map((segment, i) => (
         <DateSegment
           aria-readonly={props.isReadOnly}
           componentSize={componentSize}

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DateField/DateField.utils.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DateField/DateField.utils.tsx
@@ -1,0 +1,42 @@
+import { type DateSegment } from '@react-stately/datepicker';
+
+// Formaterer dato-segmenter til norsk locale
+export function formatDateFieldSegments(
+  segments: Array<DateSegment>,
+): Array<DateSegment> {
+  const daySegment = segments.find(segment => segment.type === 'day');
+  const monthSegment = segments.find(segment => segment.type === 'month');
+  const yearSegment = segments.find(segment => segment.type === 'year');
+  const separatorSegment = segments.find(segment => segment.type === 'literal');
+
+  if (!daySegment || !monthSegment || !yearSegment || !separatorSegment) {
+    throw new Error('Invalid date field segments');
+  }
+
+  const formattedDaySegment = {
+    ...daySegment,
+    text: daySegment.text.padStart(2, '0'),
+    placeholder: 'dd',
+  };
+
+  const formattedMonthSegment = {
+    ...monthSegment,
+    text: monthSegment.text.padStart(2, '0'),
+    placeholder: 'mm',
+  };
+
+  const formattedYearSegment = {
+    ...yearSegment,
+    placeholder: 'åååå',
+  };
+
+  const formattedSeparatorSegment = { ...separatorSegment, text: '.' };
+
+  return [
+    formattedDaySegment,
+    formattedSeparatorSegment,
+    formattedMonthSegment,
+    formattedSeparatorSegment,
+    formattedYearSegment,
+  ];
+}

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DateField/DateSegment.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DateField/DateSegment.tsx
@@ -62,9 +62,7 @@ export function DateSegment({
       >
         {segment.placeholder}
       </span>
-      {segment.isPlaceholder
-        ? ''
-        : segment.text.padStart(String(segment.maxValue ?? '').length, '0')}
+      {segment.isPlaceholder ? '' : segment.text}
     </div>
   );
 }

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.tsx
@@ -11,9 +11,10 @@ import {
   CalendarPopoverAnchor,
   CalendarPopoverContent,
 } from './CalendarPopover';
-import { locale } from './constants';
+import { LOCALE } from './constants';
 import { DateField, type DateFieldProps } from './DateField/DateField';
 import { useCombinedRef } from '../../../hooks';
+import { useLanguage } from '../../../i18n';
 import { type Breakpoint } from '../../layout';
 import { type ResponsiveProps } from '../../layout/common/Responsive.types';
 import {
@@ -65,6 +66,12 @@ export function DatePicker({
   ref,
   ...props
 }: DatePickerProps) {
+  const lang = useLanguage();
+
+  if (!lang) {
+    throw new Error('DatePicker must be used within a DdsProvider');
+  }
+
   const state = useDatePickerState(props);
   const domRef = useFocusManagerRef(ref && refIsFocusable(ref) ? ref : null);
   const internalRef = useRef<HTMLElement>(null);
@@ -76,7 +83,7 @@ export function DatePicker({
   );
 
   return (
-    <I18nProvider locale={locale}>
+    <I18nProvider locale={LOCALE[lang]}>
       <CalendarPopover
         isOpen={state.isOpen}
         onClose={state.close}

--- a/packages/dds-components/src/components/date-inputs/DatePicker/constants.ts
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/constants.ts
@@ -1,2 +1,10 @@
-export const locale = 'no-NO' as const;
+import { type Language } from '../../../i18n/translation.types';
+
+export const LOCALE: Record<Language, string> = {
+  nb: 'nb-NO',
+  no: 'no-NO',
+  nn: 'nn-NO',
+  en: 'en-GB',
+} as const;
+
 export const timezone = 'Europe/Oslo' as const;

--- a/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.tsx
+++ b/packages/dds-components/src/components/date-inputs/TimePicker/TimePicker.tsx
@@ -3,13 +3,14 @@ import { type AriaTimeFieldProps, useTimeField } from '@react-aria/datepicker';
 import { useTimeFieldState } from '@react-stately/datepicker';
 import { type Ref, useRef } from 'react';
 
+import { useLanguage } from '../../../i18n';
 import { cn } from '../../../utils';
 import { type InputProps } from '../../helpers/Input/Input.types';
 import { Icon } from '../../Icon';
 import { TimeIcon } from '../../Icon/icons';
 import { DateInput } from '../common/DateInput';
 import styles from '../common/DateInput.module.css';
-import { locale } from '../DatePicker/constants';
+import { LOCALE } from '../DatePicker/constants';
 import { DateSegment } from '../DatePicker/DateField/DateSegment';
 
 export type TimePickerProps = Omit<AriaTimeFieldProps<Time>, 'hideTimeZone'> &
@@ -26,10 +27,16 @@ export function TimePicker({
   ref,
   ...props
 }: TimePickerProps) {
+  const lang = useLanguage();
+
+  if (!lang) {
+    throw new Error('DatePicker must be used within a DdsProvider');
+  }
+
   const internalRef = useRef<HTMLInputElement>(null);
   const state = useTimeFieldState({
     ...props,
-    locale,
+    locale: LOCALE[lang],
   });
   const { labelProps, fieldProps } = useTimeField(
     { ...props, hideTimeZone: true, granularity: 'hour' },


### PR DESCRIPTION
## Beskrivelse

Språket hentes fra `<DdsProvider>`, bruker 'nb-NO' som standard. Tar hånd om oversettelser mens datoformatet alltid er norsk.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
