### PR TITLE
ELSA1-860: menuPlacement i Select.tsx og Select.styles.ts

### DIFF
--- a/.changeset/moody-kings-brake.md
+++ b/.changeset/moody-kings-brake.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Props menuPlacement kan nå brukes av Select. Hvis ingen props sendes med, er menuPlacement = "auto".

--- a/packages/dds-components/src/components/Select/MultiSelect.stories.tsx
+++ b/packages/dds-components/src/components/Select/MultiSelect.stories.tsx
@@ -22,6 +22,10 @@ const meta: Meta<typeof Select<Option, true>> = {
     required: { control: { type: 'boolean' }, table: categoryHtml },
     readOnly: { control: { type: 'boolean' } },
     isLoading: { control: { type: 'boolean' } },
+    menuPlacement: {
+      options: ['bottom', 'auto', 'top'],
+      control: { type: 'radio' },
+    },
   },
   parameters: {
     docs: {

--- a/packages/dds-components/src/components/Select/Select.stories.tsx
+++ b/packages/dds-components/src/components/Select/Select.stories.tsx
@@ -33,6 +33,10 @@ const meta: Meta<typeof Select> = {
     onChange: htmlEventArgType,
     onBlur: htmlEventArgType,
     onFocus: htmlEventArgType,
+    menuPlacement: {
+      options: ['bottom', 'top', 'auto'],
+      control: { type: 'radio' },
+    },
   },
   args: { onChange: fn(), onInputChange: fn() },
   parameters: {

--- a/packages/dds-components/src/components/Select/Select.styles.ts
+++ b/packages/dds-components/src/components/Select/Select.styles.ts
@@ -191,9 +191,9 @@ export const getCustomStyles = <TOption>(
             backgroundColor: 'var(--dds-color-surface-hover-default)',
           },
         },
-  menu: () => ({
+  menu: provided => ({
+    ...provided,
     boxSizing: 'border-box',
-    position: 'absolute',
     width: '100%',
     boxShadow: 'var(--dds-shadow-medium)',
     zIndex: 100,

--- a/packages/dds-components/src/components/Select/Select.tsx
+++ b/packages/dds-components/src/components/Select/Select.tsx
@@ -40,7 +40,7 @@ import {
   searchFilter,
   spaceSeparatedIdListGenerator,
 } from '../../utils';
-import { readOnlyKeyDownHandler } from '../../utils/readonlyEventHandlers';
+import { readOnlyKeyDownHandler } from '../../utils';
 import {
   type CommonInputProps,
   type InputIconProps,
@@ -121,6 +121,7 @@ export function Select<Option = unknown, IsMulti extends boolean = false>({
   isClearable = true,
   placeholder,
   menuPortalTarget,
+  menuPlacement = 'auto',
   customOptionElement,
   customSingleValueElement,
   'data-testid': dataTestId,
@@ -244,16 +245,13 @@ export function Select<Option = unknown, IsMulti extends boolean = false>({
     isClearable,
     hideSelectedOptions: hideSelectedOptions ? hideSelectedOptions : false,
     placeholder: placeholder ? placeholder : '',
-    closeMenuOnSelect: closeMenuOnSelect
-      ? closeMenuOnSelect
-      : isMulti
-        ? false
-        : true,
+    closeMenuOnSelect: closeMenuOnSelect ? closeMenuOnSelect : !isMulti,
     isMulti,
     instanceId: instanceId ?? useId(),
     inputId: uniqueId,
     name: uniqueId,
     menuPortalTarget: portalTarget,
+    menuPlacement,
     classNamePrefix: prefix,
     styles: getCustomStyles<Option>(componentSize, hasErrorMessage, readOnly),
     filterOption: (option, inputValue) => {


### PR DESCRIPTION
## Beskrivelse

Bugfix for `menuPlacement ` i Select.tsx og Select.styles.ts
Standard satt til "auto" men aksepterer fortsatt fasta verdier i form av props. Nedan er eksempel på når "auto" er brukt.

<img width="336" height="325" alt="Screenshot 2026-04-27 133122" src="https://github.com/user-attachments/assets/27d67877-8a5f-4a88-9621-ed649db47550" />
<img width="414" height="402" alt="Screenshot 2026-04-27 133144" src="https://github.com/user-attachments/assets/9ef1055c-4101-4566-b99d-f9e424169a51" />


## Sjekkliste
- [x]  Kan godta og se endringer i layout når menuPlacement sendes inn
- [x]  menuPlacement er 'auto' når du ikke sender inn props.
- [x]  'auto'-innstillingen legger til meny over select når menyen ikke har plass nedover, men oppover.

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR
- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)
