### PR TITLE
ELSA1-585 Gjør select i `<Pagination>` bredere

### DIFF
--- a/.changeset/clean-phones-crash.md
+++ b/.changeset/clean-phones-crash.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Gjør select i `<Pagination>` bredere slik at lenge alternativer får plass.

--- a/.changeset/sixty-wolves-greet.md
+++ b/.changeset/sixty-wolves-greet.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Legger til console warning for når verdien til `defaultItemsPerPage` prop ikke er inkludert i `selectOptions` prop i `<Pagination>`.

--- a/packages/dds-components/src/components/Pagination/Pagination.mdx
+++ b/packages/dds-components/src/components/Pagination/Pagination.mdx
@@ -4,6 +4,7 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as PaginationStories from './Pagination.stories';
+import { Tabs, Tab, TabList, TabPanel, TabPanels } from '../Tabs';
 
 <Meta of={PaginationStories} />
 
@@ -17,14 +18,31 @@ import * as PaginationStories from './Pagination.stories';
   withBottomSpacing
 />
 
-`<Pagination>` brukes i kombinasjon med tabell eller lignende innhold som kan deles opp i lister med elementer. Komponenten er responsiv.
+<Tabs>
+  <TabList>
+    <Tab>Preview</Tab>
+    <Tab>Med select</Tab>
+    <Tab>Med counter</Tab>
+    <Tab>Med counter og select</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      <Canvas of={PaginationStories.Preview} />
+      <Controls of={PaginationStories.Preview} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={PaginationStories.WithCounter} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={PaginationStories.WithSelect} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={PaginationStories.WithCounterAndSelect} />
+    </TabPanel>
+  </TabPanels>
+</Tabs>
 
-## Props
-
-<Canvas of={PaginationStories.Preview} />
-<Controls of={PaginationStories.Preview} />
-
-### Types
+## Types
 
 <Source
   code={`
@@ -35,24 +53,30 @@ import * as PaginationStories from './Pagination.stories';
   `}
 />
 
-### Indeksering
+## Indeksering
 
 Det brukes 1-indeksering slik at sidenummeret blir brukt som label i knappene.
 
 ## Eksempler
 
-### Custom options
+<Tabs>
+  <TabList>
+    <Tab>Custom options</Tab>
+    <Tab>Custom aktiv side</Tab>
+    <Tab>Liten skjerm</Tab>
 
-<Canvas of={PaginationStories.CustomOptions} />
-
-### Custom aktiv side
-
-<Canvas of={PaginationStories.DefaultActivePage} />
-
-### Custom antall elementer per side
-
-<Canvas of={PaginationStories.DefaultItemsPerPage} />
-
-### Responsiv
-
-<Canvas of={PaginationStories.Responsive} />
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      Du kan sette egne alternativer for `<select>` med `selectOptions`. Ta gjerne med `"Alle"` - mange brukere forventer å ha denne muligheten. Sørg for at `DefaultItemsPerPage`-verdien er inkludert i `selectOptions`.
+      <Canvas of={PaginationStories.CustomOptions} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={PaginationStories.DefaultActivePage} />
+    </TabPanel>
+    <TabPanel>
+      Bruk aktivt versjonen for liten skjerm. Sjekk hvilket brekkpunkt gir mest mening i din løsning.
+      <Canvas of={PaginationStories.SmallScreen} />
+    </TabPanel>
+  </TabPanels>
+</Tabs>

--- a/packages/dds-components/src/components/Pagination/Pagination.spec.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.spec.tsx
@@ -13,13 +13,13 @@ describe('<Pagination>', () => {
     render(<Pagination itemsAmount={100} defaultActivePage={3} />);
     expect(
       within(screen.getAllByRole('listitem')[0]).getByRole('button'),
-    ).toHaveAttribute('aria-label', 'Forrige side');
+    ).toHaveAccessibleName('Forrige side');
     expect(
       within(screen.getAllByRole('listitem')[1]).getByRole('button'),
-    ).toHaveAttribute('aria-label', 'Side 1');
+    ).toHaveAccessibleName('Side 1');
     expect(
       within(screen.getAllByRole('listitem')[3]).getByRole('button'),
-    ).toHaveAttribute('aria-label', 'Nåværende side (3)');
+    ).toHaveAccessibleName('Nåværende side (3)');
   });
   it('should render correct number of pages', () => {
     const itemsAmount = 6;

--- a/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
@@ -1,7 +1,12 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
-import { commonArgTypes, windowWidthDecorator } from '../../storybook/helpers';
+import {
+  StoryLabel,
+  commonArgTypes,
+  windowWidthDecorator,
+} from '../../storybook/helpers';
+import { VStack } from '../layout';
 import { StoryVStack } from '../layout/Stack/utils';
 import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
 
@@ -37,49 +42,96 @@ export const Preview: Story = {
   args: { itemsAmount: 100 },
 };
 
-export const Overview: Story = {
+export const Variants: Story = {
   args: { itemsAmount: 100 },
   render: args => (
-    <StoryVStack gap="x3">
-      <Pagination {...args} />
-      <Pagination {...args} withCounter />
-      <Pagination {...args} withSelect />
-      <Pagination {...args} withCounter withSelect />
-      <Pagination {...args} withCounter withSelect withPagination={false} />
-      <Pagination {...args} withPagination={false} withCounter />
+    <StoryVStack gap="x2.5">
+      <VStack gap="x0.25">
+        <StoryLabel>Med counter</StoryLabel>
+        <Pagination {...args} withCounter />
+      </VStack>
+      <VStack gap="x0.25">
+        <StoryLabel>Med select</StoryLabel>
+        <Pagination {...args} withSelect />
+      </VStack>
+      <VStack gap="x0.25">
+        <StoryLabel>Med select og counter</StoryLabel>
+        <Pagination {...args} withCounter withSelect />
+      </VStack>
+      <VStack gap="x0.25">
+        <StoryLabel>Kun select og counter</StoryLabel>
+        <Pagination {...args} withCounter withSelect withPagination={false} />
+      </VStack>
+      <VStack gap="x0.25">
+        <StoryLabel>Kun Counter</StoryLabel>
+        <Pagination {...args} withPagination={false} withCounter />
+      </VStack>
     </StoryVStack>
   ),
 };
 
-export const OverviewMobile: Story = {
+export const VariantsSmallScreen: Story = {
   args: { itemsAmount: 100 },
   render: args => (
-    <StoryVStack gap="x3">
-      <Pagination {...args} smallScreenBreakpoint="xl" />
-      <Pagination {...args} smallScreenBreakpoint="xl" withCounter />
-      <Pagination {...args} smallScreenBreakpoint="xl" withSelect />
-      <Pagination {...args} smallScreenBreakpoint="xl" withCounter withSelect />
+    <StoryVStack gap="x2.5">
+      <VStack gap="x0.25">
+        <StoryLabel>Pagination</StoryLabel>
+        <Pagination {...args} smallScreenBreakpoint="xl" />
+      </VStack>
+      <VStack gap="x0.25">
+        <StoryLabel>Med counter</StoryLabel>
+        <Pagination {...args} smallScreenBreakpoint="xl" withCounter />
+      </VStack>
+      <VStack gap="x0.25">
+        <StoryLabel>Med select</StoryLabel>
+        <Pagination {...args} smallScreenBreakpoint="xl" withSelect />
+      </VStack>
+      <VStack gap="x0.25">
+        <StoryLabel>Med select og counter</StoryLabel>
+        <Pagination
+          {...args}
+          smallScreenBreakpoint="xl"
+          withCounter
+          withSelect
+        />
+      </VStack>
     </StoryVStack>
   ),
+};
+
+export const WithSelect: Story = {
+  args: { itemsAmount: 100, withSelect: true },
+};
+
+export const WithCounter: Story = {
+  args: { itemsAmount: 100, withCounter: true },
+};
+
+export const WithCounterAndSelect: Story = {
+  args: { itemsAmount: 100, withCounter: true, withSelect: true },
+};
+
+export const SmallScreen: Story = {
+  args: { itemsAmount: 100, smallScreenBreakpoint: 'xl' },
 };
 
 export const CustomOptions: Story = {
-  args: { itemsAmount: 100 },
-  render: args => (
-    <Pagination
-      {...args}
-      withCounter
-      withSelect
-      defaultItemsPerPage={customOptions[0].value}
-      selectOptions={customOptions}
-      itemsAmount={customOptionsItemsAmount}
-    />
-  ),
+  args: {
+    itemsAmount: customOptionsItemsAmount,
+    defaultItemsPerPage: customOptions[0].value,
+    withCounter: true,
+    withSelect: true,
+    selectOptions: customOptions,
+  },
 };
 
 export const Responsive: Story = {
-  args: { smallScreenBreakpoint: 'sm', itemsAmount: 100 },
-  render: args => <Pagination {...args} withCounter withSelect />,
+  args: {
+    smallScreenBreakpoint: 'sm',
+    itemsAmount: 100,
+    withCounter: true,
+    withSelect: true,
+  },
   decorators: [
     Story =>
       windowWidthDecorator(
@@ -90,11 +142,5 @@ export const Responsive: Story = {
 };
 
 export const DefaultActivePage: Story = {
-  args: { itemsAmount: 100 },
-  render: args => <Pagination {...args} defaultActivePage={6} />,
-};
-
-export const DefaultItemsPerPage: Story = {
-  args: { itemsAmount: 100 },
-  render: args => <Pagination {...args} withCounter defaultItemsPerPage={48} />,
+  args: { itemsAmount: 100, defaultActivePage: 6 },
 };

--- a/packages/dds-components/src/components/Pagination/Pagination.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.tsx
@@ -27,13 +27,13 @@ export interface PaginationOption {
 export type PaginationProps = BaseComponentProps<
   HTMLElement,
   {
-    /**Totalt antall elementer å paginere. */
+    /**Totalt antall elementer som skal pagineres. */
     itemsAmount: number;
-    /**Antall elementer per side ved innlastning av komponenten.
+    /**Antall elementer per side ved innlastning.
      * @default 10
      */
     defaultItemsPerPage?: number;
-    /**Den aktive siden ved innlastning av komponenten.
+    /**Den aktive siden ved innlastning.
      * @default 1
      */
     defaultActivePage?: number;
@@ -41,11 +41,11 @@ export type PaginationProps = BaseComponentProps<
      * @default true
      */
     withPagination?: boolean;
-    /**Spesifiserer om teksten `'Vis x-y av z'` skal vises. */
+    /**Om teksten `'Vis x-y av z'` skal vises. */
     withCounter?: boolean;
-    /**Spesifiserer om `<Select />` til å velge antall resultater per side skal vises. */
+    /**Om `<Select>` for å velge antall per side skal vises. */
     withSelect?: boolean;
-    /**Custom options for `<Select />`. **OBS!** hvis det settes custom `selectOptions` bør "alle"-alternativet inkluderes der det er relevant, da brukere ofte liker å ha muligheten.
+    /**Custom options for `<Select>`. **OBS!** husk å inkludere "Alle"-alternativet hvis relevant - brukere forventer ofte den muligheten.
      * @default [
         { label: '10', value: 10 },
         { label: '25', value: 25 },
@@ -54,14 +54,16 @@ export type PaginationProps = BaseComponentProps<
       ]
      */
     selectOptions?: Array<PaginationOption>;
-    /**Brukes til å hente side og eventuelt annen logikk ved endring av side. */
+    /**Kalles ved sideendring - henter ny aktiv side og kjører ekstra logikk. */
     onChange?: (
       event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
       page: number,
     ) => void;
-    /**Brukes til å hente `selectedOption` og eventuelt kjøre annen logikk når `withSelect=true` ved endring av alternativ. */
+    /**Kalles når `selectedOption` endres, hvis `withSelect="true"`.
+     * Brukes til å hente valgt alternativ og evt. kjøre ekstra logikk.
+     */
     onSelectOptionChange?: (option: PaginationOption | null) => void;
-    /**Spesifiserer ved hvilket brekkpunkt og nedover versjonen for små skjermer skal vises; den viser færre sideknapper og stacker subkomponentene. */
+    /**Brekkpunkt for mobilvisning; den viser færre sideknapper og stacker delkomponentene. */
     smallScreenBreakpoint?: Breakpoint;
   },
   Omit<HTMLAttributes<HTMLElement>, 'onChange'>
@@ -90,6 +92,12 @@ export const Pagination = ({
   ...rest
 }: PaginationProps) => {
   const { t } = useTranslation();
+
+  if (withSelect && !selectOptions.some(o => o.value === defaultItemsPerPage)) {
+    console.warn(
+      `[Pagination] defaultItemsPerPage prop value (${defaultItemsPerPage}) is not included in customOptions prop. Please add it to ensure it appears in the dropdown.`,
+    );
+  }
 
   const [activePage, setActivePage] = useState(defaultActivePage);
   const [itemsPerPage, setItemsPerPage] = useState(defaultItemsPerPage);
@@ -308,7 +316,7 @@ export const Pagination = ({
           <Select
             options={selectOptions}
             isSearchable={false}
-            width="74px"
+            width="90px"
             defaultValue={{
               label: itemsPerPage.toString(),
               value: itemsPerPage,


### PR DESCRIPTION
## Beskrivelse

Slik at lengre alternativer som brukes i noen løsninger får plass.

<img width="862" height="105" alt="image" src="https://github.com/user-attachments/assets/7bc09b6d-c8c7-477e-a21a-8179dbece07c" />

I samme slengen:
- Utbedrer JSDoc.
- Migrerer `<Pagination>` docs til tab-visning.
- Refaktorerer stories.
- Legger til console warning for når verdien til `defaultItemsPerPage` prop ikke er inkludert i `selectOptions` prop.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
