### PR TITLE
ELSA1-714: Fjerner `-webkit`-prefixed CSS styling for scrollbar

### DIFF
--- a/.changeset/spotty-berries-knock.md
+++ b/.changeset/spotty-berries-knock.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fjerner `-webkit`-prefixed CSS styling for scrollbar. Den var brukt grunnet Safari, som støtter standard CSS regler siden desember 2025.

--- a/packages/dds-components/src/components/helpers/styling/utilStyles.module.css
+++ b/packages/dds-components/src/components/helpers/styling/utilStyles.module.css
@@ -34,20 +34,6 @@
 .scrollbar {
   scrollbar-width: thin;
   scrollbar-color: var(--dds-color-surface-scrollbar) transparent;
-
-  /* Safari styling. TODO: fjernes når scrollbar styling blir standardisert */
-  &::-webkit-scrollbar {
-    width: var(--dds-spacing-x0-5);
-    height: var(--dds-spacing-x0-5);
-  }
-
-  &::-webkit-scrollbar-track {
-    background: transparent;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    background: var(--dds-color-surface-scrollbar);
-  }
 }
 
 .scrollable-y {

--- a/packages/dds-components/src/components/helpers/styling/utils.ts
+++ b/packages/dds-components/src/components/helpers/styling/utils.ts
@@ -30,22 +30,6 @@ const scrollbarWidth: Property.ScrollbarWidth = 'thin';
 export const scrollbarStyling = {
   scrollbarColor: 'var(--dds-color-surface-scrollbar) transparent',
   scrollbarWidth: scrollbarWidth,
-
-  /* Safari styling. TODO: fjernes når scrollbar styling blir standardisert */
-
-  /* width */
-  '&::-webkit-scrollbar': {
-    width: 'var(--dds-spacing-x0-5)',
-    height: 'var(--dds-spacing-x0-5)',
-  },
-  /* Track */
-  '&::-webkit-scrollbar-track': {
-    background: 'transparent',
-  },
-  /* Handle */
-  '&::-webkit-scrollbar-thumb': {
-    background: 'var(--dds-color-surface-scrollbar)',
-  },
 };
 
 /**


### PR DESCRIPTION
## Beskrivelse

Den var brukt grunnet Safari, som støtter standard CSS regler siden desember 2025.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
