### PR TITLE
ELSA1-859:  Fikser broken MDX filer

### DIFF
--- a/packages/dds-components/src/DdsProvider/DdsProvider.mdx
+++ b/packages/dds-components/src/DdsProvider/DdsProvider.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as DdsProviderStories from './DdsProvider.stories';
+import meta from './DdsProvider.stories';
 
-<Meta of={DdsProviderStories} />
+<Meta of={meta} />
 
 # DdsProvider
 

--- a/packages/dds-components/src/DdsProvider/DdsProvider.stories.tsx
+++ b/packages/dds-components/src/DdsProvider/DdsProvider.stories.tsx
@@ -16,6 +16,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 interface TCProps {
   lang?: Language;
   theme?: DdsTheme;

--- a/packages/dds-components/src/components/BackLink/BackLink.mdx
+++ b/packages/dds-components/src/components/BackLink/BackLink.mdx
@@ -4,9 +4,10 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as BackLinkStories from './BackLink.stories';
+import meta from './BackLink.stories';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
-<Meta of={BackLinkStories} />
+<Meta of={meta} />
 
 # BackLink
 

--- a/packages/dds-components/src/components/BackLink/BackLink.stories.tsx
+++ b/packages/dds-components/src/components/BackLink/BackLink.stories.tsx
@@ -22,6 +22,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { label: 'Forrige nivå', href: '#' },
 });

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -1,9 +1,10 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as BreadcrumbsStories from './Breadcrumbs.stories';
+import meta from './Breadcrumbs.stories';
 import * as BreadcrumbStories from './Breadcrumb.stories';
 
-<Meta of={BreadcrumbsStories} />
+<Meta of={meta} />
 
 # Breadcrumbs
 

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -17,6 +17,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 const children = [
   <Breadcrumb href="#">Side 1</Breadcrumb>,
   <Breadcrumb href="#">Side 2</Breadcrumb>,

--- a/packages/dds-components/src/components/Button/Button.mdx
+++ b/packages/dds-components/src/components/Button/Button.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as ButtonStories from './Button.stories';
+import meta from './Button.stories';
 
-<Meta of={ButtonStories} />
+<Meta of={meta} />
 
 # Button
 

--- a/packages/dds-components/src/components/Button/Button.stories.tsx
+++ b/packages/dds-components/src/components/Button/Button.stories.tsx
@@ -35,6 +35,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { children: 'Tekst' },
 });

--- a/packages/dds-components/src/components/ButtonGroup/ButtonGroup.mdx
+++ b/packages/dds-components/src/components/ButtonGroup/ButtonGroup.mdx
@@ -1,8 +1,9 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as ButtonGroupStories from './ButtonGroup.stories';
+import meta from './ButtonGroup.stories';
 
-<Meta of={ButtonGroupStories} />
+<Meta of={meta} />
 
 # ButtonGroup
 

--- a/packages/dds-components/src/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/dds-components/src/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -24,6 +24,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   render: args => (
     <ButtonGroup {...args}>

--- a/packages/dds-components/src/components/Card/Card.mdx
+++ b/packages/dds-components/src/components/Card/Card.mdx
@@ -5,10 +5,11 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as CardStories from './Card.stories';
+import meta from './Card.stories';
 import * as CardSelectableStories from './CardSelectionControl/CardSelectable.stories';
 import * as CardSelectableGroupStories from './CardSelectionControl/CardSelectableGroup.stories';
 
-<Meta of={CardStories} />
+<Meta of={meta} />
 
 # Card
 

--- a/packages/dds-components/src/components/Card/Card.stories.tsx
+++ b/packages/dds-components/src/components/Card/Card.stories.tsx
@@ -22,6 +22,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 const body = (
   <Paragraph>
     Content Content Content Content Content Content Content Content

--- a/packages/dds-components/src/components/Chip/Chip.mdx
+++ b/packages/dds-components/src/components/Chip/Chip.mdx
@@ -1,11 +1,12 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as ChipStories from './Chip.stories';
+import meta from './Chip.stories';
 import * as ChipGroupStories from './ChipGroup.stories';
 import { Tabs, Tab, TabList, TabPanels, TabPanel } from '../Tabs';
 import { Divider } from '../Divider';
 
-<Meta of={ChipStories} />
+<Meta of={meta} />
 
 # Chip
 

--- a/packages/dds-components/src/components/Chip/Chip.stories.tsx
+++ b/packages/dds-components/src/components/Chip/Chip.stories.tsx
@@ -15,6 +15,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { children: 'Chip' },
 });

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.mdx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.mdx
@@ -2,8 +2,9 @@ import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import { Link } from '../Typography';
 import * as CookieBannerStories from './CookieBanner.stories';
+import meta from './CookieBanner.stories';
 
-<Meta of={CookieBannerStories} />
+<Meta of={meta} />
 
 # CookieBanner
 

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.stories.tsx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.stories.tsx
@@ -31,6 +31,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: {
     headerText: 'Tittel for banner',

--- a/packages/dds-components/src/components/DescriptionList/DescriptionList.mdx
+++ b/packages/dds-components/src/components/DescriptionList/DescriptionList.mdx
@@ -5,9 +5,10 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as DescriptionListStories from './DescriptionList.stories';
+import meta from './DescriptionList.stories';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
-<Meta of={DescriptionListStories} />
+<Meta of={meta} />
 
 # DescriptionList
 

--- a/packages/dds-components/src/components/DescriptionList/DescriptionList.stories.tsx
+++ b/packages/dds-components/src/components/DescriptionList/DescriptionList.stories.tsx
@@ -20,6 +20,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   render: args => (
     <DescriptionList {...args}>

--- a/packages/dds-components/src/components/DetailList/DetailList.mdx
+++ b/packages/dds-components/src/components/DetailList/DetailList.mdx
@@ -5,9 +5,10 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as DetailListStories from './DetailList.stories';
+import meta from './DetailList.stories';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
-<Meta of={DetailListStories} />
+<Meta of={meta} />
 
 # DetailList
 

--- a/packages/dds-components/src/components/DetailList/DetailList.stories.tsx
+++ b/packages/dds-components/src/components/DetailList/DetailList.stories.tsx
@@ -26,6 +26,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 const children = [
   <DetailListRow>
     <DetailListTerm>Term</DetailListTerm>

--- a/packages/dds-components/src/components/Divider/Divider.mdx
+++ b/packages/dds-components/src/components/Divider/Divider.mdx
@@ -1,8 +1,9 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as DividerStories from './Divider.stories';
+import meta from './Divider.stories';
 
-<Meta of={DividerStories} />
+<Meta of={meta} />
 
 # Divider
 

--- a/packages/dds-components/src/components/Divider/Divider.stories.tsx
+++ b/packages/dds-components/src/components/Divider/Divider.stories.tsx
@@ -13,6 +13,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story();
 
 const contrastStyling = `

--- a/packages/dds-components/src/components/Drawer/Drawer.mdx
+++ b/packages/dds-components/src/components/Drawer/Drawer.mdx
@@ -5,6 +5,7 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as DrawerStories from './Drawer.stories';
+import meta from './Drawer.stories';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
 <Meta of={DrawerStories} />

--- a/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.stories.tsx
@@ -33,6 +33,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { header: 'Tittel' },
   render: args => (

--- a/packages/dds-components/src/components/EmptyContent/EmptyContent.mdx
+++ b/packages/dds-components/src/components/EmptyContent/EmptyContent.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as EmptyContentStories from './EmptyContent.stories';
+import meta from './EmptyContent.stories';
 
 <Meta of={EmptyContentStories} />
 

--- a/packages/dds-components/src/components/EmptyContent/EmptyContent.stories.tsx
+++ b/packages/dds-components/src/components/EmptyContent/EmptyContent.stories.tsx
@@ -16,6 +16,8 @@ export const Preview = meta.story({
   },
 });
 
+export default meta;
+
 export const InWrapper = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/packages/dds-components/src/components/ErrorSummary/ErrorSummary.mdx
+++ b/packages/dds-components/src/components/ErrorSummary/ErrorSummary.mdx
@@ -1,11 +1,12 @@
 import { ArgTypes, Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as ErrorSummaryStories from './ErrorSummary.stories';
+import meta from './ErrorSummary.stories';
 import { ErrorSummaryItem } from '.';
 import { Tabs, Tab, TabList, TabPanels, TabPanel } from '../Tabs';
 import { Divider } from '../Divider';
 
-<Meta of={ErrorSummaryStories} />
+<Meta of={meta} />
 
 # ErrorSummary
 

--- a/packages/dds-components/src/components/ErrorSummary/ErrorSummary.stories.tsx
+++ b/packages/dds-components/src/components/ErrorSummary/ErrorSummary.stories.tsx
@@ -17,6 +17,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   render: args => (
     <ErrorSummary {...args}>

--- a/packages/dds-components/src/components/FavStar/FavStar.mdx
+++ b/packages/dds-components/src/components/FavStar/FavStar.mdx
@@ -5,8 +5,9 @@ import {
 } from '@norges-domstoler/storybook-components';
 
 import * as FavStarStories from './FavStar.stories';
+import meta from './FavStar.stories';
 
-<Meta of={FavStarStories} />
+<Meta of={meta} />
 
 # FavStar
 

--- a/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
+++ b/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
@@ -32,6 +32,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story();
 
 export const Sizes = meta.story({

--- a/packages/dds-components/src/components/Feedback/Feedback.mdx
+++ b/packages/dds-components/src/components/Feedback/Feedback.mdx
@@ -1,8 +1,9 @@
 import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as FeedbackStories from './Feedback.stories';
+import meta from './Feedback.stories';
 
-<Meta of={FeedbackStories} />
+<Meta of={meta} />
 
 # Feedback
 

--- a/packages/dds-components/src/components/Feedback/Feedback.stories.tsx
+++ b/packages/dds-components/src/components/Feedback/Feedback.stories.tsx
@@ -19,6 +19,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story();
 
 export const HorizontalLayout = meta.story({

--- a/packages/dds-components/src/components/Fieldset/Fieldset.mdx
+++ b/packages/dds-components/src/components/Fieldset/Fieldset.mdx
@@ -1,8 +1,9 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as FieldsetStories from './Fieldset.stories';
+import meta from './Fieldset.stories';
 
-<Meta of={FieldsetStories} />
+<Meta of={meta} />
 
 # Fieldset
 

--- a/packages/dds-components/src/components/Fieldset/Fieldset.stories.tsx
+++ b/packages/dds-components/src/components/Fieldset/Fieldset.stories.tsx
@@ -15,6 +15,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   render: args => (
     <Fieldset {...args}>

--- a/packages/dds-components/src/components/FileUploader/FileUploader.mdx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.mdx
@@ -4,9 +4,10 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as FileUploaderStories from './FileUploader.stories';
+import meta from './FileUploader.stories';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
-<Meta of={FileUploaderStories} />
+<Meta of={meta} />
 
 # FileUploader
 

--- a/packages/dds-components/src/components/FileUploader/FileUploader.stories.tsx
+++ b/packages/dds-components/src/components/FileUploader/FileUploader.stories.tsx
@@ -31,6 +31,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 const file = new File(['hello'], 'hello.png', { type: 'image/png' });
 
 export const Preview = meta.story({ args: { label: 'Label' } });

--- a/packages/dds-components/src/components/Footer/Footer.mdx
+++ b/packages/dds-components/src/components/Footer/Footer.mdx
@@ -4,11 +4,12 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as FooterStories from './Footer.stories';
+import meta from './Footer.stories';
 import { FooterListHeader, FooterLogo } from '.';
 import { Tabs, Tab, TabList, TabPanels, TabPanel } from '../Tabs';
 import { Divider } from '../Divider';
 
-<Meta of={FooterStories} />
+<Meta of={meta} />
 
 # Footer
 

--- a/packages/dds-components/src/components/Footer/Footer.stories.tsx
+++ b/packages/dds-components/src/components/Footer/Footer.stories.tsx
@@ -21,6 +21,8 @@ const meta = preview.meta({
   component: Footer,
 });
 
+export default meta;
+
 const socials = (
   <FooterSocialsGroup>
     <FooterListHeader>Følg oss</FooterListHeader>

--- a/packages/dds-components/src/components/FormSummary/FormSummary.mdx
+++ b/packages/dds-components/src/components/FormSummary/FormSummary.mdx
@@ -1,6 +1,7 @@
 import { ArgTypes, Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as FormSummaryStories from './FormSummary.stories';
+import meta from './FormSummary.stories';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 import {
   FormSummaryEditButton,
@@ -13,7 +14,7 @@ import {
   FormSummaryValue,
 } from './FormSummary.components';
 
-<Meta of={FormSummaryStories} />
+<Meta of={meta} />
 
 # FormSummary
 

--- a/packages/dds-components/src/components/FormSummary/FormSummary.stories.tsx
+++ b/packages/dds-components/src/components/FormSummary/FormSummary.stories.tsx
@@ -52,6 +52,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   render: args => (
     <FormSummary {...args}>

--- a/packages/dds-components/src/components/GlobalMessage/GlobalMessage.mdx
+++ b/packages/dds-components/src/components/GlobalMessage/GlobalMessage.mdx
@@ -1,9 +1,10 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as GlobalMessageStories from './GlobalMessage.stories';
+import meta from './GlobalMessage.stories';
 import { Tabs, Tab, TabList, TabPanels, TabPanel } from '../Tabs';
 
-<Meta of={GlobalMessageStories} />
+<Meta of={meta} />
 
 # GlobalMessage
 

--- a/packages/dds-components/src/components/GlobalMessage/GlobalMessage.stories.tsx
+++ b/packages/dds-components/src/components/GlobalMessage/GlobalMessage.stories.tsx
@@ -19,6 +19,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: {
     purpose: 'info',

--- a/packages/dds-components/src/components/Icon/Icon.mdx
+++ b/packages/dds-components/src/components/Icon/Icon.mdx
@@ -3,8 +3,9 @@ import LinkTo from '@storybook/addon-links/react';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import { Link } from '../Typography';
 import * as IconStories from './Icon.stories';
+import meta from './Icon.stories';
 
-<Meta of={IconStories} />
+<Meta of={meta} />
 
 # Icon
 

--- a/packages/dds-components/src/components/Icon/Icon.stories.tsx
+++ b/packages/dds-components/src/components/Icon/Icon.stories.tsx
@@ -19,6 +19,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 const icon = OpenExternal;
 
 export const Preview = meta.story({

--- a/packages/dds-components/src/components/InlineButton/InlineButton.mdx
+++ b/packages/dds-components/src/components/InlineButton/InlineButton.mdx
@@ -1,10 +1,11 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
-import * as InlineButtontories from './InlineButton.stories';
+import * as InlineButtonStories from './InlineButton.stories';
+import meta from './InlineButton.stories';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 import { LocalMessage } from '../LocalMessage';
 
-<Meta of={InlineButtontories} />
+<Meta of={meta} />
 
 # InlineButton
 
@@ -25,14 +26,14 @@ import { LocalMessage } from '../LocalMessage';
   </TabList>
   <TabPanels>
     <TabPanel>
-      <Canvas of={InlineButtontories.Preview} />
-      <Controls of={InlineButtontories.Preview} />
+      <Canvas of={InlineButtonStories.Preview} />
+      <Controls of={InlineButtonStories.Preview} />
     </TabPanel>
     <TabPanel>
-      <Canvas of={InlineButtontories.WithColor} />
+      <Canvas of={InlineButtonStories.WithColor} />
     </TabPanel>
     <TabPanel>
-      <Canvas of={InlineButtontories.Example} />
+      <Canvas of={InlineButtonStories.Example} />
     </TabPanel>
   </TabPanels>
 </Tabs>

--- a/packages/dds-components/src/components/InlineButton/InlineButton.stories.tsx
+++ b/packages/dds-components/src/components/InlineButton/InlineButton.stories.tsx
@@ -26,6 +26,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: {
     children: 'Vis mer',

--- a/packages/dds-components/src/components/InlineEdit/InlineEdit.mdx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEdit.mdx
@@ -1,11 +1,12 @@
 import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as InlineEditStories from './InlineEdit.stories';
+import meta from './InlineEdit.stories';
 import * as InlineEditInputStories from './InlineEditInput/InlineEditInput.stories';
 import * as InlineEditTextAreaStories from './InlineEditTextArea/InlineEditTextArea.stories';
 import * as InlineEditSelectStories from './InlineEditSelect/InlineEditSelect.stories';
 
-<Meta of={InlineEditStories} />
+<Meta of={meta} />
 
 # InlineEdit
 

--- a/packages/dds-components/src/components/InlineEdit/InlineEdit.stories.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEdit.stories.tsx
@@ -26,6 +26,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   render: args => {

--- a/packages/dds-components/src/components/InputMessage/InputMessage.mdx
+++ b/packages/dds-components/src/components/InputMessage/InputMessage.mdx
@@ -1,9 +1,10 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as InputMessageStories from './InputMessage.stories';
+import meta from './InputMessage.stories';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
-<Meta of={InputMessageStories} />
+<Meta of={meta} />
 
 # InputMessage
 

--- a/packages/dds-components/src/components/InputMessage/InputMessage.stories.tsx
+++ b/packages/dds-components/src/components/InputMessage/InputMessage.stories.tsx
@@ -13,6 +13,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: {
     messageType: 'error',

--- a/packages/dds-components/src/components/InputStepper/InputStepper.mdx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.mdx
@@ -1,8 +1,9 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as InputStepperStories from './InputStepper.stories';
+import meta from './InputStepper.stories';
 
-<Meta of={InputStepperStories} />
+<Meta of={meta} />
 
 # InputStepper
 

--- a/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.stories.tsx
@@ -27,6 +27,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: {
     maxValue: 5,

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.mdx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.mdx
@@ -10,9 +10,10 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as InternalHeaderStories from './InternalHeader.stories';
+import meta from './InternalHeader.stories';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
-<Meta of={InternalHeaderStories} />
+<Meta of={meta} />
 
 # InternalHeader
 

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.stories.tsx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.stories.tsx
@@ -31,6 +31,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 const navigationLink = {
   href: '#',
   children: 'navlenke',

--- a/packages/dds-components/src/components/List/List.mdx
+++ b/packages/dds-components/src/components/List/List.mdx
@@ -1,8 +1,9 @@
 import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as ListStories from './List.stories';
+import meta from './List.stories';
 
-<Meta of={ListStories} />
+<Meta of={meta} />
 
 # List
 

--- a/packages/dds-components/src/components/List/List.stories.tsx
+++ b/packages/dds-components/src/components/List/List.stories.tsx
@@ -14,6 +14,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   render: args => (
     <List {...args}>

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.mdx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.mdx
@@ -1,10 +1,11 @@
 import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as LocalMessageStories from './LocalMessage.stories';
+import meta from './LocalMessage.stories';
 import { Tabs, Tab, TabList, TabPanels, TabPanel } from '../Tabs';
 import { Divider } from '../Divider';
 
-<Meta of={LocalMessageStories} />
+<Meta of={meta} />
 
 # LocalMessage
 

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
@@ -26,6 +26,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: {
     children: 'Dette er en lokal melding',

--- a/packages/dds-components/src/components/Modal/Modal.mdx
+++ b/packages/dds-components/src/components/Modal/Modal.mdx
@@ -5,8 +5,9 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as ModalStories from './Modal.stories';
+import meta from './Modal.stories';
 
-<Meta of={ModalStories} />
+<Meta of={meta} />
 
 # Modal
 

--- a/packages/dds-components/src/components/Modal/Modal.stories.tsx
+++ b/packages/dds-components/src/components/Modal/Modal.stories.tsx
@@ -33,6 +33,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   render: args => {
     const [closed, setClosed] = useState(false);

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.mdx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.mdx
@@ -20,10 +20,11 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as OverflowMenuStories from './OverflowMenu.stories';
+import meta from './OverflowMenu.stories';
 import { Tabs, Tab, TabList, TabPanels, TabPanel } from '../Tabs';
 import { Divider } from '../Divider';
 
-<Meta of={OverflowMenuStories} />
+<Meta of={meta} />
 
 # OverflowMenu
 

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -50,6 +50,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   parameters: { docs: { story: { height: '540px' } } },
   render: args => {

--- a/packages/dds-components/src/components/Pagination/Pagination.mdx
+++ b/packages/dds-components/src/components/Pagination/Pagination.mdx
@@ -4,9 +4,10 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as PaginationStories from './Pagination.stories';
+import meta from './Pagination.stories';
 import { Tabs, Tab, TabList, TabPanel, TabPanels } from '../Tabs';
 
-<Meta of={PaginationStories} />
+<Meta of={meta} />
 
 # Pagination
 

--- a/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.stories.tsx
@@ -23,6 +23,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 const customOptionsItemsAmount = 100;
 const customOptions = [17, 32, customOptionsItemsAmount].map(o => ({
   label: o === customOptionsItemsAmount ? 'Alle' : o.toString(),

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.mdx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as PhoneInputStories from './PhoneInput.stories';
+import meta from './PhoneInput.stories';
 
-<Meta of={PhoneInputStories} />
+<Meta of={meta} />
 
 # PhoneInput
 

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.stories.tsx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.stories.tsx
@@ -35,6 +35,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({ args: { label: 'Telefonnummer' } });
 
 export const Overview = meta.story({

--- a/packages/dds-components/src/components/Popover/Popover.mdx
+++ b/packages/dds-components/src/components/Popover/Popover.mdx
@@ -11,8 +11,9 @@ import {
 } from '@norges-domstoler/storybook-components';
 import { PopoverGroup } from '.';
 import * as PopoverStories from './Popover.stories';
+import meta from './Popover.stories';
 
-<Meta of={PopoverStories} />
+<Meta of={meta} />
 
 # Popover
 

--- a/packages/dds-components/src/components/Popover/Popover.stories.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.stories.tsx
@@ -37,6 +37,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   render: args => (
     <VStack alignItems="center">

--- a/packages/dds-components/src/components/ProgressBar/ProgressBar.mdx
+++ b/packages/dds-components/src/components/ProgressBar/ProgressBar.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as ProgressBarStories from './ProgressBar.stories';
+import meta from './ProgressBar.stories';
 
-<Meta of={ProgressBarStories} />
+<Meta of={meta} />
 
 # ProgressBar
 

--- a/packages/dds-components/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/packages/dds-components/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -21,6 +21,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: {
     label: 'Label',

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.mdx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.mdx
@@ -1,5 +1,6 @@
 import { ArgTypes, Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import * as ProgressTrackerStories from './ProgressTracker.stories';
+import meta from './ProgressTracker.stories';
 import * as ProgressTrackerFormStories from './ProgressTrackerForm.stories';
 import { ProgressTracker, ProgressTrackerItem } from '.';
 import {
@@ -8,7 +9,7 @@ import {
 } from '@norges-domstoler/storybook-components';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
-<Meta of={ProgressTrackerStories} />
+<Meta of={meta} />
 
 # ProgressTracker
 

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.stories.tsx
@@ -26,6 +26,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   render: args => {
     const numSteps = 3;

--- a/packages/dds-components/src/components/Search/Search.mdx
+++ b/packages/dds-components/src/components/Search/Search.mdx
@@ -11,8 +11,9 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as SearchStories from './Search.stories';
+import meta from './Search.stories';
 
-<Meta of={SearchStories} />
+<Meta of={meta} />
 
 # Search
 

--- a/packages/dds-components/src/components/Search/Search.stories.tsx
+++ b/packages/dds-components/src/components/Search/Search.stories.tsx
@@ -25,6 +25,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 const array = [
   'lala',
   'ghostbusters',

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.mdx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.mdx
@@ -1,9 +1,10 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as CheckboxStories from './Checkbox.stories';
+import meta from './Checkbox.stories';
 import * as CheckboxGroupStories from './CheckboxGroup.stories';
 
-<Meta of={CheckboxStories} />
+<Meta of={meta} />
 
 # Checkbox
 

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/Checkbox.stories.tsx
@@ -29,6 +29,8 @@ const meta = preview.meta({
   args: { onChange: fn(), onBlur: fn() },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { label: 'Label' },
 });

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
@@ -15,8 +15,6 @@ const meta = preview.meta({
   },
 });
 
-export default meta;
-
 export const Preview = meta.story({
   args: {
     label: 'Label',

--- a/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/Checkbox/CheckboxGroup.stories.tsx
@@ -15,6 +15,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: {
     label: 'Label',

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.mdx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.mdx
@@ -4,9 +4,10 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as RadioButtonStories from './RadioButton.stories';
+import meta from './RadioButton.stories';
 import * as RadioButtonGroupStories from './RadioButtonGroup.stories';
 
-<Meta of={RadioButtonStories} />
+<Meta of={meta} />
 
 # RadioButton
 

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButton.stories.tsx
@@ -27,6 +27,8 @@ const meta = preview.meta({
   args: { onChange: fn() },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { label: 'Label' },
 });

--- a/packages/dds-components/src/components/Skeleton/Skeleton.mdx
+++ b/packages/dds-components/src/components/Skeleton/Skeleton.mdx
@@ -3,6 +3,7 @@ import {
   ComponentLinkRow,
   Source,
 } from '@norges-domstoler/storybook-components';
+import * as SkeletonStories from './Skeleton.stories';
 import meta from './Skeleton.stories';
 
 <Meta of={meta} />

--- a/packages/dds-components/src/components/Skeleton/Skeleton.mdx
+++ b/packages/dds-components/src/components/Skeleton/Skeleton.mdx
@@ -3,9 +3,9 @@ import {
   ComponentLinkRow,
   Source,
 } from '@norges-domstoler/storybook-components';
-import * as SkeletonStories from './Skeleton.stories';
+import meta from './Skeleton.stories';
 
-<Meta of={SkeletonStories} />
+<Meta of={meta} />
 
 # Skeleton
 

--- a/packages/dds-components/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/dds-components/src/components/Skeleton/Skeleton.stories.tsx
@@ -19,6 +19,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: {
     width: '320px',

--- a/packages/dds-components/src/components/SkipToContent/SkipToContent.mdx
+++ b/packages/dds-components/src/components/SkipToContent/SkipToContent.mdx
@@ -4,8 +4,9 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as SkipToContentStories from './SkipToContent.stories';
+import meta from './SkipToContent.stories';
 
-<Meta of={SkipToContentStories} />
+<Meta of={meta} />
 
 # SkipToContent
 

--- a/packages/dds-components/src/components/SkipToContent/SkipToContent.stories.tsx
+++ b/packages/dds-components/src/components/SkipToContent/SkipToContent.stories.tsx
@@ -13,6 +13,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { href: '#innhold' },
   render: args => (

--- a/packages/dds-components/src/components/Spinner/Spinner.mdx
+++ b/packages/dds-components/src/components/Spinner/Spinner.mdx
@@ -4,9 +4,10 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as SpinnerStories from './Spinner.stories';
+import meta from './Spinner.stories';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
-<Meta of={SpinnerStories} />
+<Meta of={meta} />
 
 # Spinner
 

--- a/packages/dds-components/src/components/Spinner/Spinner.stories.tsx
+++ b/packages/dds-components/src/components/Spinner/Spinner.stories.tsx
@@ -15,6 +15,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story();
 
 export const CustomColor = meta.story({

--- a/packages/dds-components/src/components/SplitButton/SplitButton.mdx
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.mdx
@@ -3,6 +3,7 @@ import {
   Source,
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
+import * as SplitButtonStories from './SplitButton.stories';
 import meta from './SplitButton.stories';
 
 <Meta of={meta} />

--- a/packages/dds-components/src/components/SplitButton/SplitButton.mdx
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.mdx
@@ -3,9 +3,9 @@ import {
   Source,
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
-import * as SplitButtonStories from './SplitButton.stories';
+import meta from './SplitButton.stories';
 
-<Meta of={SplitButtonStories} />
+<Meta of={meta} />
 
 # SplitButton
 

--- a/packages/dds-components/src/components/SplitButton/SplitButton.stories.tsx
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.stories.tsx
@@ -38,6 +38,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({});
 
 export const Purposes = meta.story({

--- a/packages/dds-components/src/components/Table/normal/Table.mdx
+++ b/packages/dds-components/src/components/Table/normal/Table.mdx
@@ -13,9 +13,10 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as TableStories from './Table.stories';
+import meta from './Table.stories';
 import * as CollapsibleTableStories from '../collapsible/CollapsibleTable.stories';
 
-<Meta of={TableStories} />
+<Meta of={meta} />
 
 # Table
 

--- a/packages/dds-components/src/components/Table/normal/Table.stories.tsx
+++ b/packages/dds-components/src/components/Table/normal/Table.stories.tsx
@@ -28,6 +28,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 const mappedHeaderCells = headerCells.map(headerCell => {
   return (
     <Table.Cell key={`head-${headerCell.dataName}`}>

--- a/packages/dds-components/src/components/Tabs/Tabs.mdx
+++ b/packages/dds-components/src/components/Tabs/Tabs.mdx
@@ -11,8 +11,9 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as TabsStories from './Tabs.stories';
+import meta from './Tabs.stories';
 
-<Meta of={TabsStories} />
+<Meta of={meta} />
 
 # Tabs
 

--- a/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
@@ -25,6 +25,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 const tabList = (icon?: boolean) => {
   const tabIcon = icon ? NotificationsIcon : undefined;
   return (

--- a/packages/dds-components/src/components/Tag/Tag.mdx
+++ b/packages/dds-components/src/components/Tag/Tag.mdx
@@ -1,9 +1,10 @@
 import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as TagStories from './Tag.stories';
+import meta from './Tag.stories';
 import { Tabs, Tab, TabList, TabPanels, TabPanel } from '../Tabs';
 
-<Meta of={TagStories} />
+<Meta of={meta} />
 
 # Tag
 

--- a/packages/dds-components/src/components/Tag/Tag.stories.tsx
+++ b/packages/dds-components/src/components/Tag/Tag.stories.tsx
@@ -15,6 +15,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { children: 'default' },
 });

--- a/packages/dds-components/src/components/TextArea/TextArea.mdx
+++ b/packages/dds-components/src/components/TextArea/TextArea.mdx
@@ -1,8 +1,9 @@
 import { Meta, Controls, Canvas } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as TextAreaStories from './TextArea.stories';
+import meta from './TextArea.stories';
 
-<Meta of={TextAreaStories} />
+<Meta of={meta} />
 
 # TextArea
 

--- a/packages/dds-components/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/dds-components/src/components/TextArea/TextArea.stories.tsx
@@ -26,6 +26,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { label: 'Label' },
 });

--- a/packages/dds-components/src/components/TextInput/TextInput.mdx
+++ b/packages/dds-components/src/components/TextInput/TextInput.mdx
@@ -1,9 +1,10 @@
 import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as TextInputStories from './TextInput.stories';
+import meta from './TextInput.stories';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
-<Meta of={TextInputStories} />
+<Meta of={meta} />
 
 # TextInput
 

--- a/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
+++ b/packages/dds-components/src/components/TextInput/TextInput.stories.tsx
@@ -32,6 +32,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { label: 'Label' },
 });

--- a/packages/dds-components/src/components/Toggle/Toggle.mdx
+++ b/packages/dds-components/src/components/Toggle/Toggle.mdx
@@ -4,9 +4,10 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as ToggleStories from './Toggle.stories';
+import meta from './Toggle.stories';
 import { Tabs, Tab, TabList, TabPanels, TabPanel } from '../Tabs';
 
-<Meta of={ToggleStories} />
+<Meta of={meta} />
 
 # Toggle
 

--- a/packages/dds-components/src/components/Toggle/Toggle.stories.tsx
+++ b/packages/dds-components/src/components/Toggle/Toggle.stories.tsx
@@ -31,6 +31,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { children: 'Ledetekst' },
 });

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.mdx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.mdx
@@ -5,8 +5,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as ToggleBarStories from './ToggleBar.stories';
+import meta from './ToggleBar.stories';
 
-<Meta of={ToggleBarStories} />
+<Meta of={meta} />
 
 # ToggleBar
 

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.stories.tsx
@@ -24,6 +24,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 const toggleRadios = (label?: boolean, icon?: boolean) => {
   const radios = [];
   for (let i = 1; i <= 3; i++) {

--- a/packages/dds-components/src/components/ToggleButton/ToggleButton.mdx
+++ b/packages/dds-components/src/components/ToggleButton/ToggleButton.mdx
@@ -1,9 +1,10 @@
 import { Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as ToggleButtonStories from './ToggleButton.stories';
+import meta from './ToggleButton.stories';
 import * as ToggleButtonGroupStories from './ToggleButtonGroup.stories';
 
-<Meta of={ToggleButtonStories} />
+<Meta of={meta} />
 
 # ToggleButton
 

--- a/packages/dds-components/src/components/ToggleButton/ToggleButton.stories.tsx
+++ b/packages/dds-components/src/components/ToggleButton/ToggleButton.stories.tsx
@@ -32,6 +32,8 @@ const meta = preview.meta({
   args: { onChange: fn(), onBlur: fn() },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { label: 'Tekst' },
 });

--- a/packages/dds-components/src/components/Tooltip/Tooltip.mdx
+++ b/packages/dds-components/src/components/Tooltip/Tooltip.mdx
@@ -5,8 +5,9 @@ import {
 } from '@norges-domstoler/storybook-components';
 import { Table } from '../Table';
 import * as TooltipStories from './Tooltip.stories';
+import meta from './Tooltip.stories';
 
-<Meta of={TooltipStories} />
+<Meta of={meta} />
 
 # Tooltip
 

--- a/packages/dds-components/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/dds-components/src/components/Tooltip/Tooltip.stories.tsx
@@ -26,6 +26,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { text: 'Dette er en tooltip' },
   render: args => (

--- a/packages/dds-components/src/components/Typography/Caption/Caption.mdx
+++ b/packages/dds-components/src/components/Typography/Caption/Caption.mdx
@@ -2,8 +2,9 @@ import { Canvas, Meta, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import { Tabs, Tab, TabPanel, TabPanels, TabList } from '../../Tabs';
 import * as CaptionStories from './Caption.stories';
+import meta from './Caption.stories';
 
-<Meta of={CaptionStories} />
+<Meta of={meta} />
 
 # Caption
 

--- a/packages/dds-components/src/components/Typography/Caption/Caption.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Caption/Caption.stories.tsx
@@ -15,6 +15,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { children: 'Caption' },
 });

--- a/packages/dds-components/src/components/Typography/Heading/Heading.mdx
+++ b/packages/dds-components/src/components/Typography/Heading/Heading.mdx
@@ -2,8 +2,9 @@ import { Canvas, Meta, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import { Link } from '..';
 import * as HeadingStories from './Heading.stories';
+import meta from './Heading.stories';
 
-<Meta of={HeadingStories} />
+<Meta of={meta} />
 
 # Heading
 

--- a/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
@@ -15,6 +15,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { children: 'Heading', level: 1 },
 });

--- a/packages/dds-components/src/components/Typography/Label/Label.mdx
+++ b/packages/dds-components/src/components/Typography/Label/Label.mdx
@@ -2,8 +2,9 @@ import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 
 import * as LabelStories from './Label.stories';
+import meta from './Label.stories';
 
-<Meta of={LabelStories} />
+<Meta of={meta} />
 
 # Label
 

--- a/packages/dds-components/src/components/Typography/Label/Label.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Label/Label.stories.tsx
@@ -19,6 +19,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { children: 'Label' },
 });

--- a/packages/dds-components/src/components/Typography/Legend/Legend.mdx
+++ b/packages/dds-components/src/components/Typography/Legend/Legend.mdx
@@ -4,8 +4,9 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as LegendStories from './Legend.stories';
+import meta from './Legend.stories';
 
-<Meta of={LegendStories} />
+<Meta of={meta} />
 
 # Legend
 

--- a/packages/dds-components/src/components/Typography/Legend/Legend.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Legend/Legend.stories.tsx
@@ -13,6 +13,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { children: 'Legend' },
 });

--- a/packages/dds-components/src/components/Typography/Link/Link.mdx
+++ b/packages/dds-components/src/components/Typography/Link/Link.mdx
@@ -5,9 +5,10 @@ import {
 } from '@norges-domstoler/storybook-components';
 import { Link } from '.';
 import * as LinkStories from './Link.stories';
+import meta from './Link.stories';
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../../Tabs';
 
-<Meta of={LinkStories} />
+<Meta of={meta} />
 
 # Link
 

--- a/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
@@ -27,6 +27,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 const showcaseProps = { children: 'Link', href: 'https://www.domstol.no' };
 
 export const Preview = meta.story({

--- a/packages/dds-components/src/components/Typography/Paragraph/Paragraph.mdx
+++ b/packages/dds-components/src/components/Typography/Paragraph/Paragraph.mdx
@@ -2,8 +2,9 @@ import { Canvas, Meta, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import { Link } from '..';
 import * as ParagraphStories from './Paragraph.stories';
+import meta from './Paragraph.stories';
 
-<Meta of={ParagraphStories} />
+<Meta of={meta} />
 
 # Paragraph
 

--- a/packages/dds-components/src/components/Typography/Paragraph/Paragraph.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Paragraph/Paragraph.stories.tsx
@@ -16,6 +16,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { children: 'Paragraph' },
 });

--- a/packages/dds-components/src/components/Typography/Typography/Typography.mdx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.mdx
@@ -5,8 +5,9 @@ import {
 } from '@norges-domstoler/storybook-components';
 import { Link } from '../Link';
 import * as TypographyStories from './Typography.stories';
+import meta from './Typography.stories';
 
-<Meta of={TypographyStories} />
+<Meta of={meta} />
 
 # Typography
 

--- a/packages/dds-components/src/components/Typography/Typography/Typography.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.stories.tsx
@@ -17,6 +17,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { children: 'Typography' },
 });

--- a/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.mdx
+++ b/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.mdx
@@ -1,8 +1,9 @@
 import { Canvas, Meta, Controls } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as VisuallyHiddenStories from './VisuallyHidden.stories';
+import meta from './VisuallyHidden.stories';
 
-<Meta of={VisuallyHiddenStories} />
+<Meta of={meta} />
 
 # VisuallyHidden
 

--- a/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
+++ b/packages/dds-components/src/components/VisuallyHidden/VisuallyHidden.stories.tsx
@@ -22,6 +22,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   render: args => (
     <>

--- a/packages/dds-components/src/components/helpers/AccordionBase/useAccordion.mdx
+++ b/packages/dds-components/src/components/helpers/AccordionBase/useAccordion.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as useAccordionStories from './useAccordion.stories';
+import meta from './useAccordion.stories';
 
-<Meta of={useAccordionStories} />
+<Meta of={meta} />
 
 # useAccordion
 

--- a/packages/dds-components/src/components/helpers/AccordionBase/useAccordion.stories.tsx
+++ b/packages/dds-components/src/components/helpers/AccordionBase/useAccordion.stories.tsx
@@ -13,4 +13,6 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story();

--- a/packages/dds-components/src/components/layout/Box/Box.mdx
+++ b/packages/dds-components/src/components/layout/Box/Box.mdx
@@ -11,8 +11,9 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as BoxStories from './Box.stories';
+import meta from './Box.stories';
 
-<Meta of={BoxStories} />
+<Meta of={meta} />
 
 # Box
 

--- a/packages/dds-components/src/components/layout/Box/Box.stories.tsx
+++ b/packages/dds-components/src/components/layout/Box/Box.stories.tsx
@@ -22,6 +22,8 @@ const meta = preview.meta({
   decorators: [Story => windowWidthDecorator(<Story />)],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: {
     style: {

--- a/packages/dds-components/src/components/layout/Contrast/Contrast.mdx
+++ b/packages/dds-components/src/components/layout/Contrast/Contrast.mdx
@@ -1,8 +1,9 @@
 import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
 import { ComponentLinkRow } from '@norges-domstoler/storybook-components';
 import * as ContrastStories from './Contrast.stories';
+import meta from './Contrast.stories';
 
-<Meta of={ContrastStories} />
+<Meta of={meta} />
 
 # Contrast
 

--- a/packages/dds-components/src/components/layout/Contrast/Contrast.stories.tsx
+++ b/packages/dds-components/src/components/layout/Contrast/Contrast.stories.tsx
@@ -29,6 +29,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   render: args => (
     <Contrast {...args} style={{ padding: 'var(--dds-spacing-x2)' }}>

--- a/packages/dds-components/src/components/layout/Grid/Grid.mdx
+++ b/packages/dds-components/src/components/layout/Grid/Grid.mdx
@@ -12,9 +12,10 @@ import {
 } from '@norges-domstoler/storybook-components';
 import { Link } from '../../Typography';
 import * as GridStories from './Grid.stories';
+import meta from './Grid.stories';
 import * as GridChildStories from './GridChild.stories';
 
-<Meta of={GridStories} />
+<Meta of={meta} />
 
 # Grid
 

--- a/packages/dds-components/src/components/layout/Grid/Grid.stories.tsx
+++ b/packages/dds-components/src/components/layout/Grid/Grid.stories.tsx
@@ -29,6 +29,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   decorators: [
     Story =>

--- a/packages/dds-components/src/components/layout/Grid/GridChild.stories.tsx
+++ b/packages/dds-components/src/components/layout/Grid/GridChild.stories.tsx
@@ -16,8 +16,6 @@ const meta = preview.meta({
   },
 });
 
-export default meta;
-
 export const Preview = meta.story({
   decorators: [
     Story => (

--- a/packages/dds-components/src/components/layout/Grid/GridChild.stories.tsx
+++ b/packages/dds-components/src/components/layout/Grid/GridChild.stories.tsx
@@ -16,6 +16,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   decorators: [
     Story => (

--- a/packages/dds-components/src/components/layout/Paper/Paper.mdx
+++ b/packages/dds-components/src/components/layout/Paper/Paper.mdx
@@ -11,8 +11,9 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as PaperStories from './Paper.stories';
+import meta from './Paper.stories';
 
-<Meta of={PaperStories} />
+<Meta of={meta} />
 
 # Paper
 

--- a/packages/dds-components/src/components/layout/Paper/Paper.stories.tsx
+++ b/packages/dds-components/src/components/layout/Paper/Paper.stories.tsx
@@ -23,6 +23,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: {
     border: 'border-default',

--- a/packages/dds-components/src/components/layout/ShowHide/ShowHide.mdx
+++ b/packages/dds-components/src/components/layout/ShowHide/ShowHide.mdx
@@ -11,8 +11,9 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as ShowHideStories from './ShowHide.stories';
+import meta from './ShowHide.stories';
 
-<Meta of={ShowHideStories} />
+<Meta of={meta} />
 
 # ShowHide
 

--- a/packages/dds-components/src/components/layout/ShowHide/ShowHide.stories.tsx
+++ b/packages/dds-components/src/components/layout/ShowHide/ShowHide.stories.tsx
@@ -19,6 +19,8 @@ const meta = preview.meta({
   decorators: [Story => windowWidthDecorator(<Story />)],
 });
 
+export default meta;
+
 export const Preview = meta.story({
   render: args => (
     <Grid gridTemplateColumns="150px 150px" gap="x1">

--- a/packages/dds-components/src/components/layout/Stack/HStack/HStack.mdx
+++ b/packages/dds-components/src/components/layout/Stack/HStack/HStack.mdx
@@ -10,8 +10,9 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as StackStories from './HStack.stories';
+import meta from './HStack.stories';
 
-<Meta of={StackStories} />
+<Meta of={meta} />
 
 # HStack
 

--- a/packages/dds-components/src/components/layout/Stack/HStack/HStack.stories.tsx
+++ b/packages/dds-components/src/components/layout/Stack/HStack/HStack.stories.tsx
@@ -15,6 +15,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 const ExampleElement = () => (
   <Box
     width="5rem"

--- a/packages/dds-components/src/components/layout/Stack/VStack/VStack.mdx
+++ b/packages/dds-components/src/components/layout/Stack/VStack/VStack.mdx
@@ -10,8 +10,9 @@ import {
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
 import * as StackStories from './VStack.stories';
+import meta from './VStack.stories';
 
-<Meta of={StackStories} />
+<Meta of={meta} />
 
 # VStack
 

--- a/packages/dds-components/src/components/layout/Stack/VStack/VStack.stories.tsx
+++ b/packages/dds-components/src/components/layout/Stack/VStack/VStack.stories.tsx
@@ -15,6 +15,8 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 const ExampleElement = () => (
   <Box
     width="5rem"

--- a/packages/dds-components/src/hooks/useCallbackRef/useCallbackRef.mdx
+++ b/packages/dds-components/src/hooks/useCallbackRef/useCallbackRef.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as useCallbackRefStories from './useCallbackRef.stories';
+import meta from './useCallbackRef.stories';
 
-<Meta of={useCallbackRefStories} />
+<Meta of={meta} />
 
 # useCallbackRef
 

--- a/packages/dds-components/src/hooks/useCallbackRef/useCallbackRef.stories.tsx
+++ b/packages/dds-components/src/hooks/useCallbackRef/useCallbackRef.stories.tsx
@@ -17,4 +17,6 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useCombinedRef/useCombinedRef.mdx
+++ b/packages/dds-components/src/hooks/useCombinedRef/useCombinedRef.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as useCombinedRefStories from './useCombinedRef.stories';
+import meta from './useCombinedRef.stories';
 
-<Meta of={useCombinedRefStories} />
+<Meta of={meta} />
 
 # useCombinedRef
 

--- a/packages/dds-components/src/hooks/useCombinedRef/useCombinedRef.stories.tsx
+++ b/packages/dds-components/src/hooks/useCombinedRef/useCombinedRef.stories.tsx
@@ -12,4 +12,6 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({ args: { refs: [null] } });

--- a/packages/dds-components/src/hooks/useControllableState/useControllableState.mdx
+++ b/packages/dds-components/src/hooks/useControllableState/useControllableState.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as useControllableStateStories from './useControllableState.stories';
+import meta from './useControllableState.stories';
 
-<Meta of={useControllableStateStories} />
+<Meta of={meta} />
 
 # useControllableState
 

--- a/packages/dds-components/src/hooks/useControllableState/useControllableState.stories.tsx
+++ b/packages/dds-components/src/hooks/useControllableState/useControllableState.stories.tsx
@@ -13,4 +13,6 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useFloatPosition/useFloatPosition.mdx
+++ b/packages/dds-components/src/hooks/useFloatPosition/useFloatPosition.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as useFloatPositionStories from './useFloatPosition.stories';
+import meta from './useFloatPosition.stories';
 
-<Meta of={useFloatPositionStories} />
+<Meta of={meta} />
 
 # useFloatPosition
 

--- a/packages/dds-components/src/hooks/useFloatPosition/useFloatPosition.stories.tsx
+++ b/packages/dds-components/src/hooks/useFloatPosition/useFloatPosition.stories.tsx
@@ -16,4 +16,6 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useFocusTrap/useFocusTrap.mdx
+++ b/packages/dds-components/src/hooks/useFocusTrap/useFocusTrap.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as useFocusTrapStories from './useFocusTrap.stories';
+import meta from './useFocusTrap.stories';
 
-<Meta of={useFocusTrapStories} />
+<Meta of={meta} />
 
 # useFocusTrap
 

--- a/packages/dds-components/src/hooks/useFocusTrap/useFocusTrap.stories.tsx
+++ b/packages/dds-components/src/hooks/useFocusTrap/useFocusTrap.stories.tsx
@@ -13,4 +13,6 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useIsMounted/useIsMounted.mdx
+++ b/packages/dds-components/src/hooks/useIsMounted/useIsMounted.mdx
@@ -3,6 +3,7 @@ import {
   ComponentLinkRow,
   Source,
 } from '@norges-domstoler/storybook-components';
+import * as useIsMountedStories from './useIsMounted.stories';
 import meta from './useIsMounted.stories';
 
 <Meta of={meta} />

--- a/packages/dds-components/src/hooks/useIsMounted/useIsMounted.mdx
+++ b/packages/dds-components/src/hooks/useIsMounted/useIsMounted.mdx
@@ -3,9 +3,9 @@ import {
   ComponentLinkRow,
   Source,
 } from '@norges-domstoler/storybook-components';
-import * as useIsMountedStories from './useIsMounted.stories';
+import meta from './useIsMounted.stories';
 
-<Meta of={useIsMountedStories} />
+<Meta of={meta} />
 
 # useIsMounted
 

--- a/packages/dds-components/src/hooks/useIsMounted/useIsMounted.stories.tsx
+++ b/packages/dds-components/src/hooks/useIsMounted/useIsMounted.stories.tsx
@@ -9,4 +9,6 @@ const meta = preview.meta({
   parameters: hookParameters,
 });
 
+export default meta;
+
 export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useMountTransition/useMountTransition.mdx
+++ b/packages/dds-components/src/hooks/useMountTransition/useMountTransition.mdx
@@ -3,6 +3,7 @@ import {
   ComponentLinkRow,
   Source,
 } from '@norges-domstoler/storybook-components';
+import * as useMountTransitionStories from './useMountTransition.stories';
 import meta from './useMountTransition.stories';
 
 <Meta of={meta} />

--- a/packages/dds-components/src/hooks/useMountTransition/useMountTransition.mdx
+++ b/packages/dds-components/src/hooks/useMountTransition/useMountTransition.mdx
@@ -3,9 +3,9 @@ import {
   ComponentLinkRow,
   Source,
 } from '@norges-domstoler/storybook-components';
-import * as useMountTransitionStories from './useMountTransition.stories';
+import meta from './useMountTransition.stories';
 
-<Meta of={useMountTransitionStories} />
+<Meta of={meta} />
 
 # useMountTransition
 

--- a/packages/dds-components/src/hooks/useMountTransition/useMountTransition.stories.tsx
+++ b/packages/dds-components/src/hooks/useMountTransition/useMountTransition.stories.tsx
@@ -9,6 +9,8 @@ const meta = preview.meta({
   parameters: hookParameters,
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: { isMounted: false, unmountDelay: 1000 },
 });

--- a/packages/dds-components/src/hooks/useOnClickOutside/useOnClickOutside.mdx
+++ b/packages/dds-components/src/hooks/useOnClickOutside/useOnClickOutside.mdx
@@ -6,8 +6,9 @@ import {
 } from '@norges-domstoler/storybook-components';
 
 import * as useOnClickOutsideStories from './useOnClickOutside.stories';
+import meta from './useOnClickOutside.stories';
 
-<Meta of={useOnClickOutsideStories} />
+<Meta of={meta} />
 
 # useOnClickOutside
 

--- a/packages/dds-components/src/hooks/useOnClickOutside/useOnClickOutside.stories.tsx
+++ b/packages/dds-components/src/hooks/useOnClickOutside/useOnClickOutside.stories.tsx
@@ -18,4 +18,6 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useOnKeyDown/useOnKeyDown.mdx
+++ b/packages/dds-components/src/hooks/useOnKeyDown/useOnKeyDown.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as useOnKeyDownStories from './useOnKeyDown.stories';
+import meta from './useOnKeyDown.stories';
 
-<Meta of={useOnKeyDownStories} />
+<Meta of={meta} />
 
 # useOnKeyDown
 

--- a/packages/dds-components/src/hooks/useOnKeyDown/useOnKeyDown.stories.tsx
+++ b/packages/dds-components/src/hooks/useOnKeyDown/useOnKeyDown.stories.tsx
@@ -18,4 +18,6 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useReturnFocusOnBlur/useReturnFocusOnBlur.mdx
+++ b/packages/dds-components/src/hooks/useReturnFocusOnBlur/useReturnFocusOnBlur.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as useReturnFocusOnBlurStories from './useReturnFocusOnBlur.stories';
+import meta from './useReturnFocusOnBlur.stories';
 
-<Meta of={useReturnFocusOnBlurStories} />
+<Meta of={meta} />
 
 # useReturnFocusOnBlur
 

--- a/packages/dds-components/src/hooks/useReturnFocusOnBlur/useReturnFocusOnBlur.stories.tsx
+++ b/packages/dds-components/src/hooks/useReturnFocusOnBlur/useReturnFocusOnBlur.stories.tsx
@@ -19,4 +19,6 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useRoveFocus/useRoveFocus.mdx
+++ b/packages/dds-components/src/hooks/useRoveFocus/useRoveFocus.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as RoveStories from './useRoveFocus.stories';
+import meta from './useRoveFocus.stories';
 
-<Meta of={RoveStories} />
+<Meta of={meta} />
 
 # useRoveFocus
 

--- a/packages/dds-components/src/hooks/useRoveFocus/useRoveFocus.stories.tsx
+++ b/packages/dds-components/src/hooks/useRoveFocus/useRoveFocus.stories.tsx
@@ -9,6 +9,8 @@ const meta = preview.meta({
   parameters: hookParameters,
 });
 
+export default meta;
+
 export const Preview = meta.story({
   args: {
     size: 4,

--- a/packages/dds-components/src/hooks/useScreenSize/useScreenSize.mdx
+++ b/packages/dds-components/src/hooks/useScreenSize/useScreenSize.mdx
@@ -4,8 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 import * as useScreenSizeStories from './useScreenSize.stories';
+import meta from './useScreenSize.stories';
 
-<Meta of={useScreenSizeStories} />
+<Meta of={meta} />
 
 # useScreenSize
 

--- a/packages/dds-components/src/hooks/useScreenSize/useScreenSize.stories.tsx
+++ b/packages/dds-components/src/hooks/useScreenSize/useScreenSize.stories.tsx
@@ -9,4 +9,6 @@ const meta = preview.meta({
   parameters: hookParameters,
 });
 
+export default meta;
+
 export const Preview = meta.story();

--- a/packages/dds-components/src/hooks/useWindowResize/useWindowResize.mdx
+++ b/packages/dds-components/src/hooks/useWindowResize/useWindowResize.mdx
@@ -4,9 +4,9 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 
-import * as useWindowResizeStories from './useWindowResize.stories';
+import meta from './useWindowResize.stories';
 
-<Meta of={useWindowResizeStories} />
+<Meta of={meta} />
 
 # useWindowResize
 

--- a/packages/dds-components/src/hooks/useWindowResize/useWindowResize.mdx
+++ b/packages/dds-components/src/hooks/useWindowResize/useWindowResize.mdx
@@ -4,6 +4,7 @@ import {
   Source,
 } from '@norges-domstoler/storybook-components';
 
+import * as useWindowResizeStories from './useWindowResize.stories';
 import meta from './useWindowResize.stories';
 
 <Meta of={meta} />

--- a/packages/dds-components/src/hooks/useWindowResize/useWindowResize.stories.tsx
+++ b/packages/dds-components/src/hooks/useWindowResize/useWindowResize.stories.tsx
@@ -14,4 +14,6 @@ const meta = preview.meta({
   },
 });
 
+export default meta;
+
 export const Preview = meta.story({});


### PR DESCRIPTION
## Beskrivelse

Storybook meta importen manglet i MDX filer som inneholder teknisk dokumentasjon. Fungerte lokalt uten import, men ikke i deploy, og ble ikke plukket opp av checks.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
