### PR TITLE
ELSA1-693 Redesign av `<Spinner>`

### DIFF
--- a/.changeset/cold-lies-jog.md
+++ b/.changeset/cold-lies-jog.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Redesign av `<Spinner>`: den bruker en animasjon av elementer som symboliserer ulike typer domstoler, slik det er definert i designmanualen.

--- a/.changeset/full-impalas-sort.md
+++ b/.changeset/full-impalas-sort.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser spacing for ikonet/spinner i `<Toggle>`.

--- a/.changeset/funny-papayas-lick.md
+++ b/.changeset/funny-papayas-lick.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der verdier for deprecated HTML attributt `color` var støttet i tillegg til `color` prop i `<Spinner>`.

--- a/packages/dds-components/src/components/Spinner/Spinner.mdx
+++ b/packages/dds-components/src/components/Spinner/Spinner.mdx
@@ -4,6 +4,7 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as SpinnerStories from './Spinner.stories';
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
 <Meta of={SpinnerStories} />
 
@@ -13,15 +14,35 @@ import * as SpinnerStories from './Spinner.stories';
   docsHref="https://design.domstol.no/987b33f71/p/37e415-spinner/b/7539bc"
   githubHref="https://github.com/domstolene/designsystem/tree/main/packages/components/src/components/Spinner"
   storybookHref="https://domstolene.github.io/designsystem/?path=/story/dds-components-components-spinner--default"
+  figmaHref="https://www.figma.com/design/ewqSDmkgqDQ5PyOsRp4V5b/DDS-Komponenter?node-id=13027-235851"
   withBottomSpacing
 />
 
-`<Spinner>` brukes for å indikere innlastning an innhold. Den er et animert `<svg>`-element som bruker nåværende tid til å bestemme hvor den skal starte i animasjonen.
+`<Spinner>` indikerer innlastning an innhold. Den er et animert `<svg>`-element som bruker nåværende tid til å bestemme hvor den skal starte i animasjonen.
 
-## Props
-
-<Canvas of={SpinnerStories.Preview} />
-<Controls of={SpinnerStories.Preview} />
+<Tabs>
+  <TabList>
+    <Tab>Preview</Tab>
+    <Tab>Custom farge</Tab>
+    <Tab>Størrelse</Tab>
+    <Tab>Custom tooltip</Tab>
+  </TabList>
+  <TabPanels>
+    <TabPanel>
+      <Canvas of={SpinnerStories.Preview} />
+      <Controls of={SpinnerStories.Preview} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={SpinnerStories.CustomColor} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={SpinnerStories.CustomSize} />
+    </TabPanel>
+    <TabPanel>
+      <Canvas of={SpinnerStories.CustomTooltip} />
+    </TabPanel>
+  </TabPanels>
+</Tabs>
 
 ## Retningslinjer
 

--- a/packages/dds-components/src/components/Spinner/Spinner.module.css
+++ b/packages/dds-components/src/components/Spinner/Spinner.module.css
@@ -1,36 +1,115 @@
 .svg {
   display: block;
-  stroke-dasharray: 90, 150;
-  animation: rotate 1.5s linear infinite;
-  @media (prefers-reduced-motion: no-preference) {
-    animation: rotate 2s linear infinite;
-  }
 }
 
-.circle {
-  stroke-linecap: round;
-  @media (prefers-reduced-motion: no-preference) {
-    animation: dash 1.5s ease-in-out infinite;
-  }
+.jordskifterett,
+.lagmannsrett,
+.tingrett {
+  transform-origin: center;
+  transform-box: fill-box;
+  animation-duration: 3.4s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
 }
 
-@keyframes rotate {
-  100% {
-    transform: rotate(360deg);
-  }
+.jordskifterett {
+  animation-name: jordskifterett;
 }
 
-@keyframes dash {
+.tingrett {
+  animation-name: tingrett;
+}
+
+.lagmannsrett {
+  animation-name: lagmannsrett;
+}
+
+@keyframes jordskifterett {
   0% {
-    stroke-dasharray: 1, 150;
-    stroke-dashoffset: 0;
+    transform: scale(0.01);
   }
+
+  16.66% {
+    transform: scale(1);
+  }
+
+  33.33% {
+    transform: scale(0.1);
+  }
+
   50% {
-    stroke-dasharray: 90, 150;
-    stroke-dashoffset: -35;
+    transform: scale(0.01);
   }
+
+  66.66% {
+    transform: scale(0.01);
+  }
+
+  83.33% {
+    transform: scale(0.01);
+  }
+
   100% {
-    stroke-dasharray: 90, 150;
-    stroke-dashoffset: -124;
+    transform: scale(0.01);
+  }
+}
+
+@keyframes tingrett {
+  0% {
+    transform: scale(0.01);
+  }
+
+  16.66% {
+    transform: scale(0.01);
+  }
+
+  33.33% {
+    transform: scale(0.01);
+  }
+
+  50% {
+    transform: scale(1);
+  }
+
+  66.66% {
+    transform: scale(0.1);
+  }
+
+  83.33% {
+    transform: scale(0.01);
+  }
+
+  100% {
+    transform: scale(0.01);
+  }
+}
+
+@keyframes lagmannsrett {
+  0% {
+    transform: scale(0.01);
+  }
+
+  16.66% {
+    transform: scale(0.01);
+  }
+
+  33.33% {
+    transform: scale(0.01);
+  }
+
+  50% {
+    transform: scale(0.01);
+  }
+
+  66.66% {
+    transform: scale(0.01);
+  }
+
+  83.33% {
+    transform: scale(1);
+  }
+
+  100% {
+    transform: scale(0.1);
   }
 }

--- a/packages/dds-components/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/dds-components/src/components/Spinner/Spinner.stories.tsx
@@ -1,7 +1,6 @@
 import { type Meta, type StoryObj } from '@storybook/react-vite';
 
 import { commonArgTypes } from '../../storybook/helpers';
-import { StoryHStack } from '../layout/Stack/utils';
 
 import { Spinner } from '.';
 
@@ -19,15 +18,12 @@ type Story = StoryObj<typeof Spinner>;
 
 export const Preview: Story = {};
 
-export const Overview: Story = {
-  render: args => (
-    <StoryHStack>
-      <Spinner {...args} />
-      <Spinner {...args} color="icon-subtle" />
-      <Spinner {...args} color="icon-on-success-default" />
-      <Spinner {...args} size="60px" />
-    </StoryHStack>
-  ),
+export const CustomColor: Story = {
+  args: { color: 'icon-on-success-default' },
+};
+
+export const CustomSize: Story = {
+  args: { size: '150px' },
 };
 
 export const CustomTooltip: Story = {

--- a/packages/dds-components/src/components/Spinner/Spinner.tsx
+++ b/packages/dds-components/src/components/Spinner/Spinner.tsx
@@ -1,5 +1,5 @@
-import { type Property } from 'csstype';
-import { useId, useRef } from 'react';
+import { type Properties, type Property } from 'csstype';
+import { type HTMLAttributes, useId, useRef } from 'react';
 
 import styles from './Spinner.module.css';
 import { useTranslation } from '../../i18n';
@@ -22,7 +22,8 @@ export type SpinnerProps = BaseComponentProps<
      * @default "Innlasting pågår"
      */
     tooltip?: string;
-  }
+  },
+  Omit<HTMLAttributes<SVGSVGElement>, 'color'>
 >;
 
 export function Spinner(props: SpinnerProps) {
@@ -39,37 +40,51 @@ export function Spinner(props: SpinnerProps) {
   const { t } = useTranslation();
 
   const mountTime = useRef(Date.now());
-  const outerAnimationDelay = -(mountTime.current % 2000);
-  const innerAnimationDelay = -(mountTime.current % 1500);
+  const animationDelay = -(mountTime.current % 1500);
+
+  const styleVariables: Properties = {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ['--dds-spinner-animation-delay' as any]: animationDelay,
+  };
 
   const generatedId = useId();
   const uniqueId = `${generatedId}-spinnerTitle`;
 
   return (
     <svg
-      viewBox="0 0 50 50"
+      viewBox="0 0 25 25"
       role="progressbar"
       aria-labelledby={uniqueId}
       {...getBaseHTMLProps(id, cn(className, styles.svg), htmlProps, rest)}
       style={{
         ...htmlProps?.style,
-        animationDelay: outerAnimationDelay + 'ms',
         width: size,
         height: size,
       }}
     >
       <title id={uniqueId}>{tooltip ?? t(commonTexts.loading)}</title>
       <circle
-        className={cn(styles.circle)}
-        style={{
-          animationDelay: innerAnimationDelay + 'ms',
-        }}
-        cx="25"
-        cy="25"
-        r="20"
-        fill="none"
-        stroke={getTextColor(color)}
-        strokeWidth="4"
+        cx="12"
+        cy="12.25"
+        r="6"
+        fill={getTextColor(color)}
+        className={styles.jordskifterett}
+        style={styleVariables}
+      />
+      <rect
+        x="4"
+        y="10.25"
+        width="16"
+        height="4"
+        fill={getTextColor(color)}
+        className={styles.lagmannsrett}
+        style={styleVariables}
+      />
+      <path
+        d="M12 16.6154C16.4183 16.6154 20 12.7581 20 8H4C4 12.7581 7.58172 16.6154 12 16.6154Z"
+        fill={getTextColor(color)}
+        className={styles.tingrett}
+        style={styleVariables}
       />
     </svg>
   );

--- a/packages/dds-components/src/components/Toggle/Toggle.module.css
+++ b/packages/dds-components/src/components/Toggle/Toggle.module.css
@@ -25,6 +25,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: var(--dds-spacing-x0-125);
   border-radius: var(--dds-border-radius-rounded);
   background-color: var(--dds-color-surface-field-default);
   border: 1px solid var(--dds-color-border-default);


### PR DESCRIPTION
## Beskrivelse

Den bruker en animasjon av elementer som symboliserer ulike typer domstoler, slik det er definert i designmanualen. Se [detaljer](https://design.domstol.no/987b33f71/p/802ae7-digitale-flater/b/1655a7).

https://github.com/user-attachments/assets/bb7e8ee6-c432-4aa4-8d45-536b405d621a


I samme slengen:
- Migrerer til tabs-visning i docs.
- Fikser `color` prop støtte slik at det ekskluderer deprecated HTML `color` attr.
- Spacing i `<Toggle>`.


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- Jira-kode for oppgaven (`ELSA1-<oppgavenummer>`):
  - [x] I commits
  - [x] I PR-tittelen
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
