### PR TITLE
Oppdaterer informasjon om linking av pakke

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,8 @@ cd ~/din-app
 npm link pakke
 ```
 
+`pakke` må tilsvare `name` som er satt i `pakke/package.json`, for eksempel `@norges-domstoler/dds-components`.
+
 ### Finner ikke pakken
 
 Skal ikke egentlig være nødvendig, men hvis du får en feilmeldinger om at den ikke finner en av pakkene kan du prøve:


### PR DESCRIPTION
## Beskrivelse

Oppdaterer informasjon om linking av dds-pakke i andre prosjekt. Navnet på pakken må være tilsvarende det som er satt opp som `name` i `package.json`.

