### PR TITLE
ELSA1-655 Utbedrer stories og docs for `<DescriptionList>`

### DIFF
--- a/packages/dds-components/src/components/DescriptionList/DescriptionList.mdx
+++ b/packages/dds-components/src/components/DescriptionList/DescriptionList.mdx
@@ -5,6 +5,7 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as DescriptionListStories from './DescriptionList.stories';
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
 <Meta of={DescriptionListStories} />
 
@@ -18,43 +19,61 @@ import * as DescriptionListStories from './DescriptionList.stories';
   withBottomSpacing
 />
 
-Beskrivelseslister bygges med følgende subkomponenter:
+## Delkomponenter
 
-- **`<DescriptionList>`**: tilsvarer `<dl>`, hele listen.
-- **`<DescriptionListTerm>`**: tilsvarer `<dt>`, uttrykk eller ledetekst.
-- **`<DescriptionListDesc>`**: tilsvarer `<dd>`, verdi eller beskrivelse.
-- **`<DescriptionListGroup>`**: wrapper til bruk for gruppering eller spesifikk layout.
+<Tabs>
+  <TabList>
+    <Tab>DescriptionList</Tab>
+    <Tab>DescriptionListGroup</Tab>
+    <Tab>DescriptionListTerm</Tab>
+    <Tab>DescriptionListDesc</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      Tilsvarer `<dl>` - hele listen.
 
-## Props
+      <Canvas of={DescriptionListStories.Preview} />
+      <Controls of={DescriptionListStories.Preview} />
+    </TabPanel>
+    <TabPanel>
+      En valgfri delkomponent som kan brukes til å gruppere terms
+      og descriptions for riktig layout.
 
-### DescriptionList
+      <ArgTypes of={DescriptionListGroup} />
+    </TabPanel>
+    <TabPanel>
+      Tilsvarer `<dt>` - uttrykk eller ledetekst.
+    </TabPanel>
+    <TabPanel>
+      Tilsvarer `<dd>` - verdi eller beskrivelse.
 
-Tilsvarer `<dl>`.
+      <ArgTypes of={DescriptionListDesc} />
+    </TabPanel>
 
-<Canvas of={DescriptionListStories.Preview} />
-<Controls of={DescriptionListStories.Preview} />
+  </TabPanels>
+</Tabs>
 
-### DescriptionListTerm
+## Eksempler
 
-Tilsvarer `<dt>`.
+<Tabs>
+  <TabList>
+    <Tab>Row</Tab>
+    <Tab>Med ikon</Tab>
+    <Tab>Gruppe</Tab>
 
-### DescriptionListDesc
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      Hvis beskrivelseslisten skal legge seg over flere kolonner
+      på en spesifikk måte kan man bruke `<DescriptionListGroup>` og sette `direction="row"` på `<DescriptionList>`.
+      <Canvas of={DescriptionListStories.Row} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={DescriptionListStories.WithIcon} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={DescriptionListStories.Group} />
+    </TabPanel>
 
-Tilsvarer `<dd>`.
-
-<ArgTypes of={DescriptionListDesc} />
-
-### DescriptionListGroup
-
-En valgfri subkomponent som kan brukes til å gruppere terms
-og descriptions. Den kan være relevant for å få til riktig layout, eller wrappe gruppen
-til andre formål.
-
-<ArgTypes of={DescriptionListGroup} />
-
-#### Eksempler
-
-Hvis beskrivelseslisten skal legge seg over flere kolonner
-på en spesifikk måte kan man sette `direction="row"` på DescriptionList-elementet.
-
-<Canvas of={DescriptionListStories.RowDirectionExample} />
+  </TabPanels>
+</Tabs>

--- a/packages/dds-components/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/packages/dds-components/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -1,9 +1,9 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import { commonArgTypes } from '../../storybook/helpers';
-import { CallIcon } from '../Icon/icons';
-import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
-import { Typography } from '../Typography';
+import { CallIcon, HomeIcon } from '../Icon/icons';
+import { StoryVStack } from '../layout/Stack/utils';
+import { Link } from '../Typography';
 
 import {
   DescriptionList,
@@ -33,53 +33,39 @@ export const Preview: Story = {
     </DescriptionList>
   ),
 };
-export const Overview: Story = {
+
+export const Appearances: Story = {
   render: () => (
-    <>
-      <StoryHStack>
-        <StoryVStack>
-          <DescriptionList>
-            <DescriptionListTerm>Tittel</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+    <StoryVStack>
+      <DescriptionList appearance="default">
+        <DescriptionListTerm>Default</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+      </DescriptionList>
+      <DescriptionList appearance="subtle">
+        <DescriptionListTerm>Subtle</DescriptionListTerm>
+        <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
+      </DescriptionList>
+    </StoryVStack>
+  ),
+};
 
-            <DescriptionListTerm>Tittel</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-            <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-          </DescriptionList>
+export const WithIcon: Story = {
+  render: args => (
+    <DescriptionList {...args}>
+      <DescriptionListTerm>Tittel</DescriptionListTerm>
+      <DescriptionListDesc icon={HomeIcon}>Beskrivelse</DescriptionListDesc>
+    </DescriptionList>
+  ),
+};
 
-          <DescriptionList>
-            <DescriptionListTerm>Tittel</DescriptionListTerm>
-            <DescriptionListDesc icon={CallIcon}>
-              <Typography typographyType="a">+47 123 45 678</Typography>
-            </DescriptionListDesc>
-            <DescriptionListTerm>Tittel</DescriptionListTerm>
-            <DescriptionListDesc icon={CallIcon}>
-              <Typography typographyType="a">+47 123 45 678</Typography>
-            </DescriptionListDesc>
-          </DescriptionList>
-        </StoryVStack>
-        <StoryVStack>
-          <DescriptionList appearance="subtle">
-            <DescriptionListTerm>Tittel</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-
-            <DescriptionListTerm>Tittel</DescriptionListTerm>
-            <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-            <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
-          </DescriptionList>
-          <DescriptionList appearance="subtle">
-            <DescriptionListTerm>Tittel</DescriptionListTerm>
-            <DescriptionListDesc icon={CallIcon}>
-              <Typography typographyType="a">+47 123 45 678</Typography>
-            </DescriptionListDesc>
-            <DescriptionListTerm>Tittel</DescriptionListTerm>
-            <DescriptionListDesc icon={CallIcon}>
-              <Typography typographyType="a">+47 123 45 678</Typography>
-            </DescriptionListDesc>
-          </DescriptionList>
-        </StoryVStack>
-      </StoryHStack>
-    </>
+export const Phone: Story = {
+  render: () => (
+    <DescriptionList>
+      <DescriptionListTerm>Tittel</DescriptionListTerm>
+      <DescriptionListDesc icon={CallIcon}>
+        <Link>+47 123 45 678</Link>
+      </DescriptionListDesc>
+    </DescriptionList>
   ),
 };
 
@@ -107,19 +93,8 @@ export const Group: Story = {
   ),
 };
 
-export const WithIcon: Story = {
-  render: args => (
-    <DescriptionList {...args}>
-      <DescriptionListTerm>Tittel</DescriptionListTerm>
-      <DescriptionListDesc icon={CallIcon}>
-        <Typography typographyType="a">+47 123 45 678</Typography>
-      </DescriptionListDesc>
-    </DescriptionList>
-  ),
-};
-
-const margin = 'var(--dds-spacing-x1)';
-export const RowDirectionExample: Story = {
+const margin = 'var(--dds-spacing-x0-75)';
+export const Row: Story = {
   render: args => (
     <DescriptionList {...args} direction="row">
       <DescriptionListGroup margin={margin}>


### PR DESCRIPTION
## Beskrivelse

Migrerer til tab-visning i docs og utbedrer eksempler i stories.

<img width="1083" height="867" alt="image" src="https://github.com/user-attachments/assets/c5842932-549c-4e9d-84ea-786a13f9883a" />

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
