### PR TITLE
ELSA1-815: fjerner unødvendig fit-height

### DIFF
--- a/.changeset/puny-doors-arrive.md
+++ b/.changeset/puny-doors-arrive.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fjerner `fit-height` fra button for å unngå ulike knapphøyde i ulike nettlesere.

--- a/packages/dds-components/src/components/Button/Button.module.css
+++ b/packages/dds-components/src/components/Button/Button.module.css
@@ -3,7 +3,6 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  height: fit-content;
   width: fit-content;
   cursor: pointer;
   box-shadow: none;


### PR DESCRIPTION

## Beskrivelse

Fjerner unødvendig fit-height som er rot årsak til forskjellige knapp-høyder mellom nettlesere (Safari og Chrome).

## Sjekkliste

### Generelt

- [ ] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
