### PR TITLE
ELSA1-813: inputfelt i `<PhoneInput>` ikke på linje med hverandre

### DIFF
--- a/.changeset/happy-monkeys-serve.md
+++ b/.changeset/happy-monkeys-serve.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der inputfeltene i `<PhoneInput>` ikke var på linje med hverandre.

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.tsx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.tsx
@@ -313,7 +313,7 @@ export const PhoneInput = ({
             </option>
           ))}
         </NativeSelect>
-        <Box width="100%" className={inputStyles['input-group']}>
+        <Box width="100%" display="flex" className={inputStyles['input-group']}>
           <span
             className={cn(
               typographyStyles[`body-short-${componentSize}`],

--- a/stories/Playground/Testing/FormComponentsTesting.stories.tsx
+++ b/stories/Playground/Testing/FormComponentsTesting.stories.tsx
@@ -7,6 +7,7 @@ import {
   LocalMessage,
   MailIcon,
   NativeSelect,
+  PhoneInput,
   Search,
   Select,
   TextInput,
@@ -33,6 +34,7 @@ const sValue = { label: 'test', value: 'test' };
 const date = new Date(2024, 2, 11, 2, 30);
 const dValue = nativeDateToCalendarDate(date);
 const tValue = nativeDateToTime(date);
+const phoneValue = { countryCode: 'NO', phoneNumber: '12345678' };
 
 function renderInputs(size: InputSize) {
   return (
@@ -61,6 +63,7 @@ function renderInputs(size: InputSize) {
         options={[sValue]}
         defaultValue={sValue}
       />
+      <PhoneInput componentSize={size} defaultValue={phoneValue} />
     </>
   );
 }


### PR DESCRIPTION
## Beskrivelse

Før:

<img width="343" height="108" alt="bilde" src="https://github.com/user-attachments/assets/1c2a9e3f-2bc7-4999-9570-dced29c1b6db" />

Etter:

<img width="333" height="84" alt="bilde" src="https://github.com/user-attachments/assets/4eae83de-7087-4c7b-96a8-38d05b08537e" />

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
