### PR TITLE
ELSA1-795: Lukking av `<OverflowMenu>` ved `onClickAsync`

### DIFF
--- a/.changeset/nine-symbols-grab.md
+++ b/.changeset/nine-symbols-grab.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Ny prop i `<OverflowMenuButton>`: `closeMenuOnClickAsync`. Den tillater custom styring av lukking av menyen ved klikk på knappen og bruk av `clickAsync`: egen fuknsjon eller ingen lukking. Bruker intern logikk som default.

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -15,6 +15,7 @@ import {
 } from '../Icon/icons';
 import { VStack } from '../layout';
 import { Table } from '../Table';
+import { Paragraph } from '../Typography';
 import { OverflowMenuToggle } from './components/OverflowMenuToggle';
 
 import {
@@ -163,7 +164,76 @@ export const WithAsyncClick: Story = {
                 Handling
               </OverflowMenuButton>
             </OverflowMenuList>
-            <OverflowMenuDivider />
+          </OverflowMenu>
+        </OverflowMenuGroup>
+      </VStack>
+    );
+  },
+};
+
+export const WithNoMenuCloseOnAsyncClick: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: args => {
+    const [text, setText] = useState('Klikk på "Handling" i menyen');
+    const click = async () => {
+      setText('Jobber...');
+      await new Promise(resolve => setTimeout(resolve, 2000));
+      setText('Ferdig!');
+    };
+    return (
+      <VStack>
+        <span>{text}</span>
+        <OverflowMenuGroup>
+          <Button icon={MenuIcon} aria-label="Åpne meny" />
+          <OverflowMenu {...args}>
+            <OverflowMenuList>
+              <OverflowMenuButton
+                onClickAsync={click}
+                closeMenuOnClickAsync={false}
+              >
+                Handling
+              </OverflowMenuButton>
+            </OverflowMenuList>
+          </OverflowMenu>
+        </OverflowMenuGroup>
+      </VStack>
+    );
+  },
+};
+
+export const CustomCloseOnAsyncClick: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: args => {
+    const [text, setText] = useState('Klikk på "Handling" i menyen.');
+
+    return (
+      <VStack>
+        <Paragraph>
+          Lukking av menyen er forsinket i forhold til når async-kall fullfører.
+        </Paragraph>
+        <Paragraph>{text}</Paragraph>
+        <OverflowMenuGroup>
+          <Button icon={MenuIcon} aria-label="Åpne meny" />
+          <OverflowMenu {...args}>
+            <OverflowMenuList>
+              <OverflowMenuButton
+                onClickAsync={async () => {
+                  setText('Jobber...');
+                  await new Promise(resolve => setTimeout(resolve, 2000));
+                  setText('Ferdig!');
+                }}
+                closeMenuOnClickAsync={async close => {
+                  await new Promise(r => setTimeout(r, 1000)); // det som skal fullføre
+                  close();
+                }}
+              >
+                Handling
+              </OverflowMenuButton>
+            </OverflowMenuList>
           </OverflowMenu>
         </OverflowMenuGroup>
       </VStack>

--- a/packages/dds-components/src/components/OverflowMenu/components/OverflowMenuButton.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/components/OverflowMenuButton.tsx
@@ -9,6 +9,7 @@ import { type OverflowMenuButtonProps } from '../OverflowMenu.types';
 export const OverflowMenuButton = ({
   onClick,
   onClickAsync,
+  closeMenuOnClickAsync = true,
   purpose = 'default',
   loading,
   ref,
@@ -30,17 +31,24 @@ export const OverflowMenuButton = ({
 
   const handleClick = async (e: MouseEvent<HTMLButtonElement>) => {
     if (isLoading) return;
+
+    const close = () => onClose?.();
+
     if (onClickAsync) {
       setInternalLoading(true);
+      const shouldAutoClose = closeMenuOnClickAsync === true;
+
       try {
         await onClickAsync(e);
+        if (typeof closeMenuOnClickAsync === 'function') {
+          closeMenuOnClickAsync(close);
+        } else if (shouldAutoClose) close();
       } finally {
         setInternalLoading(false);
-        onClose?.();
       }
     } else {
       onClick?.(e);
-      onClose?.();
+      close();
     }
   };
 

--- a/packages/dds-components/src/components/helpers/Dropdown/DropdownItem.tsx
+++ b/packages/dds-components/src/components/helpers/Dropdown/DropdownItem.tsx
@@ -20,6 +20,10 @@ type DropdownItemT = 'span' | 'a' | typeof StylelessButton | typeof Toggle;
 export type DropdownItemButtonProps = {
   /**Asynkron `onClick` event; håndterer loading status, slik at menyen ikke lukker seg under loading. */
   onClickAsync?: MouseEventHandler<HTMLButtonElement>;
+  /**Egen styring av når menyen skal lukkes ved klikk på knapp i menyen. Bruker intern logikk som default. Støtter i tillegg egen funksjon og ingen lukking (`false`).
+   * @default true
+   */
+  closeMenuOnClickAsync?: boolean | ((close: () => void) => void);
 } & Pick<ButtonProps, 'loading' | 'loadingTooltip'>;
 
 export interface DropdownItemCustomProps<T extends DropdownItemT = 'span'> {


### PR DESCRIPTION
Støtte for at konsumenten kan bestemme når lukking skal skje ved `onClickAsync` i `<OverflowMenuButton>`

## Beskrivelse

_Denne PRen endrer..._

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
