### PR TITLE
ELSA1-701 Fikser inaktiv `<InputStepper>` styling

### DIFF
--- a/.changeset/eighty-cups-write.md
+++ b/.changeset/eighty-cups-write.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser styling i `<InputStepper>` ved `disabled` og `readOnly`.

--- a/packages/dds-components/src/components/InputStepper/InputStepper.module.css
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.module.css
@@ -1,7 +1,7 @@
 .input-container {
   display: flex;
 }
-.textInput {
+.textInput:enabled:read-write {
   text-align: center;
   border-radius: 0;
 }


### PR DESCRIPTION
## Beskrivelse

Ved `disabled` og `readOnly` bør border radius være som standard og input ikke sentrert.

<img width="253" height="227" alt="image" src="https://github.com/user-attachments/assets/d83eb3db-fd3f-4a44-843f-83dfdc62dca2" />


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
