### PR TITLE
ELSA1-779: migrerer Storybook stories til CSF factory

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,9 +1,9 @@
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { StorybookConfig } from '@storybook/react-vite';
+import { defineMain } from '@storybook/react-vite/node';
 
-const config: StorybookConfig = {
+export default defineMain({
   stories: [
     '../stories/**/*.stories.@(js|jsx|ts|tsx)',
     '../stories/**/*.@(md|mdx)',
@@ -28,6 +28,15 @@ const config: StorybookConfig = {
     options: {},
   },
 
+  viteFinal(config) {
+    config.resolve = config.resolve || {};
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      '#.storybook': resolve(dirname(fileURLToPath(import.meta.url))),
+    };
+    return config;
+  },
+
   typescript: {
     reactDocgen: 'react-docgen-typescript',
     reactDocgenTypescriptOptions: {
@@ -37,9 +46,7 @@ const config: StorybookConfig = {
         prop.parent ? !/node_modules/.test(prop.parent.fileName) : true,
     },
   },
-};
-
-export default config;
+});
 
 function getAbsolutePath(value: string): string {
   return dirname(fileURLToPath(import.meta.resolve(`${value}/package.json`)));

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -41,7 +41,7 @@ const setCanvasBackgroundFromTheme = (counter: number) => {
 
 let nameCounter = 0;
 
-const preview = definePreview({
+export default definePreview({
   parameters: {
     controls: { sort: 'requiredFirst' },
     options: {
@@ -118,5 +118,3 @@ const preview = definePreview({
   tags: ['autodocs'],
   addons: [addonLinks(), addonA11y(), addonDocs()],
 });
-
-export default preview satisfies unknown;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,10 +1,13 @@
 import '@norges-domstoler/dds-components/index.css';
+import addonA11y from '@storybook/addon-a11y';
+import addonDocs from '@storybook/addon-docs';
 import {
   DocsContainer,
   type DocsContainerProps,
   Unstyled,
 } from '@storybook/addon-docs/blocks';
-import type { Preview } from '@storybook/react-vite';
+import addonLinks from '@storybook/addon-links';
+import { definePreview } from '@storybook/react-vite';
 import { type PropsWithChildren, useEffect, useState } from 'react';
 
 import {
@@ -38,7 +41,7 @@ const setCanvasBackgroundFromTheme = (counter: number) => {
 
 let nameCounter = 0;
 
-const preview: Preview = {
+export default definePreview({
   parameters: {
     controls: { sort: 'requiredFirst' },
     options: {
@@ -113,6 +116,5 @@ const preview: Preview = {
   ],
 
   tags: ['autodocs'],
-};
-
-export default preview;
+  addons: [addonLinks(), addonA11y(), addonDocs()],
+});

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -41,7 +41,7 @@ const setCanvasBackgroundFromTheme = (counter: number) => {
 
 let nameCounter = 0;
 
-export default definePreview({
+const preview = definePreview({
   parameters: {
     controls: { sort: 'requiredFirst' },
     options: {
@@ -118,3 +118,5 @@ export default definePreview({
   tags: ['autodocs'],
   addons: [addonLinks(), addonA11y(), addonDocs()],
 });
+
+export default preview satisfies unknown;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -272,12 +272,12 @@ Spørs på komponenten kan det være relevant med flere stories: eksempel med ko
 Du kan følge en enkel mal for stories-fila:
 
 ```JSX
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { Button } from '.';
-import { commonArgTypes, labelText } from '../../storybook';
+import { commonArgTypes } from '../../storybook';
 
 // config
-export default {
+const meta = preview.meta({
   title: 'dds-components/Button',
   component: Button,
   // kontrollere  for demo hvis default ikke passer
@@ -289,14 +289,12 @@ export default {
     // bruk på props som ikke trenger å styres med i demo
     icon: { control: false },
   }
-} satisfies Meta<typeof Button>;
-
-type Story = StoryObj<typeof Button>;
+});
 
 // demo; kan ha default args for bedre showcase
-export const Preview: Story = {
+export const Preview: meta.story({
   args: { children: 'Tekst' }
-};
+});
 
 ```
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,9 @@
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}
+
+declare module '*.svg?raw' {
+  const content: string;
+  export default content;
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "@storybook/addon-links": "10.3.5",
     "@storybook/react-vite": "10.3.5",
     "@testing-library/dom": "^10.4.1",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
     "chromatic": "^16.2.0",
@@ -84,5 +86,14 @@
   "packageManager": "pnpm@10.33.0",
   "peerDependencies": {
     "webpack": "^5.94.0"
+  },
+  "imports": {
+    "#*": [
+      "./*",
+      "./*.ts",
+      "./*.tsx",
+      "./*.js",
+      "./*.jsx"
+    ]
   }
 }

--- a/packages/dds-components/modules/custom.d.ts
+++ b/packages/dds-components/modules/custom.d.ts
@@ -1,9 +1,0 @@
-declare module '*.svg' {
-  const content: string;
-  export default content;
-}
-
-declare module '*.svg?raw' {
-  const content: string;
-  export default content;
-}

--- a/packages/dds-components/src/DdsProvider/DdsProvider.stories.tsx
+++ b/packages/dds-components/src/DdsProvider/DdsProvider.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { LocalMessage } from '../components/LocalMessage';
 import { type DdsTheme } from '../components/ThemeProvider';
@@ -8,15 +8,13 @@ import { type Language } from '../i18n/translation.types';
 
 import { DdsProvider } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/DdsProvider',
   component: DdsProvider,
   argTypes: {
     children: { control: false },
   },
-} satisfies Meta<typeof DdsProvider>;
-
-type Story = StoryObj<typeof DdsProvider>;
+});
 
 interface TCProps {
   lang?: Language;
@@ -63,7 +61,7 @@ function TranslationComponent(props: TCProps) {
   );
 }
 
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     theme: 'public-light',
     language: 'en',
@@ -75,4 +73,4 @@ export const Preview: Story = {
       </DdsProvider>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/dds-components/src/components/Accordion/Accordion.stories.tsx
@@ -1,5 +1,5 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
-import { useState } from 'react';
+import preview from '#.storybook/preview';
+import { type JSX, useState } from 'react';
 
 import {
   commonArgTypesWithNodeChildren,
@@ -19,29 +19,25 @@ import { Link, Paragraph, Typography } from '../Typography';
 
 import { Accordion, AccordionBody, AccordionHeader } from '.';
 
-const meta: Meta<typeof Accordion> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Accordion',
   component: Accordion,
   argTypes: {
     ...commonArgTypesWithNodeChildren,
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof Accordion>;
-
-export const Preview: Story = {
-  render: args => (
+export const Preview = meta.story({
+  render: (args): JSX.Element => (
     <Accordion {...args}>
       <AccordionHeader>Header</AccordionHeader>
       <AccordionBody>Content</AccordionBody>
     </Accordion>
   ),
-};
+});
 
-export const Group: Story = {
+export const Group = meta.story({
   render: args => (
     <>
       <div>
@@ -100,9 +96,9 @@ export const Group: Story = {
       </div>
     </>
   ),
-};
+});
 
-export const Controlled: Story = {
+export const Controlled = meta.story({
   render: args => {
     const [isExpanded, setIsExpanded] = useState(true);
 
@@ -120,9 +116,9 @@ export const Controlled: Story = {
       </>
     );
   },
-};
+});
 
-export const Styled: Story = {
+export const Styled = meta.story({
   decorators: [
     Story => (
       <>
@@ -171,9 +167,9 @@ export const Styled: Story = {
       </AccordionBody>
     </Accordion>
   ),
-};
+});
 
-export const Custom: Story = {
+export const Custom = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -250,4 +246,4 @@ export const Custom: Story = {
       </div>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/BackLink/BackLink.stories.tsx
+++ b/packages/dds-components/src/components/BackLink/BackLink.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import {
@@ -9,7 +9,7 @@ import {
 
 import { BackLink } from '.';
 
-const meta: Meta<typeof BackLink> = {
+const meta = preview.meta({
   title: 'dds-components/Components/BackLink',
   component: BackLink,
   argTypes: {
@@ -20,19 +20,15 @@ const meta: Meta<typeof BackLink> = {
   },
   args: { onClick: fn() },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof BackLink>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { label: 'Forrige nivå', href: '#' },
-};
+});
 
-export const As: Story = {
+export const As = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
   args: { label: 'Forrige nivå', href: '#', as: 'div' },
-};
+});

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumb.stories.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumb.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import { categoryHtml, htmlEventArgType } from '../../storybook';
@@ -6,7 +6,7 @@ import { StoryVStack } from '../layout/Stack/utils';
 
 import { Breadcrumb } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Breadcrumbs/Breadcrumb',
   component: Breadcrumb,
   argTypes: {
@@ -17,24 +17,22 @@ export default {
     onClick: htmlEventArgType,
   },
   args: { onClick: fn() },
-} satisfies Meta<typeof Breadcrumb>;
+});
 
-type Story = StoryObj<typeof Breadcrumb>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     children: 'Side',
     href: '/',
   },
-};
+});
 
-export const CurrentPage: Story = {
+export const CurrentPage = meta.story({
   args: {
     children: 'Side',
   },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   render: args => (
     <StoryVStack>
       <Breadcrumb {...args} href="#">
@@ -43,4 +41,4 @@ export const Overview: Story = {
       <Breadcrumb {...args}>Siden du er på</Breadcrumb>
     </StoryVStack>
   ),
-};
+});

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import {
   commonArgTypesWithNodeChildren,
@@ -8,18 +8,14 @@ import {
 
 import { Breadcrumb, Breadcrumbs } from '.';
 
-const meta: Meta<typeof Breadcrumbs> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Breadcrumbs',
   component: Breadcrumbs,
   argTypes: {
     ...commonArgTypesWithNodeChildren,
   },
   decorators: [ddsProviderDecorator],
-};
-
-export default meta;
-
-type Story = StoryObj<typeof Breadcrumbs>;
+});
 
 const children = [
   <Breadcrumb href="#">Side 1</Breadcrumb>,
@@ -28,20 +24,20 @@ const children = [
   <Breadcrumb>Siden du er på</Breadcrumb>,
 ];
 
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     children,
   },
-};
+});
 
-export const SmallScreen: Story = {
+export const SmallScreen = meta.story({
   args: {
     children,
     smallScreenBreakpoint: 'xl',
   },
-};
+});
 
-export const Responsive: Story = {
+export const Responsive = meta.story({
   args: {
     children,
     smallScreenBreakpoint: 'sm',
@@ -56,4 +52,4 @@ export const Responsive: Story = {
         'Versjonen for liten skjerm vises ved sm brekkpunkt og nedover.',
       ),
   ],
-};
+});

--- a/packages/dds-components/src/components/Button/Button.stories.tsx
+++ b/packages/dds-components/src/components/Button/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import { ArrowLeftIcon } from '../..';
@@ -15,7 +15,7 @@ import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 import { Button } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Button',
   component: Button,
   argTypes: {
@@ -33,15 +33,13 @@ export default {
   },
   args: { onClick: fn(), onBlur: fn(), onFocus: fn() },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof Button>;
+});
 
-type Story = StoryObj<typeof Button>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { children: 'Tekst' },
-};
+});
 
-export const Purposes: Story = {
+export const Purposes = meta.story({
   render: args => (
     <StoryHStack>
       <StoryVStack>
@@ -76,9 +74,9 @@ export const Purposes: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   render: args => (
     <StoryHStack>
       <StoryVStack>
@@ -113,9 +111,9 @@ export const Sizes: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const OverviewLoading: Story = {
+export const OverviewLoading = meta.story({
   args: {
     children: 'Tekst',
   },
@@ -130,9 +128,9 @@ export const OverviewLoading: Story = {
       ))}
     </StoryHStack>
   ),
-};
+});
 
-export const OverviewFullWidth: Story = {
+export const OverviewFullWidth = meta.story({
   args: { fullWidth: true, children: 'Tekst' },
   render: args => (
     <StoryVStack>
@@ -149,16 +147,16 @@ export const OverviewFullWidth: Story = {
       </Button>
     </StoryVStack>
   ),
-};
+});
 
-export const TextWithIcon: Story = {
+export const TextWithIcon = meta.story({
   args: {
     children: 'Tekst og ikon',
     icon: ArrowLeftIcon,
     iconPosition: 'left',
   },
-};
+});
 
-export const Icon: Story = {
+export const Icon = meta.story({
   args: { icon: ArrowLeftIcon },
-};
+});

--- a/packages/dds-components/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/dds-components/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import {
   categoryHtml,
@@ -12,7 +12,7 @@ import { StoryVStack } from '../layout/Stack/utils';
 
 import { ButtonGroup } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/ButtonGroup',
   component: ButtonGroup,
   argTypes: {
@@ -22,11 +22,9 @@ export default {
     ...commonArgTypesWithNodeChildren,
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof ButtonGroup>;
+});
 
-type Story = StoryObj<typeof ButtonGroup>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <ButtonGroup {...args}>
       <Button>Første</Button>
@@ -34,9 +32,9 @@ export const Preview: Story = {
       <Button>Tredje</Button>
     </ButtonGroup>
   ),
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   render: args => (
     <StoryVStack>
       {BUTTON_SIZES.map(size => (
@@ -48,9 +46,9 @@ export const Sizes: Story = {
       ))}
     </StoryVStack>
   ),
-};
+});
 
-export const Vertical: Story = {
+export const Vertical = meta.story({
   render: args => (
     <ButtonGroup {...args} direction="column">
       <Button>Første</Button>
@@ -58,4 +56,4 @@ export const Vertical: Story = {
       <Button>Tredje</Button>
     </ButtonGroup>
   ),
-};
+});

--- a/packages/dds-components/src/components/Card/Card.stories.tsx
+++ b/packages/dds-components/src/components/Card/Card.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 
 import { commonArgTypesWithNodeChildren } from '../../storybook';
@@ -12,16 +12,15 @@ import {
   CardExpandableHeader,
   CardSelectable,
 } from '.';
-export default {
+
+const meta = preview.meta({
   title: 'dds-components/Components/Card',
   component: Card,
   argTypes: {
     ...commonArgTypesWithNodeChildren,
     cardRef: { control: false },
   },
-} satisfies Meta<typeof Card>;
-
-type Story = StoryObj<typeof Card>;
+});
 
 const body = (
   <Paragraph>
@@ -39,7 +38,7 @@ const contentContainerStyle = (
   </style>
 );
 
-export const Preview: Story = {
+export const Preview = meta.story({
   decorators: [
     Story => (
       <>
@@ -49,11 +48,15 @@ export const Preview: Story = {
     ),
   ],
   args: {
+    cardType: 'info',
     children: <div className="story-container-padding">Content</div>,
   },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
+  args: {
+    cardType: 'info',
+  },
   decorators: [
     Story => (
       <>
@@ -123,9 +126,9 @@ export const Overview: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const Expandable: Story = {
+export const Expandable = meta.story({
   args: {
     children: (
       <CardExpandable>
@@ -135,9 +138,12 @@ export const Expandable: Story = {
     ),
     cardType: 'expandable',
   },
-};
+});
 
-export const ExpandableControlled: Story = {
+export const ExpandableControlled = meta.story({
+  args: {
+    cardType: 'expandable',
+  },
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   render: (args: any) => {
     const [isExpanded, setIsExpanded] = useState(true);
@@ -157,9 +163,12 @@ export const ExpandableControlled: Story = {
       </>
     );
   },
-};
+});
 
-export const ExpandableCustom: Story = {
+export const ExpandableCustom = meta.story({
+  args: {
+    cardType: 'expandable',
+  },
   decorators: [
     Story => (
       <>
@@ -208,4 +217,4 @@ export const ExpandableCustom: Story = {
       </CardExpandable>
     </Card>
   ),
-};
+});

--- a/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectable.stories.tsx
+++ b/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectable.stories.tsx
@@ -1,5 +1,4 @@
-import { type Story } from '@storybook/addon-docs/blocks';
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import { CardSelectable } from './CardSelectable';
@@ -19,7 +18,7 @@ import {
   type CardSelectableType,
 } from '../Card.types';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Card/CardSelectable',
   component: CardSelectable,
   argTypes: {
@@ -34,9 +33,7 @@ export default {
   },
 
   args: { onBlur: fn(), onChange: fn() },
-} satisfies Meta<typeof CardSelectable>;
-
-type Story = StoryObj<typeof CardSelectable>;
+});
 
 const cardExamples = (
   args: CardSelectableProps,
@@ -98,7 +95,7 @@ const cardExamples = (
   </StoryVStack>
 );
 
-export const Radio: Story = {
+export const Radio = meta.story({
   args: {
     children: 'Alternativ',
     cardType: 'radio',
@@ -108,8 +105,8 @@ export const Radio: Story = {
       <CardSelectable {...args} children="Alternativ" value={1} name="a" />
     );
   },
-};
-export const Overview: Story = {
+});
+export const Overview = meta.story({
   args: {
     children: 'Alternativ',
   },
@@ -123,16 +120,16 @@ export const Overview: Story = {
       </StoryHStack>
     );
   },
-};
+});
 
-export const Checkbox: Story = {
+export const Checkbox = meta.story({
   args: {
     children: 'Alternativ',
     cardType: 'checkbox',
   },
-};
+});
 
-export const CustomSpacing: Story = {
+export const CustomSpacing = meta.story({
   args: {
     children: 'Alternativ',
     cardType: 'checkbox',
@@ -142,9 +139,9 @@ export const CustomSpacing: Story = {
       top: 'calc(var(--dds-spacing-x2) + var(--dds-spacing-x0-25))',
     },
   },
-};
+});
 
-export const ComplexContent: Story = {
+export const ComplexContent = meta.story({
   args: {
     children: 'Alternativ',
     cardType: 'checkbox',
@@ -166,4 +163,4 @@ export const ComplexContent: Story = {
       </VStack>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectableGroup.stories.tsx
+++ b/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectableGroup.stories.tsx
@@ -1,5 +1,4 @@
-import { type Story } from '@storybook/addon-docs/blocks';
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 
 import { CardSelectable } from './CardSelectable';
@@ -26,7 +25,7 @@ const {
   padding,
 } = responsivePropsArgTypes;
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Card/CardSelectable/Group',
   component: CardSelectableGroup,
   argTypes: {
@@ -42,11 +41,9 @@ export default {
     padding,
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof CardSelectableGroup>;
+});
 
-type Story = StoryObj<typeof CardSelectableGroup>;
-
-export const Group: Story = {
+export const Group = meta.story({
   args: {
     display: 'flex',
     flexDirection: {
@@ -68,9 +65,9 @@ export const Group: Story = {
       </CardSelectableGroup>
     );
   },
-};
+});
 
-export const WithLabel: Story = {
+export const WithLabel = meta.story({
   args: {
     display: 'flex',
     gap: 'x1',
@@ -90,9 +87,9 @@ export const WithLabel: Story = {
       </VStack>
     );
   },
-};
+});
 
-export const WithCustomTip: Story = {
+export const WithCustomTip = meta.story({
   args: {
     display: 'flex',
     gap: 'x1',
@@ -113,9 +110,9 @@ export const WithCustomTip: Story = {
       </VStack>
     );
   },
-};
+});
 
-export const GroupWithInvisibleLabel: Story = {
+export const GroupWithInvisibleLabel = meta.story({
   args: {
     cardType: 'radio',
     display: 'flex',
@@ -132,9 +129,9 @@ export const GroupWithInvisibleLabel: Story = {
       </>
     );
   },
-};
+});
 
-export const WithErrorMessage: Story = {
+export const WithErrorMessage = meta.story({
   args: {
     display: 'flex',
     gap: 'x1',
@@ -157,9 +154,9 @@ export const WithErrorMessage: Story = {
       </>
     );
   },
-};
+});
 
-export const ControlledRadio: Story = {
+export const ControlledRadio = meta.story({
   args: {
     display: 'flex',
     gap: 'x1',
@@ -191,4 +188,4 @@ export const ControlledRadio: Story = {
       </>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/Chip/Chip.stories.tsx
+++ b/packages/dds-components/src/components/Chip/Chip.stories.tsx
@@ -1,11 +1,11 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import { commonArgTypes, ddsProviderDecorator } from '../../storybook';
 
 import { Chip } from '.';
 
-const meta: Meta<typeof Chip> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Chip',
   component: Chip,
   argTypes: {
@@ -13,12 +13,8 @@ const meta: Meta<typeof Chip> = {
   },
   args: { onClose: fn() },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof Chip>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { children: 'Chip' },
-};
+});

--- a/packages/dds-components/src/components/Chip/ChipGroup.stories.tsx
+++ b/packages/dds-components/src/components/Chip/ChipGroup.stories.tsx
@@ -1,22 +1,20 @@
-import { type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { ddsProviderDecorator } from '../../storybook';
 
 import { Chip, ChipGroup } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Chip/ChipGroup',
   component: ChipGroup,
   decorators: [ddsProviderDecorator],
-};
+});
 
-type Story = StoryObj<typeof ChipGroup>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <ChipGroup {...args}>
       <Chip>Chip 1</Chip>
       <Chip>Chip 2</Chip>
     </ChipGroup>
   ),
-};
+});

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.stories.tsx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { CookieBanner } from './CookieBanner';
 import {
@@ -14,7 +14,7 @@ import { Link } from '../Typography';
 const { position, left, right, top, bottom, maxHeight, width } =
   responsivePropsArgTypes;
 
-const meta: Meta<typeof CookieBanner> = {
+const meta = preview.meta({
   title: 'dds-components/Components/CookieBanner',
   component: CookieBanner,
   argTypes: {
@@ -29,13 +29,9 @@ const meta: Meta<typeof CookieBanner> = {
     checkboxes: { control: { disable: true } },
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof CookieBanner>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     headerText: 'Tittel for banner',
     description: (
@@ -47,9 +43,9 @@ export const Preview: Story = {
     ),
     buttons: [{ children: 'Godkjenn alle' }, { children: 'Kun nødvendige' }],
   },
-};
+});
 
-export const WithCheckboxes: Story = {
+export const WithCheckboxes = meta.story({
   args: {
     headerText: 'Tittel for banner',
     description: (
@@ -80,16 +76,15 @@ export const WithCheckboxes: Story = {
       },
     ],
   },
-};
+});
 
-export const Placement: Story = {
+export const Placement = meta.story({
   decorators: [Story => windowWidthDecorator(<Story />)],
   parameters: {
     layout: 'fullscreen',
     docs: {
       story: {
         inline: false,
-        iframeHeight: 800,
       },
     },
     chromatic: { disableSnapshot: true },
@@ -154,16 +149,15 @@ export const Placement: Story = {
       </Box>
     );
   },
-};
+});
 
-export const PlacementWithCheckboxes: Story = {
+export const PlacementWithCheckboxes = meta.story({
   decorators: [Story => windowWidthDecorator(<Story />)],
   parameters: {
     layout: 'fullscreen',
     docs: {
       story: {
         inline: false,
-        iframeHeight: 800,
       },
     },
     chromatic: { disableSnapshot: true },
@@ -247,9 +241,9 @@ export const PlacementWithCheckboxes: Story = {
       </Box>
     );
   },
-};
+});
 
-export const Collapsible: Story = {
+export const Collapsible = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -272,4 +266,4 @@ export const Collapsible: Story = {
     ),
     buttons: [{ children: 'Godkjenn alle' }, { children: 'Kun nødvendige' }],
   },
-};
+});

--- a/packages/dds-components/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/packages/dds-components/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { commonArgTypesWithNodeChildren } from '../../storybook';
 import { CallIcon } from '../Icon/icons';
@@ -12,19 +12,15 @@ import {
   DescriptionListTerm,
 } from '.';
 
-const meta: Meta<typeof DescriptionList> = {
+const meta = preview.meta({
   title: 'dds-components/Components/DescriptionList',
   component: DescriptionList,
   argTypes: {
     ...commonArgTypesWithNodeChildren,
   },
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof DescriptionList>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <DescriptionList {...args}>
       <DescriptionListTerm>Tittel</DescriptionListTerm>
@@ -33,9 +29,9 @@ export const Preview: Story = {
       <DescriptionListDesc>Beskrivelse</DescriptionListDesc>
     </DescriptionList>
   ),
-};
+});
 
-export const Appearances: Story = {
+export const Appearances = meta.story({
   render: () => (
     <StoryVStack>
       <DescriptionList appearance="default">
@@ -48,9 +44,9 @@ export const Appearances: Story = {
       </DescriptionList>
     </StoryVStack>
   ),
-};
+});
 
-export const Phone: Story = {
+export const Phone = meta.story({
   render: () => (
     <DescriptionList>
       <DescriptionListTerm>Tittel</DescriptionListTerm>
@@ -59,9 +55,9 @@ export const Phone: Story = {
       </DescriptionListDesc>
     </DescriptionList>
   ),
-};
+});
 
-export const Group: Story = {
+export const Group = meta.story({
   render: args => (
     <DescriptionList {...args}>
       <DescriptionListGroup>
@@ -83,10 +79,10 @@ export const Group: Story = {
       </DescriptionListGroup>
     </DescriptionList>
   ),
-};
+});
 
 const margin = 'var(--dds-spacing-x0-75)';
-export const Row: Story = {
+export const Row = meta.story({
   render: args => (
     <DescriptionList {...args} direction="row">
       <DescriptionListGroup margin={margin}>
@@ -123,4 +119,4 @@ export const Row: Story = {
       </DescriptionListGroup>
     </DescriptionList>
   ),
-};
+});

--- a/packages/dds-components/src/components/DetailList/DetailList.stories.tsx
+++ b/packages/dds-components/src/components/DetailList/DetailList.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import {
   StoryLabel,
@@ -18,17 +18,13 @@ import {
   DetailListTerm,
 } from '.';
 
-const meta: Meta<typeof DetailList> = {
+const meta = preview.meta({
   title: 'dds-components/Components/DetailList',
   component: DetailList,
   argTypes: {
     ...commonArgTypesWithNodeChildren,
   },
-};
-
-export default meta;
-
-type Story = StoryObj<typeof DetailList>;
+});
 
 const children = [
   <DetailListRow>
@@ -85,11 +81,11 @@ const children = [
   </DetailListRow>,
 ];
 
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => <DetailList {...args}>{children}</DetailList>,
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   render: args => (
     <StoryVStack>
       {DETAIL_LIST_SIZES.map(size => (
@@ -102,17 +98,17 @@ export const Sizes: Story = {
       ))}
     </StoryVStack>
   ),
-};
+});
 
-export const SmallScreen: Story = {
+export const SmallScreen = meta.story({
   render: args => (
     <DetailList {...args} smallScreenBreakpoint="xl">
       {children}
     </DetailList>
   ),
-};
+});
 
-export const Responsive: Story = {
+export const Responsive = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -125,4 +121,4 @@ export const Responsive: Story = {
   ],
   args: { smallScreenBreakpoint: 'sm' },
   render: args => <DetailList {...args}>{children}</DetailList>,
-};
+});

--- a/packages/dds-components/src/components/Divider/Divider.stories.tsx
+++ b/packages/dds-components/src/components/Divider/Divider.stories.tsx
@@ -1,23 +1,19 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { StoryLabel, commonArgTypes } from '../../storybook';
 import { Contrast } from '../layout';
 
 import { Divider } from '.';
 
-const meta: Meta<typeof Divider> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Divider',
   component: Divider,
   argTypes: {
     ...commonArgTypes,
   },
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof Divider>;
-
-export const Preview: Story = {};
+export const Preview = meta.story();
 
 const contrastStyling = `
   .story-container {
@@ -25,7 +21,7 @@ const contrastStyling = `
     }
     `;
 
-export const Colors: Story = {
+export const Colors = meta.story({
   decorators: [
     Story => (
       <>
@@ -46,4 +42,4 @@ export const Colors: Story = {
       </Contrast>
     </>
   ),
-};
+});

--- a/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
@@ -1,5 +1,4 @@
-import { type Story } from '@storybook/addon-docs/blocks';
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 
 import {
@@ -16,12 +15,12 @@ import { Drawer, DrawerGroup } from '.';
 
 const { width, maxWidth, minWidth } = responsivePropsArgTypes;
 
-const meta: Meta<typeof Drawer> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Drawer',
   component: Drawer,
   parameters: {
     docs: {
-      story: { height: '500px', scrollbar: false },
+      story: { height: '500px' },
     },
   },
   argTypes: {
@@ -32,13 +31,9 @@ const meta: Meta<typeof Drawer> = {
     minWidth,
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof Drawer>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { header: 'Tittel' },
   render: args => (
     <DrawerGroup isInitiallyOpen>
@@ -55,9 +50,9 @@ export const Preview: Story = {
       </Drawer>
     </DrawerGroup>
   ),
-};
+});
 
-export const WithBackdrop: Story = {
+export const WithBackdrop = meta.story({
   args: { header: 'Tittel' },
   parameters: {
     chromatic: { disableSnapshot: true },
@@ -77,9 +72,9 @@ export const WithBackdrop: Story = {
       </Drawer>
     </DrawerGroup>
   ),
-};
+});
 
-export const OverviewPlacement: Story = {
+export const OverviewPlacement = meta.story({
   args: { header: 'Tittel' },
   parameters: {
     chromatic: { disableSnapshot: true },
@@ -102,9 +97,9 @@ export const OverviewPlacement: Story = {
       </DrawerGroup>
     </StoryHStack>
   ),
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   args: { header: 'Header' },
   parameters: {
     chromatic: { disableSnapshot: true },
@@ -141,9 +136,9 @@ export const Sizes: Story = {
       ))}
     </StoryHStack>
   ),
-};
+});
 
-export const WithOnCloseAndOnOpen: Story = {
+export const WithOnCloseAndOnOpen = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -175,9 +170,9 @@ export const WithOnCloseAndOnOpen: Story = {
       </StoryVStack>
     );
   },
-};
+});
 
-export const LongContent: Story = {
+export const LongContent = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -246,4 +241,4 @@ export const LongContent: Story = {
       </Drawer>
     </DrawerGroup>
   ),
-};
+});

--- a/packages/dds-components/src/components/EmptyContent/EmptyContent.stories.tsx
+++ b/packages/dds-components/src/components/EmptyContent/EmptyContent.stories.tsx
@@ -1,24 +1,22 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { EmptyContent } from './EmptyContent';
 import { Box } from '../layout';
 import { Link } from '../Typography';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/EmptyContent',
   component: EmptyContent,
-} satisfies Meta<typeof EmptyContent>;
+  args: { children: 'Dette er en tekst.' },
+});
 
-type Story = StoryObj<typeof EmptyContent>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     headerText: 'Tittel',
-    children: 'Dette er en tekst.',
   },
-};
+});
 
-export const InWrapper: Story = {
+export const InWrapper = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -29,9 +27,9 @@ export const InWrapper: Story = {
       </EmptyContent>
     </Box>
   ),
-};
+});
 
-export const ComplexContent: Story = {
+export const ComplexContent = meta.story({
   args: {
     headerText: 'Tittel',
   },
@@ -40,4 +38,4 @@ export const ComplexContent: Story = {
       Dette er en forklaring. Du kan <Link href="/">registrere en aktør</Link>.
     </EmptyContent>
   ),
-};
+});

--- a/packages/dds-components/src/components/ErrorSummary/ErrorSummary.stories.tsx
+++ b/packages/dds-components/src/components/ErrorSummary/ErrorSummary.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { ErrorSummary } from './ErrorSummary';
 import { ErrorSummaryItem } from './ErrorSummaryItem';
@@ -7,7 +7,7 @@ import {
   ddsProviderDecorator,
 } from '../../storybook';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/ErrorSummary',
   component: ErrorSummary,
   argTypes: {
@@ -15,15 +15,13 @@ export default {
     heading: { control: 'text' },
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof ErrorSummary>;
+});
 
-type Story = StoryObj<typeof ErrorSummary>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <ErrorSummary {...args}>
       <ErrorSummaryItem>Epost må fylles ut</ErrorSummaryItem>
       <ErrorSummaryItem>Fødselsnummer må ha 11 sifre</ErrorSummaryItem>
     </ErrorSummary>
   ),
-};
+});

--- a/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
+++ b/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 
@@ -19,7 +19,7 @@ import { Table } from '../Table';
 import { Tooltip } from '../Tooltip';
 import { Caption, Link } from '../Typography';
 
-const meta: Meta<typeof FavStar> = {
+const meta = preview.meta({
   title: 'dds-components/Components/FavStar',
   component: FavStar,
   argTypes: {
@@ -30,15 +30,11 @@ const meta: Meta<typeof FavStar> = {
   },
   args: { onChange: fn() },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
+export const Preview = meta.story();
 
-type Story = StoryObj<typeof FavStar>;
-
-export const Preview: Story = {};
-
-export const Sizes: Story = {
+export const Sizes = meta.story({
   render: args => (
     <StoryHStack>
       {FAVSTAR_SIZES.map(size => (
@@ -49,9 +45,9 @@ export const Sizes: Story = {
       ))}
     </StoryHStack>
   ),
-};
+});
 
-export const RealWorld: Story = {
+export const RealWorld = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -177,4 +173,4 @@ export const RealWorld: Story = {
       </Table.Wrapper>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/Feedback/Feedback.stories.tsx
+++ b/packages/dds-components/src/components/Feedback/Feedback.stories.tsx
@@ -1,11 +1,11 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { ddsProviderDecorator } from '../../storybook';
 import { Divider } from '../Divider';
 
 import { Feedback } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Feedback',
   component: Feedback,
   argTypes: {
@@ -17,26 +17,24 @@ export default {
     },
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof Feedback>;
+});
 
-type Story = StoryObj<typeof Feedback>;
+export const Preview = meta.story();
 
-export const Preview: Story = {};
-
-export const HorizontalLayout: Story = {
+export const HorizontalLayout = meta.story({
   args: { layout: 'horizontal' },
-};
+});
 
-export const WithoutTextArea: Story = {
+export const WithoutTextArea = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
   args: {
     feedbackTextAreaExcluded: true,
   },
-};
+});
 
-export const CustomLabels: Story = {
+export const CustomLabels = meta.story({
   args: {
     ratingLabel: 'Min egen label',
     positiveFeedbackLabel: 'Min egen positive label',
@@ -52,9 +50,9 @@ export const CustomLabels: Story = {
       <Feedback {...args} ratingValue="negative" />
     </>
   ),
-};
+});
 
-export const CustomButtonTooltip: Story = {
+export const CustomButtonTooltip = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -62,9 +60,9 @@ export const CustomButtonTooltip: Story = {
     thumbUpTooltip: 'Liker',
     thumbDownTooltip: 'Liker ikke',
   },
-};
+});
 
-export const LoadingState: Story = {
+export const LoadingState = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -75,4 +73,4 @@ export const LoadingState: Story = {
       <Feedback {...args} ratingValue="positive" loading />
     </>
   ),
-};
+});

--- a/packages/dds-components/src/components/Fieldset/Fieldset.stories.tsx
+++ b/packages/dds-components/src/components/Fieldset/Fieldset.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { Fieldset } from './Fieldset';
 import { categoryHtml, commonArgTypesWithNodeChildren } from '../../storybook';
@@ -6,18 +6,16 @@ import { TextInput } from '../TextInput';
 import { Legend } from '../Typography';
 import { FieldsetGroup } from './FieldsetGroup';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Fieldset',
   component: Fieldset,
   argTypes: {
     disabled: { table: categoryHtml },
     ...commonArgTypesWithNodeChildren,
   },
-} satisfies Meta<typeof Fieldset>;
+});
 
-type Story = StoryObj<typeof Fieldset>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <Fieldset {...args}>
       <Legend withMargins>Telefon og epost</Legend>
@@ -27,4 +25,4 @@ export const Preview: Story = {
       </FieldsetGroup>
     </Fieldset>
   ),
-};
+});

--- a/packages/dds-components/src/components/FileUploader/FileUploader.stories.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 
@@ -17,7 +17,7 @@ import {
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 import { Heading, Paragraph } from '../Typography';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/FileUploader',
   component: FileUploader,
   argTypes: {
@@ -29,15 +29,13 @@ export default {
   },
   args: { onChange: fn() },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof FileUploader>;
-
-type Story = StoryObj<typeof FileUploader>;
+});
 
 const file = new File(['hello'], 'hello.png', { type: 'image/png' });
 
-export const Preview: Story = { args: { label: 'Label' } };
+export const Preview = meta.story({ args: { label: 'Label' } });
 
-export const States: Story = {
+export const States = meta.story({
   render: () => (
     <StoryHStack>
       <StoryVStack>
@@ -77,9 +75,9 @@ export const States: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const PdfOnly: Story = {
+export const PdfOnly = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -88,9 +86,9 @@ export const PdfOnly: Story = {
     tip: 'Kun PDF-filer',
     accept: ['.pdf', 'application/pdf'],
   },
-};
+});
 
-export const CustomFileList: Story = {
+export const CustomFileList = meta.story({
   args: { label: 'Last opp fil' },
   render: args => {
     const [files, setFiles] = useState<FileList>([file]);
@@ -119,9 +117,9 @@ export const CustomFileList: Story = {
       </>
     );
   },
-};
+});
 
-export const WithUploadStatus: Story = {
+export const WithUploadStatus = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -202,9 +200,9 @@ export const WithUploadStatus: Story = {
       </>
     );
   },
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   decorators: [Story => windowWidthDecorator(<Story />)],
   args: {
     width: {
@@ -215,4 +213,4 @@ export const ResponsiveWidth: Story = {
       xl: 'var(--dds-input-default-width)',
     },
   },
-};
+});

--- a/packages/dds-components/src/components/Footer/Footer.stories.tsx
+++ b/packages/dds-components/src/components/Footer/Footer.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { Grid, GridChild, Link, Paragraph } from '../..';
 import { Icon } from '../Icon';
@@ -16,12 +16,10 @@ import {
   FooterSocialsList,
 } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Footer',
   component: Footer,
-} satisfies Meta<typeof Footer>;
-
-type Story = StoryObj<typeof Footer>;
+});
 
 const socials = (
   <FooterSocialsGroup>
@@ -49,7 +47,7 @@ const socials = (
   </FooterSocialsGroup>
 );
 
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <Footer {...args}>
       <Grid
@@ -121,9 +119,9 @@ export const Preview: Story = {
       </Grid>
     </Footer>
   ),
-};
+});
 
-export const FourColumns: Story = {
+export const FourColumns = meta.story({
   render: args => (
     <Footer {...args}>
       <Grid
@@ -232,7 +230,7 @@ export const FourColumns: Story = {
       </Grid>
     </Footer>
   ),
-};
+});
 
 const exampleStyle = (
   <style>
@@ -244,7 +242,7 @@ const exampleStyle = (
   </style>
 );
 
-export const Address: Story = {
+export const Address = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -268,9 +266,9 @@ export const Address: Story = {
       </FooterListGroup>
     </Footer>
   ),
-};
+});
 
-export const Logo: Story = {
+export const Logo = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -287,9 +285,9 @@ export const Logo: Story = {
       <FooterLogo />
     </Footer>
   ),
-};
+});
 
-export const ListHeader: Story = {
+export const ListHeader = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -306,9 +304,9 @@ export const ListHeader: Story = {
       <FooterListHeader>Om nettstedet</FooterListHeader>
     </Footer>
   ),
-};
+});
 
-export const Left: Story = {
+export const Left = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -328,8 +326,8 @@ export const Left: Story = {
       </FooterLeft>
     </Footer>
   ),
-};
-export const ListExample: Story = {
+});
+export const ListExample = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -360,9 +358,9 @@ export const ListExample: Story = {
       </FooterListGroup>
     </Footer>
   ),
-};
+});
 
-export const Socials: Story = {
+export const Socials = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -379,4 +377,4 @@ export const Socials: Story = {
       {socials}
     </Footer>
   ),
-};
+});

--- a/packages/dds-components/src/components/FormSummary/FormSummary.stories.tsx
+++ b/packages/dds-components/src/components/FormSummary/FormSummary.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import {
   commonArgTypes,
@@ -34,7 +34,8 @@ const {
   marginBlock,
   marginInline,
 } = responsivePropsArgTypes;
-export default {
+
+const meta = preview.meta({
   title: 'dds-components/Components/FormSummary',
   component: FormSummary,
   argTypes: {
@@ -49,11 +50,9 @@ export default {
     width,
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof FormSummary>;
+});
 
-type Story = StoryObj<typeof FormSummary>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <FormSummary {...args}>
       <FormSummaryHeader>
@@ -112,9 +111,9 @@ export const Preview: Story = {
       </FormSummaryFields>
     </FormSummary>
   ),
-};
+});
 
-export const ExternalDataSource: Story = {
+export const ExternalDataSource = meta.story({
   render: args => (
     <VStack gap="x1">
       <FormSummary {...args}>
@@ -152,9 +151,9 @@ export const ExternalDataSource: Story = {
       </FormSummary>
     </VStack>
   ),
-};
+});
 
-export const Groups: Story = {
+export const Groups = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -232,9 +231,9 @@ export const Groups: Story = {
       </FormSummaryFields>
     </FormSummary>
   ),
-};
+});
 
-export const Steps: Story = {
+export const Steps = meta.story({
   render: args => (
     <VStack gap="x1">
       <FormSummary {...args}>
@@ -271,7 +270,7 @@ export const Steps: Story = {
       </FormSummary>
     </VStack>
   ),
-};
+});
 
 const renderFields = (n: number) => {
   const fields = [];
@@ -286,7 +285,7 @@ const renderFields = (n: number) => {
   return <FormSummaryFields>{fields}</FormSummaryFields>;
 };
 
-export const WithGrid: Story = {
+export const WithGrid = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -363,9 +362,9 @@ export const WithGrid: Story = {
       </GridChild>
     </Grid>
   ),
-};
+});
 
-export const WithFlex: Story = {
+export const WithFlex = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -456,4 +455,4 @@ export const WithFlex: Story = {
       </FormSummary>
     </Box>
   ),
-};
+});

--- a/packages/dds-components/src/components/GlobalMessage/GlobalMessage.stories.tsx
+++ b/packages/dds-components/src/components/GlobalMessage/GlobalMessage.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import { G_MESSAGE_PURPOSES, GlobalMessage } from './GlobalMessage';
@@ -9,7 +9,7 @@ import {
 } from '../../storybook';
 import { StoryVStack } from '../layout/Stack/utils';
 
-const meta: Meta<typeof GlobalMessage> = {
+const meta = preview.meta({
   title: 'dds-components/Components/GlobalMessage',
   component: GlobalMessage,
   argTypes: {
@@ -17,20 +17,16 @@ const meta: Meta<typeof GlobalMessage> = {
   },
   args: { onClose: fn() },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof GlobalMessage>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     purpose: 'info',
     children: 'En tilfeldig melding',
   },
-};
+});
 
-export const Variants: Story = {
+export const Variants = meta.story({
   args: {},
   render: args => (
     <StoryVStack>
@@ -41,11 +37,11 @@ export const Variants: Story = {
       ))}
     </StoryVStack>
   ),
-};
+});
 
-export const Closable: Story = {
+export const Closable = meta.story({
   args: {
     children: 'En tilfeldig melding',
     closable: true,
   },
-};
+});

--- a/packages/dds-components/src/components/Icon/Icon.stories.tsx
+++ b/packages/dds-components/src/components/Icon/Icon.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { ICON_SIZES } from './Icon';
 import { StoryLabel, commonArgTypes, labelText } from '../../storybook';
@@ -8,7 +8,7 @@ import { StoryHStack } from '../layout/Stack/utils';
 
 import { Icon } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Icon',
   component: Icon,
   argTypes: {
@@ -17,17 +17,15 @@ export default {
     icon: { control: false },
     iconState: { control: false },
   },
-} satisfies Meta<typeof Icon>;
-
-type Story = StoryObj<typeof Icon>;
+});
 
 const icon = OpenExternal;
 
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { icon },
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   args: { icon },
   render: args => (
     <StoryHStack>
@@ -39,8 +37,8 @@ export const Sizes: Story = {
       ))}
     </StoryHStack>
   ),
-};
+});
 
-export const CustomColor: Story = {
+export const CustomColor = meta.story({
   args: { icon, color: 'icon-action-resting' },
-};
+});

--- a/packages/dds-components/src/components/Icon/overview-page/icons.stories.tsx
+++ b/packages/dds-components/src/components/Icon/overview-page/icons.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useEffect, useState } from 'react';
 
 import { ICON_SIZES, Icon } from '../Icon';
@@ -26,15 +26,13 @@ import { Heading, Typography } from '../../Typography';
 import { CopyIcon } from '../icons/copy';
 import { type SvgIcon } from '../utils';
 
-const meta: Meta = {
+const meta = preview.meta({
   title: 'Icons/Overview',
   tags: ['!autodocs'],
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-export const Overview = () => {
+export const Overview = meta.story(() => {
   interface IconState {
     name: IconName;
     icon: SvgIcon;
@@ -324,4 +322,4 @@ export const Overview = () => {
       </Modal>
     </VStack>
   );
-};
+});

--- a/packages/dds-components/src/components/InlineButton/InlineButton.stories.tsx
+++ b/packages/dds-components/src/components/InlineButton/InlineButton.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 
@@ -13,7 +13,7 @@ import { Tooltip } from '../Tooltip';
 import { Paragraph } from '../Typography';
 import { VisuallyHidden } from '../VisuallyHidden';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/InlineButton',
   component: InlineButton,
   argTypes: {
@@ -24,23 +24,21 @@ export default {
   },
   args: { onClick: fn(), onBlur: fn(), onFocus: fn() },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof InlineButton>;
+});
 
-type Story = StoryObj<typeof InlineButton>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     children: 'Vis mer',
   },
-};
+});
 
-export const WithIcon: Story = {
+export const WithIcon = meta.story({
   args: {
     icon: HelpIcon,
   },
-};
+});
 
-export const WithColor: Story = {
+export const WithColor = meta.story({
   args: {
     children: 'Vis mer',
     color: 'text-subtle',
@@ -51,9 +49,9 @@ export const WithColor: Story = {
       <InlineButton {...args} icon={HelpIcon} />
     </StoryVStack>
   ),
-};
+});
 
-export const Example: Story = {
+export const Example = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -99,9 +97,9 @@ export const Example: Story = {
       </>
     );
   },
-};
+});
 
-export const ExampleIcon: Story = {
+export const ExampleIcon = meta.story({
   render: args => {
     return (
       <StoryVStack>
@@ -139,4 +137,4 @@ export const ExampleIcon: Story = {
       </StoryVStack>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/InlineEdit/InlineEdit.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEdit.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 
@@ -8,7 +8,7 @@ import { InlineEditTextArea } from './InlineEditTextArea/InlineEditTextArea';
 import { ddsProviderDecorator, htmlEventArgType } from '../../storybook';
 import { StoryVStack } from '../layout/Stack/utils';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/InlineEdit',
   component: InlineEditInput,
   argTypes: {
@@ -24,11 +24,9 @@ export default {
     },
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof InlineEditInput>;
+});
 
-type Story = StoryObj<typeof InlineEditInput>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: args => {
     const [value, setValue] = useState('Input');
@@ -47,4 +45,4 @@ export const Preview: Story = {
       </StoryVStack>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/InlineEdit/InlineEditInput/InlineEditInput.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEditInput/InlineEditInput.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 
@@ -12,7 +12,7 @@ import {
 import { StoryVStack } from '../../layout/Stack/utils';
 import { Table } from '../../Table/normal';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/InlineEdit/InlineEditInput',
   component: InlineEditInput,
   argTypes: {
@@ -29,10 +29,9 @@ export default {
     },
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof InlineEditInput>;
-type Story = StoryObj<typeof InlineEditInput>;
+});
 
-export const Preview: Story = {
+export const Preview = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -40,9 +39,9 @@ export const Preview: Story = {
     const [value, setValue] = useState('');
     return <InlineEditInput {...args} value={value} onSetValue={setValue} />;
   },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   render: args => {
     const [value, setValue] = useState('');
     const [value2, setValue2] = useState('tekst');
@@ -81,9 +80,9 @@ export const Overview: Story = {
       </StoryVStack>
     );
   },
-};
+});
 
-export const InTable: Story = {
+export const InTable = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -123,9 +122,9 @@ export const InTable: Story = {
       </Table.Wrapper>
     );
   },
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -139,4 +138,4 @@ export const ResponsiveWidth: Story = {
       xl: 'var(--dds-input-default-width)',
     },
   },
-};
+});

--- a/packages/dds-components/src/components/InlineEdit/InlineEditSelect/InlineEditSelect.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEditSelect/InlineEditSelect.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 
@@ -12,7 +12,7 @@ import {
 import { StoryVStack } from '../../layout/Stack/utils';
 import { Table } from '../../Table/normal';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/InlineEdit/InlineEditSelect',
   component: InlineEditSelect,
   argTypes: {
@@ -29,8 +29,7 @@ export default {
     },
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof InlineEditSelect>;
-type Story = StoryObj<typeof InlineEditSelect>;
+});
 
 const children = [
   <option></option>,
@@ -39,7 +38,7 @@ const children = [
   <option>Alt 3</option>,
 ];
 
-export const Preview: Story = {
+export const Preview = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -54,9 +53,9 @@ export const Preview: Story = {
       />
     );
   },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   render: args => {
     const [value, setValue] = useState('');
     const [value2, setValue2] = useState('Alt 1');
@@ -117,9 +116,9 @@ export const Overview: Story = {
       </StoryVStack>
     );
   },
-};
+});
 
-export const InTable: Story = {
+export const InTable = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -164,9 +163,9 @@ export const InTable: Story = {
       </Table.Wrapper>
     );
   },
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -180,4 +179,4 @@ export const ResponsiveWidth: Story = {
       xl: 'var(--dds-input-default-width)',
     },
   },
-};
+});

--- a/packages/dds-components/src/components/InlineEdit/InlineEditTextArea/InlineEditTextArea.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEditTextArea/InlineEditTextArea.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 import { fn } from 'storybook/test';
 
@@ -12,7 +12,7 @@ import {
 import { StoryVStack } from '../../layout/Stack/utils';
 import { Table } from '../../Table/normal';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/InlineEdit/InlineEditTextArea',
   component: InlineEditTextArea,
   argTypes: {
@@ -29,11 +29,9 @@ export default {
     },
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof InlineEditTextArea>;
+});
 
-type Story = StoryObj<typeof InlineEditTextArea>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -41,9 +39,9 @@ export const Preview: Story = {
     const [value, setValue] = useState('');
     return <InlineEditTextArea {...args} value={value} onSetValue={setValue} />;
   },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   render: args => {
     const [value, setValue] = useState('');
     const [value2, setValue2] = useState('tekst');
@@ -82,9 +80,9 @@ export const Overview: Story = {
       </StoryVStack>
     );
   },
-};
+});
 
-export const InTable: Story = {
+export const InTable = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -127,9 +125,9 @@ export const InTable: Story = {
       </Table.Wrapper>
     );
   },
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -143,4 +141,4 @@ export const ResponsiveWidth: Story = {
       xl: 'var(--dds-input-default-width)',
     },
   },
-};
+});

--- a/packages/dds-components/src/components/InputMessage/InputMessage.stories.tsx
+++ b/packages/dds-components/src/components/InputMessage/InputMessage.stories.tsx
@@ -1,30 +1,29 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { commonArgTypes } from '../../storybook';
 import { StoryHStack } from '../layout/Stack/utils';
 
 import { InputMessage } from '.';
 
-const meta: Meta<typeof InputMessage> = {
+const meta = preview.meta({
   title: 'dds-components/Components/InputMessage',
   component: InputMessage,
   argTypes: {
     ...commonArgTypes,
   },
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof InputMessage>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     messageType: 'error',
     children: 'Feilmelding',
   },
-};
+});
 
-export const Variants: Story = {
+export const Variants = meta.story({
+  args: {
+    messageType: 'error',
+  },
   render: args => (
     <StoryHStack>
       <InputMessage {...args} messageType="error">
@@ -35,4 +34,4 @@ export const Variants: Story = {
       </InputMessage>
     </StoryHStack>
   ),
-};
+});

--- a/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import { InputStepper } from './InputStepper';
@@ -13,7 +13,7 @@ import {
 } from '../../storybook';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/InputStepper',
   component: InputStepper,
   argTypes: {
@@ -25,20 +25,18 @@ export default {
   },
   args: { onChange: fn() },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof InputStepper>;
+});
 
-type Story = StoryObj<typeof InputStepper>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     maxValue: 5,
   },
   render: args => {
     return <InputStepper {...args} label="Label" />;
   },
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   args: {
     maxValue: 5,
   },
@@ -56,9 +54,9 @@ export const Sizes: Story = {
       </StoryHStack>
     );
   },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   args: {
     maxValue: 5,
   },
@@ -78,9 +76,9 @@ export const Overview: Story = {
       </StoryHStack>
     );
   },
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -95,4 +93,4 @@ export const ResponsiveWidth: Story = {
     },
     maxValue: 5,
   },
-};
+});

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.stories.tsx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import {
@@ -13,7 +13,7 @@ import { StoryVStack } from '../layout/Stack/utils';
 
 import { InternalHeader } from '.';
 
-const meta: Meta<typeof InternalHeader> = {
+const meta = preview.meta({
   title: 'dds-components/Components/InternalHeader',
   component: InternalHeader,
   argTypes: {
@@ -29,9 +29,8 @@ const meta: Meta<typeof InternalHeader> = {
     },
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
 const navigationLink = {
   href: '#',
   children: 'navlenke',
@@ -65,9 +64,7 @@ const menuElement = {
 
 const menuElements = [menuElement, menuElementWithIcon, menuElement];
 
-type Story = StoryObj<typeof InternalHeader>;
-
-export const WithNavigationAndContextMenu: Story = {
+export const WithNavigationAndContextMenu = meta.story({
   args: {
     applicationName: 'Lovisa',
     applicationDesc: 'Produktnavn',
@@ -75,9 +72,9 @@ export const WithNavigationAndContextMenu: Story = {
     contextMenuItems: menuElements,
     user,
   },
-};
+});
 
-export const Variants: Story = {
+export const Variants = meta.story({
   args: {
     applicationName: 'Lovisa',
     applicationDesc: 'Produktnavn',
@@ -133,9 +130,9 @@ export const Variants: Story = {
       </VStack>
     </StoryVStack>
   ),
-};
+});
 
-export const ResponsiveWithNavigationAndContextMenu: Story = {
+export const ResponsiveWithNavigationAndContextMenu = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: { story: { height: '420px' } },
@@ -155,4 +152,4 @@ export const ResponsiveWithNavigationAndContextMenu: Story = {
         'Versjonen for liten skjerm vises ved sm brekkpunkt.',
       ),
   ],
-};
+});

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.types.tsx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.types.tsx
@@ -23,7 +23,7 @@ type ContextMenuElementProps = {
   | ButtonHTMLAttributes<HTMLButtonElement>
 );
 
-interface InternaHeaderUserProps {
+export interface InternaHeaderUserProps {
   children: ReactNode;
   href?: string;
 }

--- a/packages/dds-components/src/components/List/List.stories.tsx
+++ b/packages/dds-components/src/components/List/List.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { commonArgTypesWithNodeChildren } from '../../storybook';
 import { StoryHStack } from '../layout/Stack/utils';
@@ -6,19 +6,15 @@ import { Typography } from '../Typography';
 
 import { List, ListItem, type ListProps } from '.';
 
-const meta: Meta<typeof List> = {
+const meta = preview.meta({
   title: 'dds-components/Components/List',
   component: List,
   argTypes: {
     ...commonArgTypesWithNodeChildren,
   },
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof List>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <List {...args}>
       <ListItem>Item</ListItem>
@@ -26,9 +22,9 @@ export const Preview: Story = {
       <ListItem>Item</ListItem>
     </List>
   ),
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   render: args => {
     interface Props {
       typographyType: ListProps['typographyType'];
@@ -80,9 +76,9 @@ export const Overview: Story = {
       </>
     );
   },
-};
+});
 
-export const Nested: Story = {
+export const Nested = meta.story({
   render: args => (
     <List {...args}>
       <ListItem>Item</ListItem>
@@ -102,9 +98,9 @@ export const Nested: Story = {
       </ListItem>
     </List>
   ),
-};
+});
 
-export const Example: Story = {
+export const Example = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -128,4 +124,4 @@ export const Example: Story = {
       </Typography>
     </div>
   ),
-};
+});

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import { L_MESSAGE_PURPOSES, LocalMessage } from './LocalMessage';
@@ -15,7 +15,7 @@ import { StoryVStack } from '../layout/Stack/utils';
 import { List, ListItem } from '../List';
 import { Heading, Paragraph } from '../Typography';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/LocalMessage',
   component: LocalMessage,
   argTypes: {
@@ -24,17 +24,15 @@ export default {
   },
   args: { onClose: fn() },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof LocalMessage>;
+});
 
-type Story = StoryObj<typeof LocalMessage>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     children: 'Dette er en lokal melding',
   },
-};
+});
 
-export const Purposes: Story = {
+export const Purposes = meta.story({
   render: args => (
     <StoryVStack alignItems="stretch">
       {L_MESSAGE_PURPOSES.map(p => (
@@ -44,9 +42,9 @@ export const Purposes: Story = {
       ))}
     </StoryVStack>
   ),
-};
+});
 
-export const Variants: Story = {
+export const Variants = meta.story({
   render: args => (
     <StoryVStack alignItems="stretch">
       <LocalMessage {...args} closable>
@@ -60,9 +58,9 @@ export const Variants: Story = {
       </LocalMessage>
     </StoryVStack>
   ),
-};
+});
 
-export const WithExtraButton: Story = {
+export const WithExtraButton = meta.story({
   args: {
     children: (
       <HStack justifyContent="space-between" gap="x0.75">
@@ -74,9 +72,9 @@ export const WithExtraButton: Story = {
     ),
     closable: true,
   },
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -91,9 +89,9 @@ export const ResponsiveWidth: Story = {
       xl: 'fit-content',
     },
   },
-};
+});
 
-export const ComplexContent: Story = {
+export const ComplexContent = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -110,4 +108,4 @@ export const ComplexContent: Story = {
       </List>
     </LocalMessage>
   ),
-};
+});

--- a/packages/dds-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/dds-components/src/components/Modal/Modal.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useRef, useState } from 'react';
 import { fn } from 'storybook/test';
 
@@ -12,7 +12,7 @@ import { Search } from '../Search';
 
 import { Modal, ModalActions, ModalBody } from '.';
 
-const meta: Meta<typeof Modal> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Modal',
   component: Modal,
   decorators: [ddsProviderDecorator],
@@ -31,12 +31,9 @@ const meta: Meta<typeof Modal> = {
       story: { height: '350px' },
     },
   },
-};
-export default meta;
+});
 
-type Story = StoryObj<typeof Modal>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => {
     const [closed, setClosed] = useState(false);
     const show = () => setClosed(false);
@@ -68,9 +65,9 @@ export const Preview: Story = {
       </>
     );
   },
-};
+});
 
-export const NotClosable: Story = {
+export const NotClosable = meta.story({
   args: { header: 'Tittel', onClose: undefined },
   render: args => {
     const [closed, setClosed] = useState(false);
@@ -98,9 +95,9 @@ export const NotClosable: Story = {
       </StoryHStack>
     );
   },
-};
+});
 
-export const Scrollable: Story = {
+export const Scrollable = meta.story({
   args: { header: 'Header' },
   render: args => {
     const [closed, setClosed] = useState(false);
@@ -137,9 +134,9 @@ export const Scrollable: Story = {
       </>
     );
   },
-};
+});
 
-export const WithInitialFocus: Story = {
+export const WithInitialFocus = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -177,4 +174,4 @@ export const WithInitialFocus: Story = {
       </>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 
 import {
@@ -32,7 +32,7 @@ import {
 const { className, htmlProps, ref, children, style } =
   commonArgTypesWithNodeChildren;
 
-const meta: Meta<typeof OverflowMenu> = {
+const meta = preview.meta({
   title: 'dds-components/Components/OverflowMenu',
   component: OverflowMenu,
   argTypes: {
@@ -48,13 +48,9 @@ const meta: Meta<typeof OverflowMenu> = {
     },
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof OverflowMenu>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   parameters: { docs: { story: { height: '540px' } } },
   render: args => {
     return (
@@ -113,9 +109,9 @@ export const Preview: Story = {
       </VStack>
     );
   },
-};
+});
 
-export const WithOnOpenAndOnClose: Story = {
+export const WithOnOpenAndOnClose = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -140,9 +136,9 @@ export const WithOnOpenAndOnClose: Story = {
       </VStack>
     );
   },
-};
+});
 
-export const WithAsyncClick: Story = {
+export const WithAsyncClick = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -169,9 +165,9 @@ export const WithAsyncClick: Story = {
       </VStack>
     );
   },
-};
+});
 
-export const WithNoMenuCloseOnAsyncClick: Story = {
+export const WithNoMenuCloseOnAsyncClick = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -201,9 +197,9 @@ export const WithNoMenuCloseOnAsyncClick: Story = {
       </VStack>
     );
   },
-};
+});
 
-export const CustomCloseOnAsyncClick: Story = {
+export const CustomCloseOnAsyncClick = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -239,9 +235,9 @@ export const CustomCloseOnAsyncClick: Story = {
       </VStack>
     );
   },
-};
+});
 
-export const WithinTable: Story = {
+export const WithinTable = meta.story({
   parameters: {
     docs: { story: { height: '540px' } },
     chromatic: { disableSnapshot: true },
@@ -284,4 +280,4 @@ export const WithinTable: Story = {
       </VStack>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import {
@@ -12,7 +12,7 @@ import { StoryVStack } from '../layout/Stack/utils';
 
 import { Pagination } from '.';
 
-const meta: Meta<typeof Pagination> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Pagination',
   component: Pagination,
   argTypes: {
@@ -21,8 +21,7 @@ const meta: Meta<typeof Pagination> = {
   },
   args: { onChange: fn(), onSelectOptionChange: fn() },
   decorators: [ddsProviderDecorator],
-};
-export default meta;
+});
 
 const customOptionsItemsAmount = 100;
 const customOptions = [17, 32, customOptionsItemsAmount].map(o => ({
@@ -30,13 +29,11 @@ const customOptions = [17, 32, customOptionsItemsAmount].map(o => ({
   value: o,
 }));
 
-type Story = StoryObj<typeof Pagination>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { itemsAmount: 100 },
-};
+});
 
-export const Variants: Story = {
+export const Variants = meta.story({
   args: { itemsAmount: 100 },
   render: args => (
     <StoryVStack gap="x2.5">
@@ -62,9 +59,9 @@ export const Variants: Story = {
       </VStack>
     </StoryVStack>
   ),
-};
+});
 
-export const VariantsSmallScreen: Story = {
+export const VariantsSmallScreen = meta.story({
   args: { itemsAmount: 100 },
   render: args => (
     <StoryVStack gap="x2.5">
@@ -91,13 +88,13 @@ export const VariantsSmallScreen: Story = {
       </VStack>
     </StoryVStack>
   ),
-};
+});
 
-export const SmallScreen: Story = {
+export const SmallScreen = meta.story({
   args: { itemsAmount: 100, smallScreenBreakpoint: 'xl' },
-};
+});
 
-export const CustomOptions: Story = {
+export const CustomOptions = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -108,9 +105,9 @@ export const CustomOptions: Story = {
     withSelect: true,
     selectOptions: customOptions,
   },
-};
+});
 
-export const Responsive: Story = {
+export const Responsive = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -127,11 +124,11 @@ export const Responsive: Story = {
         'Versjonen for liten skjerm vises ved sm brekkpunkt.',
       ),
   ],
-};
+});
 
-export const DefaultActivePage: Story = {
+export const DefaultActivePage = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
   args: { itemsAmount: 100, defaultActivePage: 6 },
-};
+});

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.stories.tsx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import {
@@ -16,7 +16,7 @@ import { PhoneInput } from '.';
 
 const { id, className, style } = commonArgTypes;
 
-const meta: Meta<typeof PhoneInput> = {
+const meta = preview.meta({
   title: 'dds-components/Components/PhoneInput',
   component: PhoneInput,
   argTypes: {
@@ -33,14 +33,11 @@ const meta: Meta<typeof PhoneInput> = {
   },
   args: { onChange: fn() },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-type Story = StoryObj<typeof PhoneInput>;
+export const Preview = meta.story({ args: { label: 'Telefonnummer' } });
 
-export const Preview: Story = { args: { label: 'Telefonnummer' } };
-
-export const Overview: Story = {
+export const Overview = meta.story({
   args: { label: 'Telefonnummer' },
   render: args => (
     <StoryHStack>
@@ -59,9 +56,9 @@ export const Overview: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   args: { label: 'Label' },
   render: args => (
     <StoryVStack>
@@ -75,9 +72,9 @@ export const Sizes: Story = {
       ))}
     </StoryVStack>
   ),
-};
+});
 
-export const Responsive: Story = {
+export const Responsive = meta.story({
   args: {
     smallScreenBreakpoint: 'sm',
   },
@@ -91,9 +88,9 @@ export const Responsive: Story = {
         'Versjonen for liten skjerm vises ved sm brekkpunkt.',
       ),
   ],
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -107,4 +104,4 @@ export const ResponsiveWidth: Story = {
       xl: 'var(--dds-input-default-width)',
     },
   },
-};
+});

--- a/packages/dds-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useRef, useState } from 'react';
 import { fn } from 'storybook/test';
 
@@ -17,7 +17,7 @@ import { Paragraph } from '../Typography';
 
 import { Popover, PopoverGroup } from '.';
 
-const meta: Meta<typeof Popover> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Popover',
   component: Popover,
   decorators: [ddsProviderDecorator],
@@ -35,13 +35,9 @@ const meta: Meta<typeof Popover> = {
       story: { height: '300px' },
     },
   },
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof Popover>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <VStack alignItems="center">
       <PopoverGroup isInitiallyOpen={true}>
@@ -57,9 +53,9 @@ export const Preview: Story = {
       </PopoverGroup>
     </VStack>
   ),
-};
+});
 
-export const ContentOverview: Story = {
+export const ContentOverview = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -106,9 +102,9 @@ export const ContentOverview: Story = {
       </div>
     </StoryHStack>
   ),
-};
+});
 
-export const PlacementOverview: Story = {
+export const PlacementOverview = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -146,9 +142,9 @@ export const PlacementOverview: Story = {
       </StoryHStack>
     );
   },
-};
+});
 
-export const WithOnOpenAndOnClose: Story = {
+export const WithOnOpenAndOnClose = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -174,9 +170,9 @@ export const WithOnOpenAndOnClose: Story = {
       </VStack>
     );
   },
-};
+});
 
-export const Overflow: Story = {
+export const Overflow = meta.story({
   render: args => (
     <PopoverGroup>
       <Button>Åpne</Button>
@@ -196,9 +192,9 @@ export const Overflow: Story = {
       </Popover>
     </PopoverGroup>
   ),
-};
+});
 
-export const InlineExample: Story = {
+export const InlineExample = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -226,9 +222,9 @@ export const InlineExample: Story = {
       </Paragraph>
     );
   },
-};
+});
 
-export const Custom: Story = {
+export const Custom = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -272,4 +268,4 @@ export const Custom: Story = {
       </StoryVStack>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/dds-components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { PROGRESS_BAR_SIZES } from './ProgressBar';
 import {
@@ -11,7 +11,7 @@ import { StoryVStack } from '../layout/Stack/utils';
 
 import { ProgressBar } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/ProgressBar',
   component: ProgressBar,
   argTypes: {
@@ -19,19 +19,17 @@ export default {
     value: { table: categoryHtml },
     width: responsivePropsArgTypes.width,
   },
-} satisfies Meta<typeof ProgressBar>;
+});
 
-type Story = StoryObj<typeof ProgressBar>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     label: 'Label',
     value: 3,
     max: 5,
   },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   args: {
     label: 'Label',
   },
@@ -44,8 +42,8 @@ export const Overview: Story = {
       <ProgressBar {...args} max={10} value={10} />
     </StoryVStack>
   ),
-};
-export const Sizes: Story = {
+});
+export const Sizes = meta.story({
   args: {
     label: 'Label',
     value: 3,
@@ -58,9 +56,9 @@ export const Sizes: Story = {
       ))}
     </StoryVStack>
   ),
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -77,4 +75,4 @@ export const ResponsiveWidth: Story = {
       xl: 'var(--dds-input-default-width)',
     },
   },
-};
+});

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 
 import { ProgressTracker } from './ProgressTracker';
@@ -17,20 +17,16 @@ import {
 } from '../Icon/icons';
 import { HStack, VStack } from '../layout';
 
-const meta: Meta<typeof ProgressTracker> = {
+const meta = preview.meta({
   title: 'dds-components/Components/ProgressTracker',
   component: ProgressTracker,
   argTypes: {
     ...commonArgTypesWithNodeChildren,
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof ProgressTracker>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => {
     const numSteps = 3;
 
@@ -79,9 +75,9 @@ export const Preview: Story = {
       </VStack>
     );
   },
-};
+});
 
-export const WithIcons: Story = {
+export const WithIcons = meta.story({
   render: args => {
     const numSteps = 3;
 
@@ -140,9 +136,9 @@ export const WithIcons: Story = {
       </VStack>
     );
   },
-};
+});
 
-export const Horisontal: Story = {
+export const Horisontal = meta.story({
   render: args => {
     const numSteps = 3;
 
@@ -191,9 +187,9 @@ export const Horisontal: Story = {
       </VStack>
     );
   },
-};
+});
 
-export const FutureStepsDisabled: Story = {
+export const FutureStepsDisabled = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -254,9 +250,9 @@ export const FutureStepsDisabled: Story = {
       </VStack>
     );
   },
-};
+});
 
-export const SmallScreen: Story = {
+export const SmallScreen = meta.story({
   render: args => {
     const numSteps = 3;
 
@@ -317,4 +313,4 @@ export const SmallScreen: Story = {
       </>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/Search/Search.stories.tsx
+++ b/packages/dds-components/src/components/Search/Search.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import { SEARCH_SIZES } from './Search.utils';
@@ -13,7 +13,7 @@ import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 import { Search } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Search',
   component: Search,
   argTypes: {
@@ -23,7 +23,7 @@ export default {
   },
   args: { onChange: fn() },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof Search>;
+});
 
 const array = [
   'lala',
@@ -53,11 +53,9 @@ const elementsInfo = (
   </div>
 );
 
-type Story = StoryObj<typeof Search>;
+export const Preview = meta.story();
 
-export const Preview: Story = {};
-
-export const Overview: Story = {
+export const Overview = meta.story({
   render: args => (
     <StoryVStack>
       <Search {...args} />
@@ -80,9 +78,9 @@ export const Overview: Story = {
       <Search {...args} buttonProps={{ onClick: () => null, loading: true }} />
     </StoryVStack>
   ),
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   render: args => (
     <StoryHStack>
       <StoryVStack>
@@ -102,9 +100,9 @@ export const Sizes: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const SizesWithSuggestions: Story = {
+export const SizesWithSuggestions = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -118,9 +116,9 @@ export const SizesWithSuggestions: Story = {
       {elementsInfo}
     </StoryVStack>
   ),
-};
+});
 
-export const WithSuggestions: Story = {
+export const WithSuggestions = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
     docs: { story: { height: '450px' } },
@@ -133,9 +131,9 @@ export const WithSuggestions: Story = {
       {elementsInfo}
     </>
   ),
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -150,4 +148,4 @@ export const ResponsiveWidth: Story = {
       xl: 'var(--dds-input-default-width)',
     },
   },
-};
+});

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import {
@@ -15,7 +15,7 @@ import { StoryHStack, StoryVStack } from '../../layout/Stack/utils';
 
 import { NativeSelect } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Select/NativeSelect',
   component: NativeSelect,
   argTypes: {
@@ -31,9 +31,7 @@ export default {
   },
   args: { onChange: fn() },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof NativeSelect>;
-
-type Story = StoryObj<typeof NativeSelect>;
+});
 
 const options = [
   { value: 'Alternativ 1', label: 'Alternativ 1' },
@@ -54,14 +52,14 @@ const nativeOptions = options.map((item, index) => (
 
 const children = [<option value=""></option>, ...nativeOptions];
 
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     label: 'Label',
     children,
   },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   args: {
     label: 'Label',
     children,
@@ -121,9 +119,9 @@ export const Overview: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   args: {
     label: 'Label',
     children,
@@ -153,9 +151,9 @@ export const Sizes: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -170,4 +168,4 @@ export const ResponsiveWidth: Story = {
       xl: 'var(--dds-input-default-width)',
     },
   },
-};
+});

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import {
@@ -11,7 +11,7 @@ import { StoryHStack, StoryVStack } from '../../layout/Stack/utils';
 
 import { Checkbox } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Checkbox',
   component: Checkbox,
   argTypes: {
@@ -27,15 +27,13 @@ export default {
     onChange: htmlEventArgType,
   },
   args: { onChange: fn(), onBlur: fn() },
-} satisfies Meta<typeof Checkbox>;
+});
 
-type Story = StoryObj<typeof Checkbox>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { label: 'Label' },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   render: args => (
     <StoryHStack>
       <StoryVStack>
@@ -68,4 +66,4 @@ export const Overview: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { commonArgTypesWithNodeChildren } from '../../../storybook';
 import { Fieldset } from '../../Fieldset';
@@ -7,19 +7,15 @@ import { Legend } from '../../Typography';
 
 import { Checkbox, CheckboxGroup } from '.';
 
-const meta: Meta<typeof CheckboxGroup> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Checkbox/CheckboxGroup',
   component: CheckboxGroup,
   argTypes: {
     ...commonArgTypesWithNodeChildren,
   },
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof CheckboxGroup>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     label: 'Label',
     children: [
@@ -28,7 +24,7 @@ export const Preview: Story = {
       <Checkbox key={2} label="Option 3" />,
     ],
   },
-};
+});
 
 const fieldsetStyling = `
 .fieldset-story-container div[role="group"] {
@@ -38,7 +34,7 @@ const fieldsetStyling = `
 }
 `;
 
-export const WithFieldset: Story = {
+export const WithFieldset = meta.story({
   decorators: [
     Story => (
       <>
@@ -64,9 +60,9 @@ export const WithFieldset: Story = {
       <CheckboxGroup {...args} className="fieldset-story-container" />
     </Fieldset>
   ),
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   args: {
     label: 'Label',
     children: [
@@ -90,4 +86,4 @@ export const Overview: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import {
@@ -11,7 +11,7 @@ import { StoryHStack, StoryVStack } from '../../layout/Stack/utils';
 
 import { RadioButton } from '.';
 
-const meta: Meta<typeof RadioButton> = {
+const meta = preview.meta({
   title: 'dds-components/Components/RadioButton',
   component: RadioButton,
   argTypes: {
@@ -25,16 +25,13 @@ const meta: Meta<typeof RadioButton> = {
     onChange: htmlEventArgType,
   },
   args: { onChange: fn() },
-};
+});
 
-export default meta;
-type Story = StoryObj<typeof RadioButton>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { label: 'Label' },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   render: args => (
     <StoryHStack>
       <StoryVStack>
@@ -50,4 +47,4 @@ export const Overview: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 
 import { commonArgTypes, ddsProviderDecorator } from '../../../storybook';
@@ -6,7 +6,7 @@ import { StoryHStack, StoryVStack } from '../../layout/Stack/utils';
 
 import { RadioButton, RadioButtonGroup } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/RadioButton/RadioButtonGroup',
   component: RadioButtonGroup,
   argTypes: {
@@ -14,9 +14,7 @@ export default {
     value: { control: false },
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof RadioButtonGroup>;
-
-type Story = StoryObj<typeof RadioButtonGroup>;
+});
 
 const children = [
   <RadioButton value={1} label="Option 1" key={1} />,
@@ -33,11 +31,11 @@ const childrenString = [
 let counter = 0;
 const name = () => `test${counter++}`;
 
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { label: 'Label', children, name: 'test' },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   args: { label: 'Label' },
   render: args => {
     return (
@@ -76,9 +74,9 @@ export const Overview: Story = {
       </StoryHStack>
     );
   },
-};
+});
 
-export const Direction: Story = {
+export const Direction = meta.story({
   args: { label: 'Label' },
   render: args => {
     return (
@@ -92,9 +90,9 @@ export const Direction: Story = {
       </StoryVStack>
     );
   },
-};
+});
 
-export const WithValue: Story = {
+export const WithValue = meta.story({
   args: { label: 'Label', children },
   render: args => {
     const [value, setValue] = useState<number | undefined>(2);
@@ -109,9 +107,9 @@ export const WithValue: Story = {
       />
     );
   },
-};
+});
 
-export const WithStringValue: Story = {
+export const WithStringValue = meta.story({
   args: { label: 'Label', children: childrenString },
   render: args => {
     const [value, setValue] = useState<string | undefined>('1');
@@ -126,18 +124,18 @@ export const WithStringValue: Story = {
       />
     );
   },
-};
+});
 
-export const WithDefaultValue: Story = {
+export const WithDefaultValue = meta.story({
   args: { label: 'Label', children },
   render: args => {
     return <RadioButtonGroup {...args} defaultValue={2} name={name()} />;
   },
-};
+});
 
-export const WithDefaultStringValue: Story = {
+export const WithDefaultStringValue = meta.story({
   args: { label: 'Label', children: childrenString },
   render: args => {
     return <RadioButtonGroup {...args} defaultValue="2" name={name()} />;
   },
-};
+});

--- a/packages/dds-components/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/dds-components/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { Skeleton } from './Skeleton';
 import {
@@ -9,7 +9,7 @@ import {
 import { Box, VStack } from '../layout';
 import { StoryVStack } from '../layout/Stack/utils';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Skeleton',
   component: Skeleton,
   argTypes: {
@@ -17,18 +17,16 @@ export default {
     height: responsivePropsArgTypes.height,
     borderRadius: { control: 'text', table: categoryCss },
   },
-} satisfies Meta<typeof Skeleton>;
+});
 
-type Story = StoryObj<typeof Skeleton>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     width: '320px',
     height: 'var(--dds-spacing-x2)',
   },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   args: {
     width: 'var(--dds-spacing-x2)',
     height: 'var(--dds-spacing-x2)',
@@ -39,9 +37,9 @@ export const Overview: Story = {
       <Skeleton {...args} width="320px" />
     </StoryVStack>
   ),
-};
+});
 
-export const Example: Story = {
+export const Example = meta.story({
   render: args => (
     <StoryVStack>
       <Skeleton
@@ -62,9 +60,9 @@ export const Example: Story = {
       />
     </StoryVStack>
   ),
-};
+});
 
-export const Responsive: Story = {
+export const Responsive = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -179,4 +177,4 @@ export const Responsive: Story = {
       </Box>
     </VStack>
   ),
-};
+});

--- a/packages/dds-components/src/components/SkipToContent/SkipToContent.stories.tsx
+++ b/packages/dds-components/src/components/SkipToContent/SkipToContent.stories.tsx
@@ -1,21 +1,19 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { categoryCss, commonArgTypes } from '../../storybook';
 
 import { SkipToContent } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/SkipToContent',
   component: SkipToContent,
   argTypes: {
     top: { control: 'text', table: categoryCss },
     ...commonArgTypes,
   },
-} satisfies Meta<typeof SkipToContent>;
+});
 
-type Story = StoryObj<typeof SkipToContent>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { href: '#innhold' },
   render: args => (
     <div style={{ position: 'relative' }}>
@@ -24,9 +22,9 @@ export const Preview: Story = {
       <main id="innhold">Innhold</main>
     </div>
   ),
-};
+});
 
-export const CustomTop: Story = {
+export const CustomTop = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -38,9 +36,9 @@ export const CustomTop: Story = {
       <main id="innhold">Innhold</main>
     </div>
   ),
-};
+});
 
-export const CustomText: Story = {
+export const CustomText = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -52,4 +50,4 @@ export const CustomText: Story = {
       <main id="innhold">Innhold</main>
     </div>
   ),
-};
+});

--- a/packages/dds-components/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/dds-components/src/components/Spinner/Spinner.stories.tsx
@@ -1,10 +1,10 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { commonArgTypes, ddsProviderDecorator } from '../../storybook';
 
 import { Spinner } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Spinner',
   component: Spinner,
   argTypes: {
@@ -13,28 +13,26 @@ export default {
     ...commonArgTypes,
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof Spinner>;
+});
 
-type Story = StoryObj<typeof Spinner>;
+export const Preview = meta.story();
 
-export const Preview: Story = {};
-
-export const CustomColor: Story = {
+export const CustomColor = meta.story({
   args: { color: 'icon-on-success-default' },
-};
+});
 
-export const CustomSize: Story = {
+export const CustomSize = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
   args: { size: '150px' },
-};
+});
 
-export const CustomTooltip: Story = {
+export const CustomTooltip = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
   args: {
     tooltip: 'Egendefinert melding',
   },
-};
+});

--- a/packages/dds-components/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { ddsProviderDecorator, labelText } from '../../storybook';
 import { BUTTON_SIZES } from '../Button/Button.types';
@@ -6,21 +6,6 @@ import { PlusCircledIcon } from '../Icon/icons';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 import { SplitButton } from '.';
-
-export default {
-  title: 'dds-components/Components/SplitButton',
-  component: SplitButton,
-  parameters: {
-    docs: {
-      story: { height: '200px' },
-    },
-  },
-  argTypes: {
-    secondaryActions: { control: false },
-    primaryAction: { control: false },
-  },
-  decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof SplitButton>;
 
 const items = [
   {
@@ -34,16 +19,28 @@ const items = [
   },
 ];
 
-type Story = StoryObj<typeof SplitButton>;
-
-export const Preview: Story = {
+const meta = preview.meta({
+  title: 'dds-components/Components/SplitButton',
+  component: SplitButton,
+  parameters: {
+    docs: {
+      story: { height: '200px' },
+    },
+  },
+  argTypes: {
+    secondaryActions: { control: false },
+    primaryAction: { control: false },
+  },
   args: {
     primaryAction: { children: 'Tekst' },
     secondaryActions: items,
   },
-};
+  decorators: [ddsProviderDecorator],
+});
 
-export const Purposes: Story = {
+export const Preview = meta.story({});
+
+export const Purposes = meta.story({
   render: args => (
     <StoryHStack>
       <StoryVStack>
@@ -62,9 +59,9 @@ export const Purposes: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   render: args => (
     <StoryHStack>
       <StoryVStack>
@@ -73,7 +70,6 @@ export const Sizes: Story = {
             {...args}
             key={size}
             primaryAction={{ children: labelText(size) }}
-            secondaryActions={items}
             size={size}
           />
         ))}
@@ -86,18 +82,16 @@ export const Sizes: Story = {
               children: labelText(size),
               icon: PlusCircledIcon,
             }}
-            secondaryActions={items}
             size={size}
           />
         ))}
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const FullWidth: Story = {
+export const FullWidth = meta.story({
   args: {
     primaryAction: { children: 'Tekst', fullWidth: true },
-    secondaryActions: items,
   },
-};
+});

--- a/packages/dds-components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
+++ b/packages/dds-components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { ScreenSize, useScreenSize } from '../../../hooks';
 import { ddsProviderDecorator, windowWidthDecorator } from '../../../storybook';
@@ -19,7 +19,14 @@ import { data, headerCells, mapCellContents } from '../normal/tableData';
 
 import { CollapsibleTable } from '.';
 
-const meta: Meta<typeof CollapsibleTable> = {
+const headerValues = headerCells.map(cell => {
+  return {
+    content: cell.name,
+    key: cell.name,
+  };
+});
+
+const meta = preview.meta({
   title: 'dds-components/Components/Table/CollapsibleTable',
   component: CollapsibleTable,
   parameters: {
@@ -32,12 +39,9 @@ const meta: Meta<typeof CollapsibleTable> = {
       exclude: ['headerValues', 'definingColumnIndex'],
     },
   },
+  args: { headerValues },
   decorators: [ddsProviderDecorator],
-};
-
-export default meta;
-
-type Story = StoryObj<typeof CollapsibleTable>;
+});
 
 const mappedHeaderCells = headerCells.map(headerCell => {
   return (
@@ -47,18 +51,11 @@ const mappedHeaderCells = headerCells.map(headerCell => {
   );
 });
 
-const headerValues = headerCells.map(cell => {
-  return {
-    content: cell.name,
-    key: cell.name,
-  };
-});
-
-export const SingleDefiningColumn: Story = {
+export const SingleDefiningColumn = meta.story({
+  args: { headerValues },
   render: args => (
     <CollapsibleTable
       {...args}
-      headerValues={headerValues}
       isCollapsed={args.isCollapsed !== false && true}
     >
       <Table.Head>
@@ -75,15 +72,14 @@ export const SingleDefiningColumn: Story = {
       </Table.Body>
     </CollapsibleTable>
   ),
-};
+});
 
-export const MultipleDefiningColumns: Story = {
+export const MultipleDefiningColumns = meta.story({
   render: args => (
     <Table.Wrapper>
       <CollapsibleTable
         {...args}
         isCollapsed={args.isCollapsed !== false && true}
-        headerValues={headerValues}
         definingColumnIndex={[0, 2]}
       >
         <Table.Head>
@@ -103,15 +99,14 @@ export const MultipleDefiningColumns: Story = {
       </CollapsibleTable>
     </Table.Wrapper>
   ),
-};
+});
 
-export const PrioritizedDefiningColumns: Story = {
+export const PrioritizedDefiningColumns = meta.story({
   render: args => (
     <Table.Wrapper>
       <CollapsibleTable
         {...args}
         isCollapsed={args.isCollapsed !== false && true}
-        headerValues={headerValues}
         definingColumnIndex={[2, 0]}
       >
         <Table.Head>
@@ -131,14 +126,13 @@ export const PrioritizedDefiningColumns: Story = {
       </CollapsibleTable>
     </Table.Wrapper>
   ),
-};
+});
 
-export const WithDividers: Story = {
+export const WithDividers = meta.story({
   render: args => (
     <CollapsibleTable
       {...args}
       withDividers
-      headerValues={headerValues}
       isCollapsed={args.isCollapsed !== false && true}
     >
       <Table.Head>
@@ -155,14 +149,13 @@ export const WithDividers: Story = {
       </Table.Body>
     </CollapsibleTable>
   ),
-};
+});
 
-export const Large: Story = {
+export const Large = meta.story({
   render: args => (
     <CollapsibleTable
       {...args}
       size="large"
-      headerValues={headerValues}
       isCollapsed={args.isCollapsed !== false && true}
     >
       <Table.Head>
@@ -179,15 +172,14 @@ export const Large: Story = {
       </Table.Body>
     </CollapsibleTable>
   ),
-};
+});
 
-export const StickyHeader: Story = {
+export const StickyHeader = meta.story({
   render: args => (
     <CollapsibleTable
       {...args}
       stickyHeader
       isCollapsed={args.isCollapsed !== false && true}
-      headerValues={headerValues}
       definingColumnIndex={[0, 2]}
     >
       <Table.Head>
@@ -211,18 +203,20 @@ export const StickyHeader: Story = {
       </Table.Body>
     </CollapsibleTable>
   ),
-};
+});
 
 const adminIcon = <Icon icon={PersonIcon} />;
 
-export const WithButtonAndIcons: Story = {
-  render: args => {
-    const headerValues = [
+export const WithButtonAndIcons = meta.story({
+  args: {
+    headerValues: [
       { content: 'Navn til venstre', key: 'Navn til venstre' },
       { content: 'Navn til høyre', key: 'Navn til høyre' },
       { content: 'Rolle', key: 'Rolle' },
       { content: 'Aksjoner', key: 'Aksjoner' },
-    ];
+    ],
+  },
+  render: args => {
     const deleteButton = (
       <Button
         purpose="secondary"
@@ -234,7 +228,7 @@ export const WithButtonAndIcons: Story = {
       </Button>
     );
     return (
-      <CollapsibleTable {...args} headerValues={headerValues} isCollapsed>
+      <CollapsibleTable {...args} isCollapsed>
         <Table.Head>
           <CollapsibleTable.Row>
             {headerValues.map(headerCell => {
@@ -263,9 +257,9 @@ export const WithButtonAndIcons: Story = {
       </CollapsibleTable>
     );
   },
-};
+});
 
-export const Responsive: Story = {
+export const Responsive = meta.story({
   render: args => {
     const screenSize = useScreenSize();
     return (
@@ -273,7 +267,6 @@ export const Responsive: Story = {
         <CollapsibleTable
           {...args}
           isCollapsed={screenSize <= ScreenSize.Small}
-          headerValues={headerValues}
         >
           <Table.Head>
             <CollapsibleTable.Row>{mappedHeaderCells}</CollapsibleTable.Row>
@@ -300,9 +293,9 @@ export const Responsive: Story = {
         'Kollapset versjon vises ved sm brekkpunkt.',
       ),
   ],
-};
+});
 
-export const ResposiveMultipleBreakpoints: Story = {
+export const ResposiveMultipleBreakpoints = meta.story({
   render: args => {
     const screenSize = useScreenSize();
     return (
@@ -310,7 +303,6 @@ export const ResposiveMultipleBreakpoints: Story = {
         <CollapsibleTable
           {...args}
           isCollapsed={screenSize <= ScreenSize.Small}
-          headerValues={headerValues}
           definingColumnIndex={screenSize === ScreenSize.XSmall ? [2] : [2, 0]}
         >
           <Table.Head>
@@ -338,7 +330,7 @@ export const ResposiveMultipleBreakpoints: Story = {
         'Ulike kollapsede versjoner vises ved xs og sm brekkpunkt.',
       ),
   ],
-};
+});
 
 const headers = [
   {
@@ -359,7 +351,7 @@ const headers = [
   { key: 'Mottakere', content: 'Mottakere' },
   { key: 'Sendt', content: 'Sendt' },
 ];
-export const Example: Story = {
+export const Example = meta.story({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: args => {
     const screenSize = useScreenSize();
@@ -423,4 +415,4 @@ export const Example: Story = {
       </CollapsibleTable>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/Table/normal/Table.stories.tsx
+++ b/packages/dds-components/src/components/Table/normal/Table.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { type ChangeEvent, useEffect, useState } from 'react';
 
 import {
@@ -17,7 +17,7 @@ import { Link, Paragraph } from '../../Typography';
 
 import { Table } from '.';
 
-const meta: Meta<typeof Table> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Table',
   component: Table,
   parameters: {
@@ -26,11 +26,7 @@ const meta: Meta<typeof Table> = {
     },
   },
   decorators: [ddsProviderDecorator],
-};
-
-export default meta;
-
-type Story = StoryObj<typeof Table>;
+});
 
 const mappedHeaderCells = headerCells.map(headerCell => {
   return (
@@ -40,7 +36,7 @@ const mappedHeaderCells = headerCells.map(headerCell => {
   );
 });
 
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args}>
@@ -61,9 +57,9 @@ export const Preview: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});
 
-export const WithDividers: Story = {
+export const WithDividers = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args} withDividers>
@@ -84,9 +80,9 @@ export const WithDividers: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});
 
-export const WithoutStripes: Story = {
+export const WithoutStripes = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args} withStripes={false}>
@@ -107,9 +103,9 @@ export const WithoutStripes: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});
 
-export const Small: Story = {
+export const Small = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args} size="small">
@@ -130,9 +126,9 @@ export const Small: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});
 
-export const Large: Story = {
+export const Large = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args} size="large">
@@ -153,9 +149,9 @@ export const Large: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});
 
-export const StickyHeader: Story = {
+export const StickyHeader = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args} stickyHeader>
@@ -185,9 +181,9 @@ export const StickyHeader: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});
 
-export const Focusable: Story = {
+export const Focusable = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args}>
@@ -214,9 +210,9 @@ export const Focusable: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});
 
-export const Hoverable: Story = {
+export const Hoverable = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args}>
@@ -237,7 +233,7 @@ export const Hoverable: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});
 
 const adminIcon = <Icon icon={PersonIcon} />;
 const deleteButton = (
@@ -245,7 +241,7 @@ const deleteButton = (
     Fjern tilgang
   </Button>
 );
-export const WithButtonAndIcons: Story = {
+export const WithButtonAndIcons = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args}>
@@ -274,7 +270,7 @@ export const WithButtonAndIcons: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});
 
 const sumData = [
   {
@@ -295,7 +291,7 @@ const sumData = [
   },
 ];
 
-export const WithSum: Story = {
+export const WithSum = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args}>
@@ -324,9 +320,9 @@ export const WithSum: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});
 
-export const WithCheckbox: Story = {
+export const WithCheckbox = meta.story({
   render: args => {
     type chechboxRow = {
       id: string;
@@ -428,9 +424,9 @@ export const WithCheckbox: Story = {
       </Table.Wrapper>
     );
   },
-};
+});
 
-export const Complex: Story = {
+export const Complex = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args} stickyHeader>
@@ -503,9 +499,9 @@ export const Complex: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});
 
-export const Sortable: Story = {
+export const Sortable = meta.story({
   render: args => {
     const [headerSortCells, setHeaderSortCells] =
       useState<Array<HeaderCellToSort>>(headerCells);
@@ -601,9 +597,9 @@ export const Sortable: Story = {
       </Table.Wrapper>
     );
   },
-};
+});
 
-export const ColumnAndRowHeaders: Story = {
+export const ColumnAndRowHeaders = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args}>
@@ -635,9 +631,9 @@ export const ColumnAndRowHeaders: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});
 
-export const WithScroll: Story = {
+export const WithScroll = meta.story({
   render: args => (
     <>
       <Paragraph withMargins>
@@ -676,9 +672,9 @@ export const WithScroll: Story = {
       </Table.Wrapper>
     </>
   ),
-};
+});
 
-export const InteractiveContent: Story = {
+export const InteractiveContent = meta.story({
   render: args => (
     <Table.Wrapper>
       <Table {...args}>
@@ -707,4 +703,4 @@ export const InteractiveContent: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});

--- a/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 
 import { TABS_SIZES } from './Tabs';
@@ -15,7 +15,7 @@ import { Paragraph } from '../Typography';
 
 import { Tab, TabList, TabPanel, TabPanels, Tabs } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Tabs',
   component: Tabs,
   argTypes: {
@@ -23,9 +23,7 @@ export default {
     ...commonArgTypesWithNodeChildren,
     addTabButtonProps: { control: false },
   },
-} satisfies Meta<typeof Tabs>;
-
-type Story = StoryObj<typeof Tabs>;
+});
 
 const tabList = (icon?: boolean) => {
   const tabIcon = icon ? NotificationsIcon : undefined;
@@ -46,16 +44,16 @@ const tabPanels = (
   </TabPanels>
 );
 
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <Tabs {...args}>
       {tabList()}
       {tabPanels}
     </Tabs>
   ),
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   render: args => (
     <StoryVStack gap="x2.5">
       {TABS_SIZES.map(size => (
@@ -74,9 +72,9 @@ export const Sizes: Story = {
       ))}
     </StoryVStack>
   ),
-};
+});
 
-export const ActiveTab: Story = {
+export const ActiveTab = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -89,9 +87,9 @@ export const ActiveTab: Story = {
       </Tabs>
     );
   },
-};
+});
 
-export const WithAddTabButton: Story = {
+export const WithAddTabButton = meta.story({
   render: args => {
     const [tooManyText, setTooManyText] = useState('');
     const [activeTab, setActiveTab] = useState(0);
@@ -150,9 +148,9 @@ export const WithAddTabButton: Story = {
       </>
     );
   },
-};
+});
 
-export const WithWidth: Story = {
+export const WithWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -166,9 +164,9 @@ export const WithWidth: Story = {
       </Tabs>
     </>
   ),
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -188,9 +186,9 @@ export const ResponsiveWidth: Story = {
       {tabPanels}
     </Tabs>
   ),
-};
+});
 
-export const DifferentWidths: Story = {
+export const DifferentWidths = meta.story({
   render: args => (
     <>
       <Paragraph withMargins>
@@ -208,9 +206,9 @@ export const DifferentWidths: Story = {
       </Tabs>
     </>
   ),
-};
+});
 
-export const TabOverflow: Story = {
+export const TabOverflow = meta.story({
   render: args => (
     <>
       <Paragraph withMargins>
@@ -235,4 +233,4 @@ export const TabOverflow: Story = {
       </Tabs>
     </>
   ),
-};
+});

--- a/packages/dds-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/dds-components/src/components/Tag/Tag.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { TAG_PURPOSES, icons } from './Tag';
 import { commonArgTypes, labelText } from '../../storybook';
@@ -6,22 +6,20 @@ import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 import { Tag } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Tag',
   component: Tag,
   argTypes: {
     children: { control: 'text' },
     ...commonArgTypes,
   },
-} satisfies Meta<typeof Tag>;
+});
 
-type Story = StoryObj<typeof Tag>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { children: 'default' },
-};
+});
 
-export const Variants: Story = {
+export const Variants = meta.story({
   args: { children: 'default' },
   render: args => (
     <StoryHStack>
@@ -69,4 +67,4 @@ export const Variants: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});

--- a/packages/dds-components/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/dds-components/src/components/TextArea/TextArea.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import { TextArea } from './TextArea';
@@ -11,7 +11,7 @@ import {
 } from '../../storybook';
 import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/TextArea',
   component: TextArea,
   argTypes: {
@@ -24,15 +24,13 @@ export default {
   },
   args: { onChange: fn() },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof TextArea>;
+});
 
-type Story = StoryObj<typeof TextArea>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { label: 'Label' },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   args: { label: 'Label' },
   render: args => (
     <StoryHStack>
@@ -56,9 +54,9 @@ export const Overview: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -73,4 +71,4 @@ export const ResponsiveWidth: Story = {
       xl: 'var(--dds-input-default-width)',
     },
   },
-};
+});

--- a/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import {
@@ -16,7 +16,7 @@ import { LocalMessage } from '../LocalMessage';
 
 import { TextInput } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/TextInput',
   component: TextInput,
   argTypes: {
@@ -30,15 +30,13 @@ export default {
   },
   args: { onChange: fn() },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof TextInput>;
+});
 
-type Story = StoryObj<typeof TextInput>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { label: 'Label' },
-};
+});
 
-export const States: Story = {
+export const States = meta.story({
   args: { label: 'Label' },
   render: args => (
     <StoryHStack>
@@ -58,9 +56,9 @@ export const States: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   render: args => (
     <StoryHStack>
       <StoryVStack>
@@ -86,9 +84,9 @@ export const Sizes: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const WithAffixes: Story = {
+export const WithAffixes = meta.story({
   render: args => (
     <StoryVStack>
       <LocalMessage purpose="tips">
@@ -113,9 +111,9 @@ export const WithAffixes: Story = {
       />
     </StoryVStack>
   ),
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -130,4 +128,4 @@ export const ResponsiveWidth: Story = {
       xl: 'var(--dds-input-default-width)',
     },
   },
-};
+});

--- a/packages/dds-components/src/components/Toggle/Toggle.stories.tsx
+++ b/packages/dds-components/src/components/Toggle/Toggle.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import { TOGGLE_SIZES } from './Toggle';
@@ -14,7 +14,7 @@ import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 import { Toggle } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Toggle',
   component: Toggle,
   argTypes: {
@@ -29,15 +29,13 @@ export default {
   },
   args: { onChange: fn(), onBlur: fn() },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof Toggle>;
+});
 
-type Story = StoryObj<typeof Toggle>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { children: 'Ledetekst' },
-};
+});
 
-export const States: Story = {
+export const States = meta.story({
   args: { children: 'Ledetekst' },
   render: args => (
     <StoryHStack>
@@ -62,9 +60,9 @@ export const States: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   render: args => (
     <StoryVStack>
       {TOGGLE_SIZES.map(size => (
@@ -74,4 +72,4 @@ export const Sizes: Story = {
       ))}
     </StoryVStack>
   ),
-};
+});

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
@@ -1,5 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
-import { fn } from 'storybook/test';
+import preview from '#.storybook/preview';
 
 import { TOGGLE_BAR_PURPOSES, TOGGLE_BAR_SIZES } from './ToggleBar.types';
 import {
@@ -15,7 +14,7 @@ import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 import { ToggleBar, ToggleRadio } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/ToggleBar',
   component: ToggleBar,
   argTypes: {
@@ -23,10 +22,7 @@ export default {
     value: { control: false },
     ...commonArgTypesWithNodeChildren,
   },
-  args: { onChange: fn() },
-} satisfies Meta<typeof ToggleBar>;
-
-type Story = StoryObj<typeof ToggleBar>;
+});
 
 const toggleRadios = (label?: boolean, icon?: boolean) => {
   const radios = [];
@@ -43,7 +39,7 @@ const toggleRadios = (label?: boolean, icon?: boolean) => {
   return <>{radios}</>;
 };
 
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <ToggleBar {...args} name="test">
       <ToggleRadio label="Alt1" value="Alt1" />
@@ -51,9 +47,9 @@ export const Preview: Story = {
       <ToggleRadio label="Alt3" value="Alt3" />
     </ToggleBar>
   ),
-};
+});
 
-export const Purposes: Story = {
+export const Purposes = meta.story({
   render: args => {
     let name = 0;
     return (
@@ -71,9 +67,9 @@ export const Purposes: Story = {
       </StoryVStack>
     );
   },
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   render: args => {
     let name = 0;
     return (
@@ -97,9 +93,9 @@ export const Sizes: Story = {
       </StoryHStack>
     );
   },
-};
+});
 
-export const WithWidth: Story = {
+export const WithWidth = meta.story({
   render: args => {
     return (
       <ToggleBar {...args} name="test" width="320px">
@@ -107,9 +103,9 @@ export const WithWidth: Story = {
       </ToggleBar>
     );
   },
-};
+});
 
-export const ResponsiveWidth: Story = {
+export const ResponsiveWidth = meta.story({
   decorators: [Story => windowWidthDecorator(<Story />)],
   args: {
     width: {
@@ -127,4 +123,4 @@ export const ResponsiveWidth: Story = {
       </ToggleBar>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/packages/dds-components/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import { TOGGLE_BUTTON_SIZES } from './ToggleButton.types';
@@ -14,7 +14,7 @@ import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 import { ToggleButton } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/ToggleButton',
   component: ToggleButton,
   argTypes: {
@@ -30,19 +30,17 @@ export default {
     icon: { control: false },
   },
   args: { onChange: fn(), onBlur: fn() },
-} satisfies Meta<typeof ToggleButton>;
+});
 
-type Story = StoryObj<typeof ToggleButton>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { label: 'Tekst' },
-};
+});
 
-export const WithIcon: Story = {
+export const WithIcon = meta.story({
   args: { label: 'Tekst', icon: NotificationsIcon },
-};
+});
 
-export const Sizes: Story = {
+export const Sizes = meta.story({
   render: args => (
     <StoryHStack>
       <StoryVStack>
@@ -68,4 +66,4 @@ export const Sizes: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});

--- a/packages/dds-components/src/components/ToggleButton/ToggleButtonGroup.stories.tsx
+++ b/packages/dds-components/src/components/ToggleButton/ToggleButtonGroup.stories.tsx
@@ -1,21 +1,20 @@
-import { type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { commonArgTypesWithNodeChildren } from '../../storybook';
 
 import { ToggleButton, ToggleButtonGroup } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/ToggleButton/ToggleButtonGroup',
   component: ToggleButtonGroup,
+
   argTypes: {
     ...commonArgTypesWithNodeChildren,
     labelId: { control: false },
   },
-};
+});
 
-type Story = StoryObj<typeof ToggleButtonGroup>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { label: 'Label' },
   render: args => (
     <ToggleButtonGroup {...args}>
@@ -25,4 +24,4 @@ export const Preview: Story = {
       <ToggleButton label="Tekst" />
     </ToggleButtonGroup>
   ),
-};
+});

--- a/packages/dds-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/dds-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import {
@@ -12,7 +12,7 @@ import { StoryHStack, StoryVStack } from '../layout/Stack/utils';
 
 import { Tooltip } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Tooltip',
   component: Tooltip,
   argTypes: {
@@ -22,13 +22,11 @@ export default {
     onMouseLeave: htmlEventArgType,
     onMouseOver: htmlEventArgType,
   },
-  args: { onMouseLeave: fn(), onMouseOver: fn() },
+  args: { onMouseLeave: fn(), onMouseOver: fn(), children: <></> },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof Tooltip>;
+});
 
-type Story = StoryObj<typeof Tooltip>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { text: 'Dette er en tooltip' },
   render: args => (
     <StoryVStack alignItems="center" paddingBlock="x6">
@@ -37,9 +35,9 @@ export const Preview: Story = {
       </Tooltip>
     </StoryVStack>
   ),
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -89,9 +87,9 @@ export const Overview: Story = {
       </StoryVStack>
     </StoryHStack>
   ),
-};
+});
 
-export const NotKeptMounted: Story = {
+export const NotKeptMounted = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -103,4 +101,4 @@ export const NotKeptMounted: Story = {
       </Tooltip>
     </StoryVStack>
   ),
-};
+});

--- a/packages/dds-components/src/components/Typography/Caption/Caption.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Caption/Caption.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { ddsProviderDecorator } from '../../../storybook';
 import { Table } from '../../Table';
@@ -6,24 +6,20 @@ import { storyTypographyHtmlAttrs } from '../storyUtils';
 
 import { Caption } from '.';
 
-const meta: Meta<typeof Caption> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Typography/Caption',
   component: Caption,
   argTypes: {
     ...storyTypographyHtmlAttrs,
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof Caption>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { children: 'Caption' },
-};
+});
 
-export const WithTable: Story = {
+export const WithTable = meta.story({
   args: { children: 'Caption', withMargins: true },
   render: args => (
     <Table>
@@ -42,4 +38,4 @@ export const WithTable: Story = {
       </Table.Body>
     </Table>
   ),
-};
+});

--- a/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { ddsProviderDecorator } from '../../../storybook';
 import { StoryVStack } from '../../layout/Stack/utils';
@@ -6,23 +6,21 @@ import { storyTypographyHtmlAttrs } from '../storyUtils';
 
 import { Heading } from '.';
 
-const meta: Meta<typeof Heading> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Typography/Heading',
   component: Heading,
   argTypes: {
     ...storyTypographyHtmlAttrs,
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-type Story = StoryObj<typeof Heading>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { children: 'Heading', level: 1 },
-};
+});
 
-export const LevelDefaults: Story = {
+export const LevelDefaults = meta.story({
+  args: { level: 1 },
   render: args => (
     <StoryVStack>
       <Heading {...args} level={1}>
@@ -45,9 +43,10 @@ export const LevelDefaults: Story = {
       </Heading>
     </StoryVStack>
   ),
-};
+});
 
-export const TypographyStyles: Story = {
+export const TypographyStyles = meta.story({
+  args: { level: 1 },
   render: args => (
     <StoryVStack>
       <Heading {...args} level={1} typographyType="headingXxlarge">
@@ -73,9 +72,9 @@ export const TypographyStyles: Story = {
       </Heading>
     </StoryVStack>
   ),
-};
+});
 
-export const WithMargins: Story = {
+export const WithMargins = meta.story({
   args: { children: 'Heading with margins', level: 1 },
   render: args => (
     <div
@@ -84,4 +83,4 @@ export const WithMargins: Story = {
       <Heading {...args} withMargins />
     </div>
   ),
-};
+});

--- a/packages/dds-components/src/components/Typography/Label/Label.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Label/Label.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { categoryHtml, ddsProviderDecorator } from '../../../storybook';
 import { HelpIcon } from '../../Icon/icons';
@@ -9,7 +9,7 @@ import { storyTypographyHtmlAttrs } from '../storyUtils';
 
 import { Label } from '.';
 
-const meta: Meta<typeof Label> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Typography/Label',
   component: Label,
   argTypes: {
@@ -17,21 +17,17 @@ const meta: Meta<typeof Label> = {
     ...storyTypographyHtmlAttrs,
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof Label>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { children: 'Label' },
-};
+});
 
-export const readOnly: Story = {
+export const readOnly = meta.story({
   args: { children: 'Label', readOnly: true },
-};
+});
 
-export const afterLabelContent: Story = {
+export const afterLabelContent = meta.story({
   args: {
     children: 'Label',
     afterLabelContent: (
@@ -43,4 +39,4 @@ export const afterLabelContent: Story = {
       </PopoverGroup>
     ),
   },
-};
+});

--- a/packages/dds-components/src/components/Typography/Legend/Legend.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Legend/Legend.stories.tsx
@@ -1,22 +1,18 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { Legend } from '..';
 import { ddsProviderDecorator } from '../../../storybook';
 import { storyTypographyHtmlAttrs } from '../storyUtils';
 
-const meta: Meta<typeof Legend> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Typography/Legend',
   component: Legend,
   argTypes: {
     ...storyTypographyHtmlAttrs,
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof Legend>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { children: 'Legend' },
-};
+});

--- a/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { fn } from 'storybook/test';
 
 import {
@@ -13,7 +13,7 @@ import { storyTypographyHtmlAttrs } from '../storyUtils';
 
 import { Link } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Typography/Link',
   component: Link,
   argTypes: {
@@ -25,17 +25,15 @@ export default {
   },
   args: { onClick: fn() },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof Link>;
-
-type Story = StoryObj<typeof Link>;
+});
 
 const showcaseProps = { children: 'Link', href: 'https://www.domstol.no' };
 
-export const Preview: Story = {
+export const Preview = meta.story({
   args: showcaseProps,
-};
+});
 
-export const Variants: Story = {
+export const Variants = meta.story({
   args: showcaseProps,
   render: args => (
     <StoryVStack>
@@ -50,9 +48,9 @@ export const Variants: Story = {
       </Link>
     </StoryVStack>
   ),
-};
+});
 
-export const As: Story = {
+export const As = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -60,9 +58,9 @@ export const As: Story = {
     ...showcaseProps,
     as: 'span',
   },
-};
+});
 
-export const InText: Story = {
+export const InText = meta.story({
   args: showcaseProps,
   render: args => (
     <Paragraph>
@@ -89,4 +87,4 @@ export const InText: Story = {
       laborum.
     </Paragraph>
   ),
-};
+});

--- a/packages/dds-components/src/components/Typography/Paragraph/Paragraph.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Paragraph/Paragraph.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { ddsProviderDecorator } from '../../../storybook';
 import { StoryVStack } from '../../layout/Stack/utils';
@@ -7,24 +7,20 @@ import { Typography } from '../Typography';
 
 import { Paragraph } from '.';
 
-const meta: Meta<typeof Paragraph> = {
+const meta = preview.meta({
   title: 'dds-components/Components/Typography/Paragraph',
   component: Paragraph,
   argTypes: {
     ...storyTypographyHtmlAttrs,
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof Paragraph>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { children: 'Paragraph' },
-};
+});
 
-export const Overview: Story = {
+export const Overview = meta.story({
   render: args => (
     <StoryVStack>
       <Paragraph {...args} typographyType="bodyShortXsmall">
@@ -56,9 +52,9 @@ export const Overview: Story = {
       </Paragraph>
     </StoryVStack>
   ),
-};
+});
 
-export const CustomColor: Story = {
+export const CustomColor = meta.story({
   render: args => (
     <Paragraph {...args} color="text-subtle">
       {' '}
@@ -69,4 +65,4 @@ export const CustomColor: Story = {
       .
     </Paragraph>
   ),
-};
+});

--- a/packages/dds-components/src/components/Typography/Typography/Typography.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.stories.tsx
@@ -1,10 +1,10 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { Typography } from '..';
 import { categoryHtml } from '../../../storybook';
 import { storyTypographyHtmlAttrs } from '../storyUtils';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Typography/Typography',
   component: Typography,
   argTypes: {
@@ -15,14 +15,12 @@ export default {
     as: { control: 'text' },
     ...storyTypographyHtmlAttrs,
   },
-} satisfies Meta<typeof Typography>;
+});
 
-type Story = StoryObj<typeof Typography>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { children: 'Typography' },
-};
+});
 
-export const CustomColor: Story = {
+export const CustomColor = meta.story({
   args: { children: 'Typography', color: 'text-action-resting' },
-};
+});

--- a/packages/dds-components/src/components/Typography/stories/Examples.stories.tsx
+++ b/packages/dds-components/src/components/Typography/stories/Examples.stories.tsx
@@ -1,11 +1,13 @@
+import preview from '#.storybook/preview';
+
 import { Heading, Paragraph } from '..';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/Typography/Examples',
   tags: ['!autodocs'],
-};
+});
 
-export const Article = () => {
+export const Article = meta.story(() => {
   return (
     <div className="story-article">
       <Heading level={1} withMargins>
@@ -72,4 +74,4 @@ export const Article = () => {
       </style>
     </div>
   );
-};
+});

--- a/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import {
   commonArgTypes,
@@ -11,7 +11,7 @@ import { Link, Paragraph } from '../Typography';
 
 import { VisuallyHidden } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Components/VisuallyHidden',
   component: VisuallyHidden,
   argTypes: {
@@ -20,20 +20,18 @@ export default {
     style: htmlArgType,
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof VisuallyHidden>;
+});
 
-type Story = StoryObj<typeof VisuallyHidden>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <>
       <Paragraph>Teksten under er usynlig.</Paragraph>
       <VisuallyHidden {...args}>Denne teksten er usynlig.</VisuallyHidden>
     </>
   ),
-};
+});
 
-export const WithLink: Story = {
+export const WithLink = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -53,9 +51,9 @@ export const WithLink: Story = {
       </Paragraph>
     </>
   ),
-};
+});
 
-export const TableButtons: Story = {
+export const TableButtons = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -92,4 +90,4 @@ export const TableButtons: Story = {
       </Table>
     </Table.Wrapper>
   ),
-};
+});

--- a/packages/dds-components/src/components/helpers/AccordionBase/useAccordion.stories.tsx
+++ b/packages/dds-components/src/components/helpers/AccordionBase/useAccordion.stories.tsx
@@ -1,8 +1,8 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { AccordionExample } from './AccordionExample';
 
-const meta: Meta<typeof AccordionExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useAccordion',
   component: AccordionExample,
   parameters: {
@@ -11,9 +11,6 @@ const meta: Meta<typeof AccordionExample> = {
   argTypes: {
     id: { control: false },
   },
-};
+});
 
-export default meta;
-type Story = StoryObj<typeof AccordionExample>;
-
-export const Preview: Story = {};
+export const Preview = meta.story();

--- a/packages/dds-components/src/components/layout/Box/Box.stories.tsx
+++ b/packages/dds-components/src/components/layout/Box/Box.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { useState } from 'react';
 
 import { useWindowResize } from '../../../hooks';
@@ -13,19 +13,16 @@ import {
 
 import { Box } from '.';
 
-const meta: Meta<typeof Box> = {
+const meta = preview.meta({
   title: 'dds-components/Layout Primitives/Box',
   component: Box,
   argTypes: {
     ...responsivePropsArgTypes,
   },
   decorators: [Story => windowWidthDecorator(<Story />)],
-};
-export default meta;
+});
 
-type Story = StoryObj<typeof Box>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     style: {
       border: '1px solid var(--dds-color-border-default)',
@@ -34,9 +31,9 @@ export const Preview: Story = {
     height: { xs: '1rem', sm: '2rem', md: '6rem', lg: '8rem', xl: '10rem' },
     width: '6rem',
   },
-};
+});
 
-export const WithPaddingPerBreakpoint: Story = {
+export const WithPaddingPerBreakpoint = meta.story({
   args: {
     style: {
       border: '1px solid var(--dds-color-border-default)',
@@ -58,4 +55,4 @@ export const WithPaddingPerBreakpoint: Story = {
       </Box>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/layout/Contrast/Contrast.stories.tsx
+++ b/packages/dds-components/src/components/layout/Contrast/Contrast.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { VStack } from '..';
 import {
@@ -19,7 +19,7 @@ import { Link, Paragraph } from '../../Typography';
 
 import { Contrast } from '.';
 
-const meta: Meta<typeof Contrast> = {
+const meta = preview.meta({
   title: 'dds-components/Layout primitives/Contrast',
   component: Contrast,
   argTypes: {
@@ -27,12 +27,9 @@ const meta: Meta<typeof Contrast> = {
     ...responsivePropsArgTypes,
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-type Story = StoryObj<typeof Contrast>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <Contrast {...args} style={{ padding: 'var(--dds-spacing-x2)' }}>
       <Paragraph>
@@ -41,8 +38,8 @@ export const Preview: Story = {
       </Paragraph>
     </Contrast>
   ),
-};
-export const Examples: Story = {
+});
+export const Examples = meta.story({
   render: args => (
     <Contrast {...args}>
       <VStack padding="x2" gap="x1">
@@ -65,4 +62,4 @@ export const Examples: Story = {
       </VStack>
     </Contrast>
   ),
-};
+});

--- a/packages/dds-components/src/components/layout/Grid/Grid.stories.tsx
+++ b/packages/dds-components/src/components/layout/Grid/Grid.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import {
   categoryCss,
@@ -19,7 +19,7 @@ import { Heading } from '../../Typography';
 
 import { Grid, GridChild } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Layout Primitives/Grid',
   component: Grid,
   argTypes: {
@@ -27,11 +27,9 @@ export default {
     gridTemplateColumns: { control: 'text', table: categoryCss },
   },
   decorators: [ddsProviderDecorator],
-} satisfies Meta<typeof Grid>;
+});
 
-type Story = StoryObj<typeof Grid>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   decorators: [
     Story =>
       windowWidthDecorator(
@@ -112,9 +110,9 @@ export const Preview: Story = {
       </Grid>
     );
   },
-};
+});
 
-export const PageExample: Story = {
+export const PageExample = meta.story({
   render: args => {
     return (
       <>
@@ -196,9 +194,9 @@ export const PageExample: Story = {
       </>
     );
   },
-};
+});
 
-export const JustRelativeColumns: Story = {
+export const JustRelativeColumns = meta.story({
   render: args => (
     <Grid {...args} maxWidth={{ lg: '750px', xl: '750px' }}>
       <GridChild columnsOccupied="all">
@@ -225,4 +223,4 @@ export const JustRelativeColumns: Story = {
       </GridChild>
     </Grid>
   ),
-};
+});

--- a/packages/dds-components/src/components/layout/Grid/GridChild.stories.tsx
+++ b/packages/dds-components/src/components/layout/Grid/GridChild.stories.tsx
@@ -1,11 +1,11 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { Paper } from '..';
 import { categoryCss, responsivePropsArgTypes } from '../../../storybook';
 
 import { Grid, GridChild } from '.';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Layout Primitives/Grid/GridChild',
   component: GridChild,
   argTypes: {
@@ -14,11 +14,9 @@ export default {
     columnsOccupied: { control: 'text' },
     ...responsivePropsArgTypes,
   },
-} satisfies Meta<typeof GridChild>;
+});
 
-type Story = StoryObj<typeof GridChild>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   decorators: [
     Story => (
       <>
@@ -45,4 +43,4 @@ export const Preview: Story = {
       </Grid>
     );
   },
-};
+});

--- a/packages/dds-components/src/components/layout/Paper/Paper.stories.tsx
+++ b/packages/dds-components/src/components/layout/Paper/Paper.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import {
   CSSSelectArgType,
@@ -8,7 +8,7 @@ import {
 
 import { Paper } from '.';
 
-const meta: Meta<typeof Paper> = {
+const meta = preview.meta({
   title: 'dds-components/Layout Primitives/Paper',
   component: Paper,
   argTypes: {
@@ -21,12 +21,9 @@ const meta: Meta<typeof Paper> = {
     tabIndex: htmlArgType,
     role: htmlArgType,
   },
-};
-export default meta;
+});
 
-type Story = StoryObj<typeof Paper>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     border: 'border-default',
     padding: 'x1.5',
@@ -34,9 +31,9 @@ export const Preview: Story = {
     children:
       'Dette er en Paper: layout-komponent med støtte for flate-styling',
   },
-};
+});
 
-export const Styled: Story = {
+export const Styled = meta.story({
   args: {
     border: 'border-default',
     background: 'surface-info-default',
@@ -45,9 +42,9 @@ export const Styled: Story = {
     maxWidth: '20rem',
     children: 'Dette er en styled Paper',
   },
-};
+});
 
-export const Branded: Story = {
+export const Branded = meta.story({
   args: {
     background: 'brand-secondary-subtle',
     elevation: 'medium',
@@ -55,4 +52,4 @@ export const Branded: Story = {
     maxWidth: '20rem',
     children: 'Dette er en branded Paper',
   },
-};
+});

--- a/packages/dds-components/src/components/layout/ShowHide/ShowHide.stories.tsx
+++ b/packages/dds-components/src/components/layout/ShowHide/ShowHide.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import {
   commonResponsivePropsArgTypes,
@@ -10,19 +10,16 @@ import { Grid } from '../Grid';
 
 import { ShowHide } from '.';
 
-const meta: Meta<typeof ShowHide> = {
+const meta = preview.meta({
   title: 'dds-components/Layout Primitives/ShowHide',
   component: ShowHide,
   argTypes: {
     ...commonResponsivePropsArgTypes,
   },
   decorators: [Story => windowWidthDecorator(<Story />)],
-};
-export default meta;
+});
 
-type Story = StoryObj<typeof ShowHide>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   render: args => (
     <Grid gridTemplateColumns="150px 150px" gap="x1">
       <div>
@@ -45,10 +42,10 @@ export const Preview: Story = {
       </div>
     </Grid>
   ),
-};
+});
 
-export const SetBreakpoints: Story = {
+export const SetBreakpoints = meta.story({
   args: {
     children: 'Skjul eller vis meg ved å sette brekkpunkter i props',
   },
-};
+});

--- a/packages/dds-components/src/components/layout/Stack/HStack/HStack.stories.tsx
+++ b/packages/dds-components/src/components/layout/Stack/HStack/HStack.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { HStack } from './HStack';
 import { Box } from '../..';
@@ -7,13 +7,13 @@ import {
   windowWidthDecorator,
 } from '../../../../storybook';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Layout Primitives/HStack',
   component: HStack,
   argTypes: {
     ...responsiveStackPropsArgTypes,
   },
-} satisfies Meta<typeof HStack>;
+});
 
 const ExampleElement = () => (
   <Box
@@ -25,9 +25,7 @@ const ExampleElement = () => (
   />
 );
 
-type Story = StoryObj<typeof HStack>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     children: [
       <ExampleElement />,
@@ -36,9 +34,9 @@ export const Preview: Story = {
       <ExampleElement />,
     ],
   },
-};
+});
 
-export const StylingPerBreakpoint: Story = {
+export const StylingPerBreakpoint = meta.story({
   decorators: [Story => windowWidthDecorator(<Story />)],
   args: {
     style: {
@@ -65,4 +63,4 @@ export const StylingPerBreakpoint: Story = {
       <ExampleElement />,
     ],
   },
-};
+});

--- a/packages/dds-components/src/components/layout/Stack/VStack/VStack.stories.tsx
+++ b/packages/dds-components/src/components/layout/Stack/VStack/VStack.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { VStack } from './VStack';
 import { Box } from '../..';
@@ -7,13 +7,13 @@ import {
   windowWidthDecorator,
 } from '../../../../storybook';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Layout Primitives/VStack',
   component: VStack,
   argTypes: {
     ...responsiveStackPropsArgTypes,
   },
-} satisfies Meta<typeof VStack>;
+});
 
 const ExampleElement = () => (
   <Box
@@ -25,9 +25,7 @@ const ExampleElement = () => (
   />
 );
 
-type Story = StoryObj<typeof VStack>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     children: [
       <ExampleElement />,
@@ -36,9 +34,9 @@ export const Preview: Story = {
       <ExampleElement />,
     ],
   },
-};
+});
 
-export const StylingPerBreakpoint: Story = {
+export const StylingPerBreakpoint = meta.story({
   decorators: [Story => windowWidthDecorator(<Story />)],
   args: {
     style: {
@@ -65,4 +63,4 @@ export const StylingPerBreakpoint: Story = {
       <ExampleElement />,
     ],
   },
-};
+});

--- a/packages/dds-components/src/components/layout/common/Responsive.types.tsx
+++ b/packages/dds-components/src/components/layout/common/Responsive.types.tsx
@@ -34,7 +34,7 @@ export type BreakpointBasedProp<T> = Partial<Record<Breakpoint, T>>;
 
 export type ResponsiveProp<T> = T | BreakpointBasedProp<T>;
 
-interface PrimitiveLayoutProps {
+export interface PrimitiveLayoutProps {
   /** CSS `width`. Støtter verdi per brekkpunkt eller samme for alle skjermstørrelser. */
   width?: ResponsiveProp<Property.Width>;
   /** CSS `max-width`. Støtter verdi per brekkpunkt eller samme for alle skjermstørrelser. */

--- a/packages/dds-components/src/hooks/useCallbackRef/useCallbackRef.stories.tsx
+++ b/packages/dds-components/src/hooks/useCallbackRef/useCallbackRef.stories.tsx
@@ -1,18 +1,20 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { CallbackRefExample } from './CallbackRefExample';
 import { hookParameters } from '../hooks.utils';
 
-const meta: Meta<typeof CallbackRefExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useCallbackRef',
   component: CallbackRefExample,
   parameters: hookParameters,
   argTypes: {
     deps: { control: false },
   },
-};
+  args: {
+    callback: () => {
+      //test
+    },
+  },
+});
 
-export default meta;
-type Story = StoryObj<typeof CallbackRefExample>;
-
-export const Preview: Story = {};
+export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useCombinedRef/useCombinedRef.stories.tsx
+++ b/packages/dds-components/src/hooks/useCombinedRef/useCombinedRef.stories.tsx
@@ -1,18 +1,19 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
+import { useRef } from 'react';
 
 import { CombinedRefExample } from './CombinedRefExample';
 import { hookParameters } from '../hooks.utils';
 
-const meta: Meta<typeof CombinedRefExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useCombinedRef',
   component: CombinedRefExample,
   parameters: hookParameters,
   argTypes: {
     refs: { control: false },
   },
-};
+});
 
-export default meta;
-type Story = StoryObj<typeof CombinedRefExample>;
+const ref1 = useRef<HTMLDivElement>(null);
+const ref2 = useRef<HTMLDivElement>(null);
 
-export const Preview: Story = {};
+export const Preview = meta.story({ args: { refs: [ref1, ref2] } });

--- a/packages/dds-components/src/hooks/useCombinedRef/useCombinedRef.stories.tsx
+++ b/packages/dds-components/src/hooks/useCombinedRef/useCombinedRef.stories.tsx
@@ -1,5 +1,4 @@
 import preview from '#.storybook/preview';
-import { useRef } from 'react';
 
 import { CombinedRefExample } from './CombinedRefExample';
 import { hookParameters } from '../hooks.utils';
@@ -13,7 +12,4 @@ const meta = preview.meta({
   },
 });
 
-const ref1 = useRef<HTMLDivElement>(null);
-const ref2 = useRef<HTMLDivElement>(null);
-
-export const Preview = meta.story({ args: { refs: [ref1, ref2] } });
+export const Preview = meta.story({ args: { refs: [null] } });

--- a/packages/dds-components/src/hooks/useControllableState/useControllableState.stories.tsx
+++ b/packages/dds-components/src/hooks/useControllableState/useControllableState.stories.tsx
@@ -1,9 +1,9 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { ControllableStateExample } from './ControllableStateExample';
 import { hookParameters } from '../hooks.utils';
 
-const meta: Meta<typeof ControllableStateExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useControllableState',
   component: ControllableStateExample,
   parameters: hookParameters,
@@ -11,9 +11,6 @@ const meta: Meta<typeof ControllableStateExample> = {
     value: { control: false },
     defaultValue: { control: false },
   },
-};
+});
 
-export default meta;
-type Story = StoryObj<typeof ControllableStateExample>;
-
-export const Preview: Story = {};
+export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useFloatPosition/FloatPositionExample.tsx
+++ b/packages/dds-components/src/hooks/useFloatPosition/FloatPositionExample.tsx
@@ -5,7 +5,7 @@ import { Paper } from '../../components/layout';
 
 export interface FloatPositionProps {
   /**`ref` til pilen. */
-  arrowRef: Parameters<typeof useFloatPosition>[0];
+  arrowRef?: Parameters<typeof useFloatPosition>[0];
   /**Alternativer: plassering i forhold til ankeret, offset og om posisjonen skal oppdateres ved hver animation frame.  */
   options: Parameters<typeof useFloatPosition>[1];
 }

--- a/packages/dds-components/src/hooks/useFloatPosition/useFloatPosition.stories.tsx
+++ b/packages/dds-components/src/hooks/useFloatPosition/useFloatPosition.stories.tsx
@@ -1,19 +1,19 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { FloatPositionExample } from './FloatPositionExample';
 import { hookParameters } from '../hooks.utils';
 
-const meta: Meta<typeof FloatPositionExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useFloatPosition',
   component: FloatPositionExample,
   parameters: hookParameters,
+  args: {
+    options: {},
+  },
   argTypes: {
     arrowRef: { control: false },
     options: { control: false },
   },
-};
+});
 
-export default meta;
-type Story = StoryObj<typeof FloatPositionExample>;
-
-export const Preview: Story = {};
+export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useFocusTrap/useFocusTrap.stories.tsx
+++ b/packages/dds-components/src/hooks/useFocusTrap/useFocusTrap.stories.tsx
@@ -1,9 +1,9 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { FocusTrapExample } from './FocusTrapExample';
 import { hookParameters } from '../hooks.utils';
 
-const meta: Meta<typeof FocusTrapExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useFocusTrap',
   component: FocusTrapExample,
   parameters: hookParameters,
@@ -11,10 +11,6 @@ const meta: Meta<typeof FocusTrapExample> = {
     active: { control: false },
     initialFocusRef: { control: false },
   },
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof FocusTrapExample>;
-
-export const Preview: Story = {};
+export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useIsMounted/useIsMounted.stories.tsx
+++ b/packages/dds-components/src/hooks/useIsMounted/useIsMounted.stories.tsx
@@ -1,15 +1,12 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { IsMountedExample } from './IsMountedExample';
 import { hookParameters } from '../hooks.utils';
 
-const meta: Meta<typeof IsMountedExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useIsMounted',
   component: IsMountedExample,
   parameters: hookParameters,
-};
+});
 
-export default meta;
-type Story = StoryObj<typeof IsMountedExample>;
-
-export const Preview: Story = {};
+export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useMountTransition/useMountTransition.stories.tsx
+++ b/packages/dds-components/src/hooks/useMountTransition/useMountTransition.stories.tsx
@@ -1,17 +1,14 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { MountTransitionExample } from './MountTransitionExample';
 import { hookParameters } from '../hooks.utils';
 
-const meta: Meta<typeof MountTransitionExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useMountTransition',
   component: MountTransitionExample,
   parameters: hookParameters,
-};
+});
 
-export default meta;
-type Story = StoryObj<typeof MountTransitionExample>;
-
-export const Preview: Story = {
+export const Preview = meta.story({
   args: { isMounted: false, unmountDelay: 1000 },
-};
+});

--- a/packages/dds-components/src/hooks/useOnClickOutside/useOnClickOutside.stories.tsx
+++ b/packages/dds-components/src/hooks/useOnClickOutside/useOnClickOutside.stories.tsx
@@ -1,9 +1,9 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { OnClickOutsideExample } from './OnClickOutsideExample';
 import { hookParameters } from '../hooks.utils';
 
-const meta: Meta<typeof OnClickOutsideExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useOnClickOutside',
 
   component: OnClickOutsideExample,
@@ -11,10 +11,11 @@ const meta: Meta<typeof OnClickOutsideExample> = {
   argTypes: {
     element: { control: false },
   },
-};
+  args: {
+    handler: () => {
+      //placeholder
+    },
+  },
+});
 
-export default meta;
-
-type Story = StoryObj<typeof OnClickOutsideExample>;
-
-export const Preview: Story = {};
+export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useOnKeyDown/useOnKeyDown.stories.tsx
+++ b/packages/dds-components/src/hooks/useOnKeyDown/useOnKeyDown.stories.tsx
@@ -1,18 +1,21 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { OnKeyDownExample } from './OnKeyDownExample';
 import { hookParameters } from '../hooks.utils';
 
-const meta: Meta<typeof OnKeyDownExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useOnKeyDown',
   component: OnKeyDownExample,
   parameters: hookParameters,
   argTypes: {
     key: { control: false },
   },
-};
+  args: {
+    key: '',
+    handler: () => {
+      //placeholder
+    },
+  },
+});
 
-export default meta;
-type Story = StoryObj<typeof OnKeyDownExample>;
-
-export const Preview: Story = {};
+export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useReturnFocusOnBlur/ReturnFocusOnBlurExample.tsx
+++ b/packages/dds-components/src/hooks/useReturnFocusOnBlur/ReturnFocusOnBlurExample.tsx
@@ -8,7 +8,7 @@ export interface ReturnFocusOnBlurProps {
   /**Funksjon som kjører når fokus forlater container.*/
   onBlur: Parameters<typeof useReturnFocusOnBlur>[1];
   /**Elementet som skal få fokus når fokus forlater container. */
-  triggerElement: Parameters<typeof useReturnFocusOnBlur>[2];
+  triggerElement?: Parameters<typeof useReturnFocusOnBlur>[2];
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/dds-components/src/hooks/useReturnFocusOnBlur/useReturnFocusOnBlur.stories.tsx
+++ b/packages/dds-components/src/hooks/useReturnFocusOnBlur/useReturnFocusOnBlur.stories.tsx
@@ -1,9 +1,9 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { ReturnFocusOnBlurExample } from './ReturnFocusOnBlurExample';
 import { hookParameters } from '../hooks.utils';
 
-const meta: Meta<typeof ReturnFocusOnBlurExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useReturnFocusOnBlur',
   component: ReturnFocusOnBlurExample,
   parameters: hookParameters,
@@ -11,9 +11,12 @@ const meta: Meta<typeof ReturnFocusOnBlurExample> = {
     active: { control: false },
     triggerElement: { control: false },
   },
-};
+  args: {
+    active: true,
+    onBlur: () => {
+      //placeholder
+    },
+  },
+});
 
-export default meta;
-type Story = StoryObj<typeof ReturnFocusOnBlurExample>;
-
-export const Preview: Story = {};
+export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useRoveFocus/useRoveFocus.stories.tsx
+++ b/packages/dds-components/src/hooks/useRoveFocus/useRoveFocus.stories.tsx
@@ -1,19 +1,18 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { RoveFocusExample } from './RoveFocusExample';
 import { hookParameters } from '../hooks.utils';
 
-export default {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useRoveFocus',
   component: RoveFocusExample,
   parameters: hookParameters,
-} as Meta<typeof RoveFocusExample>;
+});
 
-type Story = StoryObj<typeof RoveFocusExample>;
-export const Preview: Story = {
+export const Preview = meta.story({
   args: {
     size: 4,
     active: true,
     direction: 'column',
   },
-};
+});

--- a/packages/dds-components/src/hooks/useScreenSize/useScreenSize.stories.tsx
+++ b/packages/dds-components/src/hooks/useScreenSize/useScreenSize.stories.tsx
@@ -1,16 +1,12 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { ScreenSizeExample } from './ScreenSizeExample';
 import { hookParameters } from '../hooks.utils';
 
-const meta: Meta<typeof ScreenSizeExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useScreenSize',
   component: ScreenSizeExample,
   parameters: hookParameters,
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof ScreenSizeExample>;
-
-export const Preview: Story = {};
+export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useWindowResize/useWindowResize.stories.tsx
+++ b/packages/dds-components/src/hooks/useWindowResize/useWindowResize.stories.tsx
@@ -1,15 +1,17 @@
-import { type Meta, type StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { WindowResizeExample } from './WindowResizeExample';
 import { hookParameters } from '../hooks.utils';
 
-const meta: Meta<typeof WindowResizeExample> = {
+const meta = preview.meta({
   title: 'dds-components/Hooks/useWindowResize',
   component: WindowResizeExample,
   parameters: hookParameters,
-};
+  args: {
+    handler: () => {
+      //placeholder
+    },
+  },
+});
 
-export default meta;
-type Story = StoryObj<typeof WindowResizeExample>;
-
-export const Preview: Story = {};
+export const Preview = meta.story({});

--- a/packages/dds-components/src/types/BaseComponentProps.ts
+++ b/packages/dds-components/src/types/BaseComponentProps.ts
@@ -8,7 +8,7 @@ import {
   type Ref,
 } from 'react';
 
-interface HTMLRootProps {
+export interface HTMLRootProps {
   /**HTML id. */
   id?: string;
   /**HTML klassenavn. */

--- a/packages/dds-components/stories/patterns/Form/Form.stories.tsx
+++ b/packages/dds-components/stories/patterns/Form/Form.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 import { type FormEvent, Fragment, useState } from 'react';
 
 import {
@@ -31,18 +31,16 @@ import {
 } from '../../../src';
 import { ddsProviderDecorator } from '../../../src/storybook';
 
-const meta: Meta = {
+const meta = preview.meta({
   title: 'Patterns/Form',
   parameters: {
     layout: 'fullscreen',
-    docs: { canvas: { inline: false } },
+    docs: { story: { inline: false } },
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-export const Form = () => {
+export const Form = meta.story(() => {
   return (
     <>
       <InternalHeader
@@ -135,9 +133,9 @@ export const Form = () => {
       </Grid>
     </>
   );
-};
+});
 
-export const FormWithSteps = () => {
+export const FormWithSteps = meta.story(() => {
   const [activeStep, setActiveStep] = useState(0);
   const [completedSteps, setCompletedSteps] = useState(new Set<number>());
   const [progressTrackerDrawerOpen, setProgressTrackerDrawerOpen] =
@@ -376,9 +374,9 @@ export const FormWithSteps = () => {
       </Grid>
     </>
   );
-};
+});
 
-export const FormWithStepsCustomGrid = () => {
+export const FormWithStepsCustomGrid = meta.story(() => {
   const [activeStep, setActiveStep] = useState(0);
   const [completedSteps, setCompletedSteps] = useState(new Set<number>());
   const [progressTrackerDrawerOpen, setProgressTrackerDrawerOpen] =
@@ -589,9 +587,9 @@ export const FormWithStepsCustomGrid = () => {
       </Grid>
     </>
   );
-};
+});
 
-export const ExitForm = () => {
+export const ExitForm = meta.story(() => {
   const [isFormPage, setIsFormPage] = useState(true);
   const [showModal, setShowModal] = useState(false);
 
@@ -678,4 +676,4 @@ export const ExitForm = () => {
       </Grid>
     </>
   );
-};
+});

--- a/packages/dds-components/tsconfig.json
+++ b/packages/dds-components/tsconfig.json
@@ -6,6 +6,6 @@
     ".eslintrc.cjs",
     "vitest.config.ts",
     "tsup.config.ts",
-    "modules/custom.d.ts"
+    "../../global.d.ts"
   ]
 }

--- a/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBannerProvider.stories.tsx
+++ b/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBannerProvider.stories.tsx
@@ -10,6 +10,6 @@ const meta = preview.meta({
   },
 });
 
-export const Preview: unknown = meta.story({
+export const Preview = meta.story({
   args: { bannerPosition: 'fixed', environment: 'TEST', children: null },
 });

--- a/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBannerProvider.stories.tsx
+++ b/packages/development-utils/src/EnvironmentBannerProvider/EnvironmentBannerProvider.stories.tsx
@@ -1,20 +1,15 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { EnvironmentBannerProvider } from './EnvironmentBannerProvider';
 
-const meta: Meta<typeof EnvironmentBannerProvider> = {
+const meta = preview.meta({
   title: 'development-utils/EnvironmentBannerProvider',
   component: EnvironmentBannerProvider,
   parameters: {
     disableGlobalDecorator: true,
   },
-};
+});
 
-export default meta;
-
-type Story = StoryObj<typeof EnvironmentBannerProvider>;
-
-export const Preview: Story = {
-  args: { bannerPosition: 'fixed', environment: 'TEST' },
-  render: args => <EnvironmentBannerProvider {...args} />,
-};
+export const Preview: unknown = meta.story({
+  args: { bannerPosition: 'fixed', environment: 'TEST', children: null },
+});

--- a/packages/development-utils/tsconfig.json
+++ b/packages/development-utils/tsconfig.json
@@ -6,5 +6,6 @@
     ".eslintrc.cjs",
     "tsup.config.ts",
     "../../global.d.ts"
-  ]
+  ],
+  "exclude": ["**/*.stories.tsx"]
 }

--- a/packages/development-utils/tsconfig.json
+++ b/packages/development-utils/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["src", "vitest.config.ts", ".eslintrc.cjs", "tsup.config.ts"]
+  "include": [
+    "src",
+    "vitest.config.ts",
+    ".eslintrc.cjs",
+    "tsup.config.ts",
+    "../../global.d.ts"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,12 @@ importers:
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.14)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.58.2
         version: 8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)

--- a/stories/Playground/Saksliste.stories.tsx
+++ b/stories/Playground/Saksliste.stories.tsx
@@ -1,3 +1,5 @@
+import preview from '#.storybook/preview';
+
 import {
   ArrowRightIcon,
   Button,
@@ -14,10 +16,10 @@ import {
 } from '../../packages/dds-components/src/index';
 import { ddsProviderDecorator } from '../../packages/dds-components/src/storybook';
 
-export default {
+const meta = preview.meta({
   title: 'Playground/Saksliste',
   decorators: [ddsProviderDecorator],
-};
+});
 
 const dødsfallItems = [
   {
@@ -98,7 +100,7 @@ const wrapperStyle = {
   width: '100%',
 };
 
-export const Saksliste = () => {
+export const Saksliste = meta.story(() => {
   return (
     <Grid as="div">
       <GridChild columnsOccupied="all">
@@ -204,4 +206,4 @@ export const Saksliste = () => {
       </GridChild>
     </Grid>
   );
-};
+});

--- a/stories/Playground/Testing/FormComponentsTesting.stories.tsx
+++ b/stories/Playground/Testing/FormComponentsTesting.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { type InputSize } from '../../../packages/dds-components/src/components/helpers/Input';
 import {
@@ -21,11 +21,10 @@ import {
   ddsProviderDecorator,
 } from '../../../packages/dds-components/src/storybook';
 
-const meta: Meta = {
+const meta = preview.meta({
   title: 'Playground/Testing',
   decorators: [ddsProviderDecorator],
-};
-export default meta;
+});
 
 const icon = MailIcon;
 
@@ -68,7 +67,7 @@ function renderInputs(size: InputSize) {
   );
 }
 
-export const FormComponents = () => {
+export const FormComponents = meta.story(() => {
   return (
     <VStack gap="x1.5">
       <LocalMessage>
@@ -92,4 +91,4 @@ export const FormComponents = () => {
       </VStack>
     </VStack>
   );
-};
+});

--- a/stories/Playground/Testing/Select.stories.tsx
+++ b/stories/Playground/Testing/Select.stories.tsx
@@ -1,17 +1,16 @@
-import { type Meta } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import { INPUT_SIZES } from '../../../packages/dds-components/src/components/helpers/Input';
 import { StoryHStack } from '../../../packages/dds-components/src/components/layout/Stack/utils';
 import { Select } from '../../../packages/dds-components/src/index';
 import { ddsProviderDecorator } from '../../../packages/dds-components/src/storybook';
 
-const meta: Meta = {
+const meta = preview.meta({
   title: 'Playground/Testing',
   decorators: [ddsProviderDecorator],
-};
-export default meta;
+});
 
-export const SelectDropdown = () => {
+export const SelectDropdown = meta.story(() => {
   return (
     <StoryHStack>
       {INPUT_SIZES.map(size => (
@@ -28,4 +27,4 @@ export const SelectDropdown = () => {
       ))}
     </StoryHStack>
   );
-};
+});

--- a/stories/Tokens/NotExposed.stories.tsx
+++ b/stories/Tokens/NotExposed.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import {
   BorderRadiusBaseGenerator,
@@ -9,28 +9,27 @@ import {
 import { MotionBaseGenerator } from './utils/MotionGenerator';
 import { ddsProviderDecorator } from '../../packages/dds-components/src/storybook';
 
-const meta: Meta = {
+const meta = preview.meta({
   title: 'dds-design-tokens/Tokens/NotExposed',
   parameters: {
     disableGlobalDecorator: true,
   },
   tags: ['!autodocs'],
   decorators: [ddsProviderDecorator],
-};
-export default meta;
+});
 
-export const ColorsBase = () => {
+export const ColorsBase = meta.story(() => {
   return <Wrapper>{ColorsBaseGenerator()}</Wrapper>;
-};
+});
 
-export const BorderRadiusBase = () => {
+export const BorderRadiusBase = meta.story(() => {
   return <Wrapper>{BorderRadiusBaseGenerator()}</Wrapper>;
-};
+});
 
-export const ShadowsBase = () => {
+export const ShadowsBase = meta.story(() => {
   return <Wrapper>{ShadowsBaseGenerator()}</Wrapper>;
-};
+});
 
-export const MotionBase = () => {
+export const MotionBase = meta.story(() => {
   return <Wrapper>{MotionBaseGenerator()}</Wrapper>;
-};
+});

--- a/stories/Tokens/Tokens.stories.tsx
+++ b/stories/Tokens/Tokens.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import {
   BorderRadiusGenerator,
@@ -23,17 +23,16 @@ import {
 } from '../../packages/dds-components/src';
 import { ddsProviderDecorator } from '../../packages/dds-components/src/storybook';
 
-const meta: Meta = {
+const meta = preview.meta({
   title: 'dds-design-tokens/Tokens',
   parameters: {
     disableGlobalDecorator: true,
   },
   tags: ['!autodocs'],
   decorators: [ddsProviderDecorator],
-};
-export default meta;
+});
 
-export const BorderRadius = () => {
+export const BorderRadius = meta.story(() => {
   return (
     <Wrapper>
       <Tabs>
@@ -48,13 +47,13 @@ export const BorderRadius = () => {
       </Tabs>
     </Wrapper>
   );
-};
+});
 
-export const Breakpoints = () => {
+export const Breakpoints = meta.story(() => {
   return <Wrapper> {BreakpointsGenerator()}</Wrapper>;
-};
+});
 
-export const Colors = () => {
+export const Colors = meta.story(() => {
   return (
     <Wrapper>
       <Tabs>
@@ -69,9 +68,9 @@ export const Colors = () => {
       </Tabs>
     </Wrapper>
   );
-};
+});
 
-export const ColorsDataVisualisation = () => {
+export const ColorsDataVisualisation = meta.story(() => {
   return (
     <Wrapper>
       <Tabs>
@@ -86,17 +85,17 @@ export const ColorsDataVisualisation = () => {
       </Tabs>
     </Wrapper>
   );
-};
+});
 
-export const Grid = () => {
+export const Grid = meta.story(() => {
   return <Wrapper> {GridGenerator()}</Wrapper>;
-};
+});
 
-export const IconSizes = () => {
+export const IconSizes = meta.story(() => {
   return <Wrapper> {IconSizesGenerator()}</Wrapper>;
-};
+});
 
-export const Shadows = () => {
+export const Shadows = meta.story(() => {
   return (
     <Wrapper>
       <Tabs>
@@ -111,17 +110,17 @@ export const Shadows = () => {
       </Tabs>
     </Wrapper>
   );
-};
+});
 
-export const Spacing = () => {
+export const Spacing = meta.story(() => {
   return <Wrapper> {SpacingGenerator()}</Wrapper>;
-};
+});
 
-export const Motion = () => {
+export const Motion = meta.story(() => {
   return <Wrapper> {MotionGenerator()}</Wrapper>;
-};
+});
 
-export const Typography = () => {
+export const Typography = meta.story(() => {
   return (
     <Wrapper maxWidth="120ch">
       <Tabs>
@@ -136,8 +135,8 @@ export const Typography = () => {
       </Tabs>
     </Wrapper>
   );
-};
+});
 
-export const ZIndex = () => {
+export const ZIndex = meta.story(() => {
   return <Wrapper> {ZIndexGenerator()}</Wrapper>;
-};
+});

--- a/stories/Tokens/TypographyBase.stories.tsx
+++ b/stories/Tokens/TypographyBase.stories.tsx
@@ -1,4 +1,4 @@
-import { type Meta } from '@storybook/react-vite';
+import preview from '#.storybook/preview';
 
 import {
   DataColorsBaseGenerator,
@@ -13,45 +13,43 @@ import {
 } from './utils';
 import { ddsProviderDecorator } from '../../packages/dds-components/src/storybook';
 
-const meta: Meta = {
+const meta = preview.meta({
   title: 'dds-design-tokens/Tokens/Base',
   parameters: {
     disableGlobalDecorator: true,
   },
   tags: ['!autodocs'],
   decorators: [ddsProviderDecorator],
-};
+});
 
-export default meta;
-
-export const FontFamily = () => {
+export const FontFamily = meta.story(() => {
   return <Wrapper>{FontFamilyGenerator()}</Wrapper>;
-};
+});
 
-export const FontSize = () => {
+export const FontSize = meta.story(() => {
   return <Wrapper> {FontSizeGenerator()}</Wrapper>;
-};
+});
 
-export const FontWeight = () => {
+export const FontWeight = meta.story(() => {
   return <Wrapper> {FontWeightGenerator()} </Wrapper>;
-};
+});
 
-export const FontStyle = () => {
+export const FontStyle = meta.story(() => {
   return <Wrapper>{FontStyleGenerator()}</Wrapper>;
-};
+});
 
-export const LineHeight = () => {
+export const LineHeight = meta.story(() => {
   return <Wrapper> {FontLineheightGenerator()}</Wrapper>;
-};
+});
 
-export const LetterSpacing = () => {
+export const LetterSpacing = meta.story(() => {
   return <Wrapper> {FontLetterSpacingGenerator()}</Wrapper>;
-};
+});
 
-export const ParagraphSpacing = () => {
+export const ParagraphSpacing = meta.story(() => {
   return <Wrapper> {FontParagraphSpacingGenerator()}</Wrapper>;
-};
+});
 
-export const DataVisualisation = () => {
+export const DataVisualisation = meta.story(() => {
   return <Wrapper>{DataColorsBaseGenerator()}</Wrapper>;
-};
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,11 @@
     "jsx": "react-jsx",
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "paths": {
+      "#.storybook/*": ["./.storybook/*"]
+    }
   },
-  "include": ["packages", "stories", ".storybook"],
+  "include": ["packages", "stories", ".storybook", "global.d.ts"],
   "exclude": ["**/node_modules"]
 }


### PR DESCRIPTION
## Beskrivelse

[Storybook docs om CSF factory](https://storybook.js.org/docs/api/doc-blocks/doc-block-story)

Typisk story-fil før:
```JSX
import { type Meta, type StoryObj } from '@storybook/react-vite';
import { Button } from '.';
import { commonArgTypes } from '../../storybook';

export default {
  title: 'dds-components/Button',
  component: Button,
  icon: { control: false },
} satisfies Meta<typeof Button>;

type Story = StoryObj<typeof Button>;

export const Preview: Story = {
  args: { children: 'Tekst' }
};
```


Typisk story-fil nå:
```JSX
import preview from '#.storybook/preview';
import { Button } from '.';
import { commonArgTypes } from '../../storybook';

const meta = preview.meta({
  title: 'dds-components/Button',
  component: Button,
  icon: { control: false },
});

export const Preview: meta.story({
  args: { children: 'Tekst' }
});

```
Gevinstene:
- Slipper type annotations imports som `Meta` og `StoryObj`
- Typesafe
- Mindre kode
- Mer lesbart
- Lettere å vedlikeholde, mindre know-how

Unntak: DatePicker, TimePicker, Select. Dette grunnet inferred types som ikke eksporteres fra bibliotekene vi bruker i disse komponentene (som `react-aria/datepicker`). Blir muligens migrert senere.

Oppdaterer tsconfig-filene og noen type imports da det er mange type infers nå som gå opp.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
