### PR TITLE
ELSA1-608: fikser rekkefølge på design tokens i preview

### DIFF
--- a/stories/Tokens/utils/ColorsGenerator.tsx
+++ b/stories/Tokens/utils/ColorsGenerator.tsx
@@ -90,7 +90,11 @@ export const DataColorsGenerator = (mode: ThemeMode) => {
   function generateBodyRows() {
     const rows: Array<React.JSX.Element> = [];
 
-    for (const key1 in tokens) {
+    const sortedKeys = Object.keys(tokens).sort(
+      (a, b) => Number(a) - Number(b),
+    );
+
+    for (const key1 of sortedKeys) {
       for (const key2 in tokens[key1]) {
         const token = tokens[key1][key2];
         let alpha = '';


### PR DESCRIPTION
## Beskrivelse

Gjør at design token med nøkkel  01 havner på toppen istedenfor 10:

<img width="1390" height="820" alt="bilde" src="https://github.com/user-attachments/assets/76171171-2169-4f83-82aa-dc446bc01ed7" />

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
