### PR TITLE
ELSA1-698 Støtte for `disabled` og `readOnly` i `<Fileuploader>`

### DIFF
--- a/.changeset/mean-icons-begin.md
+++ b/.changeset/mean-icons-begin.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Implementerer ordentlig støtte for `disabled` og `readOnly` props i `<FileUploader>`.

--- a/.changeset/open-eagles-stop.md
+++ b/.changeset/open-eagles-stop.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Utvider `background` prop i `<Paper>` til å støtte `'surface-field-disabled'`.

--- a/.changeset/tall-owls-hide.md
+++ b/.changeset/tall-owls-hide.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser manglende interne oversettelser i `<FileUploader>`.

--- a/packages/dds-components/src/components/FileUploader/File.tsx
+++ b/packages/dds-components/src/components/FileUploader/File.tsx
@@ -11,7 +11,7 @@ import { Button } from '../Button';
 import { Icon } from '../Icon';
 import { CheckCircledIcon, CloseIcon, ErrorIcon } from '../Icon/icons';
 import { Paper } from '../layout';
-import typographyStyles from '../Typography/typographyStyles.module.css';
+import { Typography } from '../Typography';
 
 interface FileProps {
   parentId: string;
@@ -19,16 +19,28 @@ interface FileProps {
   isValid: boolean;
   file: FileUploaderFile;
   removeFile: () => void;
+  disabled?: boolean;
+  readOnly?: boolean;
 }
 
 export const File = (props: FileProps) => {
   const { t } = useTranslation();
-  const { parentId, index, file: stateFile, removeFile, isValid } = props;
+  const {
+    parentId,
+    index,
+    file: stateFile,
+    removeFile,
+    isValid,
+    disabled,
+    readOnly,
+  } = props;
 
   const errorsList = stateFile.errors.map((e, errorIndex) => ({
     id: derivativeIdGenerator(parentId, `file-${index}-error-${errorIndex}`),
     message: e,
   }));
+
+  const inactive = disabled || readOnly;
 
   return (
     <li>
@@ -39,34 +51,50 @@ export const File = (props: FileProps) => {
         gap="x0.75"
         marginBlock="x0.5 0"
         padding="x0.5 x1"
-        border={isValid ? 'border-default' : 'border-danger'}
-        background="surface-subtle"
+        border={
+          disabled
+            ? 'border-subtle'
+            : isValid
+              ? 'border-default'
+              : 'border-danger'
+        }
+        background={inactive ? 'surface-field-disabled' : 'surface-subtle'}
         className={cn(!isValid && styles['file--invalid'])}
       >
-        <span
-          className={cn(styles.file__name, typographyStyles['body-medium'])}
+        <Typography
+          as="span"
+          color={
+            disabled ? 'text-subtle' : readOnly ? 'text-medium' : undefined
+          }
+          className={cn(styles.file__name)}
         >
           {stateFile.file.name}
-        </span>
-        <Icon
-          icon={isValid ? CheckCircledIcon : ErrorIcon}
-          className={styles[`file__icon--${isValid ? 'valid' : 'invalid'}`]}
-        />
-        <Button
-          size="small"
-          purpose="tertiary"
-          type="button"
-          onClick={removeFile}
-          icon={CloseIcon}
-          htmlProps={{
-            'aria-label': t(texts.removeFile(stateFile.file.name)),
-            'aria-invalid': !isValid ? true : undefined,
-            'aria-errormessage': !isValid ? t(texts.invalidFile) : undefined,
-            'aria-describedby': spaceSeparatedIdListGenerator(
-              errorsList.map(e => e.id),
-            ),
-          }}
-        />
+        </Typography>
+        {!inactive && (
+          <>
+            <Icon
+              icon={isValid ? CheckCircledIcon : ErrorIcon}
+              className={styles[`file__icon--${isValid ? 'valid' : 'invalid'}`]}
+            />
+            <Button
+              size="small"
+              purpose="tertiary"
+              type="button"
+              onClick={removeFile}
+              icon={CloseIcon}
+              htmlProps={{
+                'aria-label': t(texts.removeFile(stateFile.file.name)),
+                'aria-invalid': !isValid ? true : undefined,
+                'aria-errormessage': !isValid
+                  ? t(texts.invalidFile)
+                  : undefined,
+                'aria-describedby': spaceSeparatedIdListGenerator(
+                  errorsList.map(e => e.id),
+                ),
+              }}
+            />
+          </>
+        )}
       </Paper>
       <ErrorList errors={errorsList} />
     </li>

--- a/packages/dds-components/src/components/FileUploader/FileUploader.mdx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.mdx
@@ -4,6 +4,7 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as FileUploaderStories from './FileUploader.stories';
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
 <Meta of={FileUploaderStories} />
 
@@ -18,8 +19,35 @@ import * as FileUploaderStories from './FileUploader.stories';
 
 ## Props
 
-<Canvas of={FileUploaderStories.Preview} />
-<Controls of={FileUploaderStories.Preview} />
+<Tabs>
+  <TabList>
+    <Tab>Demo</Tab>
+    <Tab>Controlled</Tab>
+    <Tab>Kun PDF</Tab>
+    <Tab>Uten drag-and-drop</Tab>
+    <Tab>Custom filliste</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      <Canvas of={FileUploaderStories.Preview} />
+      <Controls of={FileUploaderStories.Preview} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={FileUploaderStories.Controlled} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={FileUploaderStories.PdfOnly} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={FileUploaderStories.NoZone} />
+    </TabPanel>
+    <TabPanel>
+      Hvis du har behov for annen visning av fillisten enn den interne i
+      komponenten, kan du skjule den med en prop og implementere egen.
+      <Canvas of={FileUploaderStories.CustomFileList} />
+    </TabPanel>
+  </TabPanels>
+</Tabs>
 
 ## Bruk
 
@@ -33,11 +61,6 @@ const [files, setFiles] = useState<Array<File>>([]);
   onChange={files => {
     setFiles(files);
   }}
+  value={files}
 />
 `} />
-
-## Eksempler
-
-### Custom filliste
-
-<Canvas of={FileUploaderStories.CustomFileList} />

--- a/packages/dds-components/src/components/FileUploader/FileUploader.module.css
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.module.css
@@ -21,10 +21,6 @@
   background-color: var(--dds-color-surface-hover-default);
 }
 
-.input-container--no-drag-zone {
-  padding: var(--dds-spacing-x0-5) 0;
-}
-
 .file--invalid {
   box-shadow: inset 0 0 0 1px var(--dds-color-border-danger);
 }
@@ -40,4 +36,10 @@
 .file__name {
   word-break: break-all;
   width: 100%;
+}
+
+.readonly--file-list {
+  @media (prefers-reduced-motion: no-preference) {
+    transition: var(--dds-focus-transition);
+  }
 }

--- a/packages/dds-components/src/components/FileUploader/FileUploader.spec.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { type ComponentProps, useState } from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { FileUploader } from './FileUploader';
 import type { FileList } from './types';
@@ -12,8 +12,10 @@ function FileUploaderTest(
   const [files, setFiles] = useState<FileList>([]);
   return <FileUploader {...props} value={files} onChange={setFiles} />;
 }
-
-const file = new File(['hello'], 'hello.png', { type: 'image/png' });
+const fileName = 'hello.png';
+const fileValue = 'C:\\fakepath\\hello.png';
+const file = new File(['hello'], fileName, { type: 'image/png' });
+const file2 = new File(['hello2'], 'hello2.png', { type: 'image/png' });
 
 describe('<FileUploader>', () => {
   it('accepts uploading files', async () => {
@@ -21,7 +23,37 @@ describe('<FileUploader>', () => {
     const fileInput = screen.getByTestId('file-uploader-input');
     await userEvent.upload(fileInput, file);
     await waitFor(() => {
-      expect(screen.getByText('hello.png', {})).toBeInTheDocument();
+      expect(screen.getByText('hello.png')).toBeInTheDocument();
+      expect(fileInput).toHaveValue(fileValue);
+    });
+  });
+
+  it('should render delete button for uploaded file', async () => {
+    render(<FileUploaderTest />);
+    const fileInput = screen.getByTestId('file-uploader-input');
+    await userEvent.upload(fileInput, file);
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: `Fjern fil ${fileName}` }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('should delete file on delete button click', async () => {
+    render(<FileUploaderTest />);
+    const fileInput = screen.getByTestId('file-uploader-input');
+    const name = `Fjern fil ${fileName}`;
+
+    await userEvent.upload(fileInput, file);
+    const button = await screen.findByRole('button', { name });
+
+    expect(button).toBeInTheDocument();
+    expect(fileInput).toHaveValue(fileValue);
+
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name })).not.toBeInTheDocument();
     });
   });
 
@@ -30,7 +62,34 @@ describe('<FileUploader>', () => {
     const fileInput = screen.getByTestId('file-uploader-input');
     await userEvent.upload(fileInput, file);
     await waitFor(() => {
-      expect(screen.getByText('hello.png', {})).toBeInTheDocument();
+      expect(screen.getByText('hello.png')).toBeInTheDocument();
+      expect(fileInput).toHaveValue(fileValue);
+    });
+  });
+
+  it('should not upload if file in wrong format', async () => {
+    render(<FileUploaderTest accept={['.pdf']} />);
+    const fileInput = screen.getByTestId('file-uploader-input');
+    await userEvent.upload(fileInput, file);
+    await waitFor(() => {
+      expect(screen.queryByText('hello.png')).not.toBeInTheDocument();
+      expect(fileInput).not.toHaveValue();
+    });
+  });
+
+  it('should get error if too many files ', async () => {
+    const maxFiles = 1;
+    render(<FileUploaderTest maxFiles={maxFiles} />);
+    const fileInput = screen.getByTestId('file-uploader-input');
+    await userEvent.upload(fileInput, file);
+    await userEvent.upload(fileInput, file2);
+    await waitFor(() => {
+      expect(screen.queryByText('hello.png')).toBeInTheDocument();
+      expect(screen.queryByText('hello2.png')).toBeInTheDocument();
+      expect(
+        screen.getByText(`For mange filer. Maksimalt antall er ${maxFiles}`),
+      ).toBeInTheDocument();
+      expect(fileInput).toHaveValue('C:\\fakepath\\hello2.png');
     });
   });
 
@@ -46,5 +105,114 @@ describe('<FileUploader>', () => {
     render(<FileUploaderTest label={label} />);
     const labelNode = screen.getByText(label);
     expect(labelNode).toHaveAttribute('for');
+  });
+  describe('disabled', () => {
+    it('should be disabled', async () => {
+      render(<FileUploaderTest disabled />);
+      const fileInput = screen.getByTestId('file-uploader-input');
+      expect(fileInput).toBeDisabled();
+    });
+
+    it('input should not get keyboard focus', async () => {
+      render(<FileUploaderTest disabled />);
+      const fileInput = screen.getByTestId('file-uploader-input');
+      await userEvent.keyboard('[Tab]');
+      expect(fileInput).not.toHaveFocus();
+    });
+
+    it('should not render upload button', async () => {
+      render(<FileUploaderTest disabled />);
+
+      expect(
+        screen.queryByRole('button', { name: /Velg fil/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('readonly', () => {
+    it('should be readonly', async () => {
+      render(<FileUploaderTest readOnly />);
+      const fileInput = screen.getByTestId('file-uploader-input');
+      expect(fileInput).toHaveAttribute('readonly');
+    });
+
+    it('should not render upload button', async () => {
+      render(<FileUploaderTest readOnly />);
+
+      expect(
+        screen.queryByRole('button', { name: /Velg fil/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('should have accessible description', async () => {
+      render(<FileUploaderTest readOnly />);
+      const fileInput = screen.getByTestId('file-uploader-input');
+      expect(fileInput).toHaveAccessibleDescription(
+        /Opplastede filer Ingen filer./i,
+      );
+    });
+
+    it('should get keyboard focus', async () => {
+      render(<FileUploaderTest readOnly />);
+      const fileInput = screen.getByTestId('file-uploader-input');
+      await userEvent.keyboard('[Tab]');
+      expect(fileInput).toHaveFocus();
+    });
+
+    it('should prevent default when Enter is pressed', async () => {
+      render(<FileUploaderTest readOnly />);
+      const fileInput = screen.getByTestId('file-uploader-input');
+
+      const preventDefault = vi.fn();
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'Enter',
+        bubbles: true,
+        cancelable: true,
+      });
+
+      Object.defineProperty(event, 'preventDefault', {
+        value: preventDefault,
+        writable: true,
+      });
+
+      fileInput.dispatchEvent(event);
+
+      expect(preventDefault).toHaveBeenCalled();
+    });
+
+    it('should prevent default when Space is pressed', async () => {
+      render(<FileUploaderTest readOnly />);
+      const fileInput = screen.getByTestId('file-uploader-input');
+
+      const preventDefault = vi.fn();
+
+      const event = new KeyboardEvent('keydown', {
+        key: ' ',
+        bubbles: true,
+        cancelable: true,
+      });
+
+      Object.defineProperty(event, 'preventDefault', {
+        value: preventDefault,
+        writable: true,
+      });
+
+      fileInput.dispatchEvent(event);
+
+      expect(preventDefault).toHaveBeenCalled();
+    });
+
+    it('should not allow uploads', async () => {
+      const handleChange = vi.fn();
+
+      render(
+        <FileUploader onChange={handleChange} value={[]} readOnly={true} />,
+      );
+
+      const fileInput = screen.getByTestId('file-uploader-input');
+      await userEvent.upload(fileInput, file);
+      expect(handleChange).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/dds-components/src/components/FileUploader/FileUploader.stories.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.stories.tsx
@@ -4,19 +4,20 @@ import { fn } from 'storybook/test';
 
 import { FileUploader } from './FileUploader';
 import {
-  categoryCss,
   categoryHtml,
+  responsivePropsArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
-import { StoryVStack } from '../layout/Stack/utils';
+import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { Heading, Paragraph } from '../Typography';
 
 export default {
   title: 'dds-components/Components/FileUploader',
   component: FileUploader,
   argTypes: {
-    width: { control: 'text', table: categoryCss },
-    id: { control: false, table: categoryHtml },
+    width: responsivePropsArgTypes.width,
+    id: { control: 'text', table: categoryHtml },
+    disabled: { control: 'boolean', table: categoryHtml },
     initialFiles: { control: false },
     accept: { control: false },
   },
@@ -25,92 +26,72 @@ export default {
 
 type Story = StoryObj<typeof FileUploader>;
 
-export const Preview: Story = {};
+const file = new File(['hello'], 'hello.png', { type: 'image/png' });
 
-const SingleFileUploader = () => {
-  const [files, setFiles] = useState<Array<File>>([]);
-
-  return (
-    <FileUploader
-      label="Last opp fil"
-      tip="Maks 1 fil"
-      required
-      initialFiles={files}
-      onChange={files => {
-        setFiles(files);
-      }}
-      maxFiles={1}
-    />
-  );
-};
-
-const NoZoneUploader = () => {
-  const [files, setFiles] = useState<Array<File>>([]);
-
-  return (
-    <FileUploader
-      label="Last opp fil"
-      tip="Maks 1 fil"
-      withDragAndDrop={false}
-      required
-      initialFiles={files}
-      onChange={files => {
-        setFiles(files);
-      }}
-      maxFiles={1}
-    />
-  );
-};
-
-const WithErrorMessage = () => {
-  const [files, setFiles] = useState<Array<File>>([]);
-
-  return (
-    <FileUploader
-      label="Last opp fil"
-      tip="Maks 2 filer"
-      required
-      initialFiles={files}
-      onChange={files => {
-        setFiles(files);
-      }}
-      errorMessage="Feilmelding"
-      maxFiles={2}
-    />
-  );
-};
+export const Preview: Story = { args: { label: 'Label' } };
 
 export const Overview: Story = {
-  args: {},
   render: () => (
-    <StoryVStack>
-      <SingleFileUploader />
-      <NoZoneUploader />
-      <WithErrorMessage />
-    </StoryVStack>
+    <StoryHStack>
+      <StoryVStack>
+        <FileUploader
+          label="Med fil"
+          initialFiles={[file]}
+          onChange={() => null}
+        />
+        <FileUploader label="Required" required onChange={() => null} />
+        <FileUploader
+          label="Error"
+          errorMessage="Feilmelding"
+          onChange={() => null}
+        />
+      </StoryVStack>
+      <StoryVStack>
+        <FileUploader label="Disabled" disabled onChange={() => null} />
+        <FileUploader label="ReadOnly" readOnly onChange={() => null} />
+        <FileUploader
+          label="Disabled med fil"
+          disabled
+          onChange={() => null}
+          initialFiles={[file]}
+        />
+        <FileUploader
+          label="ReadOnly med fil"
+          readOnly
+          onChange={() => null}
+          initialFiles={[file]}
+        />
+      </StoryVStack>
+    </StoryHStack>
   ),
 };
-export const NoZone: Story = {
-  args: { label: 'Last opp fil' },
-  render: args => {
-    return <FileUploader {...args} withDragAndDrop={false} />;
-  },
-};
 
-export const Pdf: Story = {
-  args: { label: 'Last opp fil', tip: 'Kun PDF-filer' },
+export const Controlled: Story = {
+  args: { label: 'Last opp fil', tip: 'Maks 1 fil', maxFiles: 1 },
   render: args => {
     const [files, setFiles] = useState<Array<File>>([]);
+
     return (
       <FileUploader
         {...args}
-        initialFiles={files}
+        value={files}
         onChange={files => {
           setFiles(files);
         }}
-        accept={['.pdf', 'application/pdf']}
       />
     );
+  },
+};
+
+export const NoZone: Story = {
+  args: { label: 'Last opp fil', withDragAndDrop: false },
+};
+
+export const PdfOnly: Story = {
+  args: {
+    label: 'Last opp fil',
+    tip: 'Kun PDF-filer',
+    accept: ['.pdf', 'application/pdf'],
   },
 };
 
@@ -157,4 +138,8 @@ export const ResponsiveWidth: Story = {
       xl: 'var(--dds-input-default-width)',
     },
   },
+};
+
+export const MaxOneFile: Story = {
+  args: { label: 'Label', maxFiles: 1, tip: 'Maks 1 fil' },
 };

--- a/packages/dds-components/src/components/FileUploader/utils.ts
+++ b/packages/dds-components/src/components/FileUploader/utils.ts
@@ -38,8 +38,3 @@ export const isFileAccepted = (
 //   minSize: number | undefined,
 //   maxSize: number | undefined
 // ): boolean => {};
-
-export const getTooManyFilesErrorMessage = (maxFiles: number) =>
-  `For mange filer, maks ${maxFiles}stk`;
-
-export const getInvalidFileTypeErrorMessage = () => 'Ugyldig filtype';

--- a/packages/dds-components/src/types/Surface.tsx
+++ b/packages/dds-components/src/types/Surface.tsx
@@ -36,6 +36,7 @@ const BACKGROUNDS = [
   'surface-info-strong',
   'surface-paper-default',
   'surface-notification',
+  'surface-field-disabled',
   'brand-primary-default',
   'brand-primary-subtle',
   'brand-primary-medium',

--- a/packages/dds-components/src/utils/readonlyEventHandlers.tsx
+++ b/packages/dds-components/src/utils/readonlyEventHandlers.tsx
@@ -23,7 +23,7 @@ export const readOnlyMouseDownHandler = <T,>(
   };
 };
 
-type ReadOnlyKeyDownHandlerType = 'select' | 'selectionControl';
+type ReadOnlyKeyDownHandlerType = 'select' | 'selectionControl' | 'file';
 
 export const readOnlyKeyDownHandler = <T,>(
   type: ReadOnlyKeyDownHandlerType,
@@ -41,6 +41,8 @@ export const readOnlyKeyDownHandler = <T,>(
       ) {
         evt.preventDefault();
       } else if (type === 'selectionControl' && evt.key === ' ') {
+        evt.preventDefault();
+      } else if (type === 'file' && (evt.key === ' ' || evt.key === 'Enter')) {
         evt.preventDefault();
       }
     } else onKeyDown?.(evt);


### PR DESCRIPTION
## Beskrivelse

Komponenten kunne få disse props uten noe effekt. Implementerer de på ordentlig:

- Hvis komponenten har ingen filer ser man kun ledetekst og ingen filer-tekst. ved `readOnly` kan `<input>` få fokus og teksten er tilgjengelig.
- Hvis filer er lastet opp ser man ledetekst + filliste tilgjengelig for skjermlesere..

<img width="472" height="367" alt="image" src="https://github.com/user-attachments/assets/2e145866-ec52-4dee-8a0d-878f940de67d" />

Gjort i samme slengen:

- Utbedrer tester.
- Legger til manglende oversettelser.
- Migrerer `FileUploader.mdx` til visning med `<Tabs>`.
- Utvider `background` prop i `<Paper>` til å støtte `'surface-field-disabled'`.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
