### PR TITLE
Legge til støtte for kontrollert state i `<Pagination>`

### DIFF
--- a/.changeset/calm-results-drive.md
+++ b/.changeset/calm-results-drive.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+`<Pagination>` støtter nå kontrollert state via den nye `activePage`-propen.

--- a/packages/dds-components/src/components/Pagination/Pagination.spec.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen, within } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { userEvent } from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Pagination } from '.';
 
@@ -93,5 +94,49 @@ describe('<Pagination>', () => {
       // itemsAmount +  < button for large screen, active item + |< < buttons for small screen
       expect(screen.getAllByRole('listitem')).toHaveLength(itemsAmount + 4);
     });
+  });
+  it('should work as controlled component when activePage prop is provided', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <Pagination
+        itemsAmount={100}
+        defaultItemsPerPage={10}
+        activePage={3}
+        onChange={onChange}
+      />,
+    );
+
+    // Should display page 3 as active (controlled)
+    expect(
+      screen.getByRole('button', { name: 'Nåværende side (3)' }),
+    ).toBeInTheDocument();
+
+    // Click page 5
+    const page5Button = screen.getByRole('button', { name: 'Side 5' });
+    await user.click(page5Button);
+
+    // onChange should be called
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), 5);
+
+    // Page should still be 3 (controlled - doesn't change until prop changes)
+    expect(
+      screen.getByRole('button', { name: 'Nåværende side (3)' }),
+    ).toBeInTheDocument();
+
+    // Re-render with new activePage
+    rerender(
+      <Pagination
+        itemsAmount={100}
+        defaultItemsPerPage={10}
+        activePage={5}
+        onChange={onChange}
+      />,
+    );
+
+    // Now page 5 should be active
+    expect(
+      screen.getByRole('button', { name: 'Nåværende side (5)' }),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
@@ -1,4 +1,5 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
 import { fn } from 'storybook/test';
 
 import {
@@ -6,8 +7,9 @@ import {
   commonArgTypes,
   windowWidthDecorator,
 } from '../../storybook/helpers';
+import { Button } from '../Button';
 import { VStack } from '../layout';
-import { StoryVStack } from '../layout/Stack/utils';
+import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { StoryThemeProvider } from '../ThemeProvider/utils/StoryThemeProvider';
 
 import { Pagination } from '.';
@@ -143,4 +145,51 @@ export const Responsive: Story = {
 
 export const DefaultActivePage: Story = {
   args: { itemsAmount: 100, defaultActivePage: 6 },
+};
+
+export const Controlled: Story = {
+  args: { itemsAmount: 100 },
+  render: args => {
+    const ControlledExample = () => {
+      const [currentPage, setCurrentPage] = useState(1);
+
+      return (
+        <StoryVStack gap="x2">
+          <StoryHStack gap="x0.5" alignItems="center">
+            <span>Ekstern kontroll:</span>
+            <Button
+              size="small"
+              onClick={() => setCurrentPage(1)}
+              purpose={currentPage === 1 ? 'primary' : 'secondary'}
+            >
+              Gå til side 1
+            </Button>
+            <Button
+              size="small"
+              onClick={() => setCurrentPage(5)}
+              purpose={currentPage === 5 ? 'primary' : 'secondary'}
+            >
+              Gå til side 5
+            </Button>
+            <Button
+              size="small"
+              onClick={() => setCurrentPage(10)}
+              purpose={currentPage === 10 ? 'primary' : 'secondary'}
+            >
+              Gå til side 10
+            </Button>
+          </StoryHStack>
+          <Pagination
+            {...args}
+            activePage={currentPage}
+            onChange={(_, page) => {
+              setCurrentPage(page);
+            }}
+          />
+        </StoryVStack>
+      );
+    };
+
+    return <ControlledExample />;
+  },
 };

--- a/packages/dds-components/src/components/Pagination/Pagination.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.tsx
@@ -2,6 +2,7 @@ import { type HTMLAttributes, useState } from 'react';
 
 import styles from './Pagination.module.css';
 import { PaginationGenerator } from './paginationGenerator';
+import { useControllableState } from '../../hooks/useControllableState';
 import { createTexts, useTranslation } from '../../i18n';
 import { type BaseComponentProps, getBaseHTMLProps } from '../../types';
 import { cn } from '../../utils';
@@ -37,6 +38,8 @@ export type PaginationProps = BaseComponentProps<
      * @default 1
      */
     defaultActivePage?: number;
+    /**Den aktive siden. Brukes til kontrollert tilstand - når denne er satt styrer du siden utenfra. */
+    activePage?: number;
     /**Spesifiserer om selve pagineringen skal vises.
      * @default true
      */
@@ -73,6 +76,7 @@ export const Pagination = ({
   itemsAmount,
   defaultItemsPerPage = 10,
   defaultActivePage = 1,
+  activePage: activePageProp,
   withPagination = true,
   withCounter,
   withSelect,
@@ -98,8 +102,10 @@ export const Pagination = ({
       `[Pagination] defaultItemsPerPage prop value (${defaultItemsPerPage}) is not included in customOptions prop. Please add it to ensure it appears in the dropdown.`,
     );
   }
-
-  const [activePage, setActivePage] = useState(defaultActivePage);
+  const [activePage, setActivePage] = useControllableState({
+    value: activePageProp,
+    defaultValue: defaultActivePage,
+  });
   const [itemsPerPage, setItemsPerPage] = useState(defaultItemsPerPage);
 
   const pagesLength = Math.ceil(itemsAmount / itemsPerPage);


### PR DESCRIPTION
## Beskrivelse

Komponenten bruker nå `useControllableState`-hooken for å støtte både kontrollert og ukontrollert bruk. Den nye `activePage`-propen lar utviklere styre aktiv side utenfra, mens eksisterende bruk med `defaultActivePage` fortsatt fungerer som før (ukontrollert).

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [ ] I commits
  - [ ] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
