### PR TITLE
Uten issue: Fikser `dev` skriptet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,6 @@ Installer dependencies:
 pnpm install
 ```
 
-Bygg løsningen:
-
-```shell
-pnpm build
-```
-
 Kjør dev server:
 
 ```shell
@@ -51,6 +45,12 @@ pnpm storybook
 ```
 
 Storybook kjører på port `6006`.
+
+`dist`-mappa for hver pakke bygges én gang når `pnpm dev` kjøres. Du kan ellers bygge ved behov:
+
+```shell
+pnpm build
+```
 
 ### Linking
 

--- a/packages/dds-components/package.json
+++ b/packages/dds-components/package.json
@@ -28,8 +28,8 @@
     "test": "vitest run",
     "test:watch": "vitest watch",
     "generate-css-types": "tcm src",
-    "build": "pnpm run generate-css-types && tsup --dts",
-    "dev": "pnpm run generate-css-types --watch && tsup",
+    "build": "pnpm generate-css-types && tsup --dts",
+    "dev": "pnpm generate-css-types && tsup --dts && pnpm generate-css-types --watch",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [


### PR DESCRIPTION
## Beskrivelse

`pnpm dev` bygde ikke `dist`-mappa for `dds-components` da `generate-css-types`-skriptet kjørte med `--watch` flagg og aldri avsluttet. Man måtte kjøre `pnpm build` i tillegg, som var litt unødvendig.

Som easy fix genereres css types først en gang med `generate-css-types`, så bygges `dist` en gang, så `generate-css-types --watch`.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
