### PR TITLE
ELSA1-864: støtte for utvalgte responsive props i typografikomponenter

### DIFF
--- a/.changeset/young-pans-like.md
+++ b/.changeset/young-pans-like.md
@@ -1,0 +1,8 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for utvalgte responsive props i alle typografikomponenter:
+
+- `textAlign`, `wordBreak`, `display`, `margin`, `marginBlock`, `maxWidth`, `width`, `minWidth` i `<Heading>`, `<Legend>`, `<Caption>`, `<Paragraph>` og `<Typography>`.
+- `textAlign`, `wordBreak`, `display`, `marginBlock` i `<Link>` og `<Label>`.

--- a/packages/dds-components/src/components/Typography/Caption/Caption.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Caption/Caption.stories.tsx
@@ -2,7 +2,7 @@ import preview from '#.storybook/preview';
 
 import { ddsProviderDecorator } from '../../../storybook';
 import { Table } from '../../Table';
-import { storyTypographyHtmlAttrs } from '../storyUtils';
+import { blockTgCommonArgTypes } from '../storyUtils';
 
 import { Caption } from '.';
 
@@ -10,7 +10,7 @@ const meta = preview.meta({
   title: 'dds-components/Components/Typography/Caption',
   component: Caption,
   argTypes: {
-    ...storyTypographyHtmlAttrs,
+    ...blockTgCommonArgTypes,
   },
   decorators: [ddsProviderDecorator],
 });

--- a/packages/dds-components/src/components/Typography/Caption/Caption.tsx
+++ b/packages/dds-components/src/components/Typography/Caption/Caption.tsx
@@ -1,15 +1,12 @@
-import { type ComponentProps } from 'react';
-
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../../types';
-import { type BaseTypographyProps, Typography } from '../Typography';
+import { type CommonBlockTypographyProps, Typography } from '../Typography';
 
 export type CaptionProps = BaseComponentPropsWithChildren<
   HTMLTableCaptionElement,
-  BaseTypographyProps,
-  Omit<ComponentProps<'caption'>, 'color'>
+  CommonBlockTypographyProps
 >;
 
 export const Caption = ({

--- a/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
@@ -2,7 +2,7 @@ import preview from '#.storybook/preview';
 
 import { ddsProviderDecorator } from '../../../storybook';
 import { StoryVStack } from '../../layout/Stack/utils';
-import { storyTypographyHtmlAttrs } from '../storyUtils';
+import { blockTgCommonArgTypes } from '../storyUtils';
 
 import { Heading } from '.';
 
@@ -10,7 +10,7 @@ const meta = preview.meta({
   title: 'dds-components/Components/Typography/Heading',
   component: Heading,
   argTypes: {
-    ...storyTypographyHtmlAttrs,
+    ...blockTgCommonArgTypes,
   },
   decorators: [ddsProviderDecorator],
 });

--- a/packages/dds-components/src/components/Typography/Heading/Heading.tsx
+++ b/packages/dds-components/src/components/Typography/Heading/Heading.tsx
@@ -1,4 +1,4 @@
-import { type ElementType, type HTMLAttributes } from 'react';
+import { type ElementType } from 'react';
 
 import {
   type BaseComponentPropsWithChildren,
@@ -6,7 +6,7 @@ import {
 } from '../../../types';
 import { cn, optAttr } from '../../../utils';
 import {
-  type BaseTypographyProps,
+  type CommonBlockTypographyProps,
   Typography,
   type TypographyHeadingType,
 } from '../Typography';
@@ -44,8 +44,7 @@ export type HeadingProps = BaseComponentPropsWithChildren<
     typographyType?: TypographyHeadingType;
     /**Setter standard spacing for `<Heading>` som er over et inputelement. */
     withMarginsOverInput?: boolean;
-  } & BaseTypographyProps,
-  Omit<HTMLAttributes<HTMLHeadingElement>, 'color'>
+  } & CommonBlockTypographyProps
 >;
 
 export const Heading = ({

--- a/packages/dds-components/src/components/Typography/Label/Label.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Label/Label.stories.tsx
@@ -5,7 +5,7 @@ import { HelpIcon } from '../../Icon/icons';
 import { InlineButton } from '../../InlineButton';
 import { Popover, PopoverGroup } from '../../Popover';
 import { Paragraph } from '../Paragraph';
-import { storyTypographyHtmlAttrs } from '../storyUtils';
+import { inlineTgCommonArgTypes } from '../storyUtils';
 
 import { Label } from '.';
 
@@ -14,7 +14,7 @@ const meta = preview.meta({
   component: Label,
   argTypes: {
     htmlFor: { control: false, table: categoryHtml },
-    ...storyTypographyHtmlAttrs,
+    ...inlineTgCommonArgTypes,
   },
   decorators: [ddsProviderDecorator],
 });

--- a/packages/dds-components/src/components/Typography/Label/Label.tsx
+++ b/packages/dds-components/src/components/Typography/Label/Label.tsx
@@ -8,7 +8,7 @@ import {
 import { RequiredMarker, cn } from '../../../utils';
 import { Icon } from '../../Icon';
 import { LockFilledIcon } from '../../Icon/icons';
-import { type BaseTypographyProps, Typography } from '../Typography';
+import { type CommonInlineTypographyProps, Typography } from '../Typography';
 
 type PickedHTMLAttributes = Pick<
   LabelHTMLAttributes<HTMLLabelElement>,
@@ -26,11 +26,7 @@ export interface BaseLabelProps {
 
 export type LabelProps = BaseComponentPropsWithChildren<
   HTMLLabelElement,
-  BaseLabelProps & BaseTypographyProps & PickedHTMLAttributes,
-  Omit<
-    LabelHTMLAttributes<HTMLLabelElement>,
-    keyof PickedHTMLAttributes | 'color'
-  >
+  BaseLabelProps & CommonInlineTypographyProps & PickedHTMLAttributes
 >;
 
 export const Label = ({

--- a/packages/dds-components/src/components/Typography/Legend/Legend.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Legend/Legend.stories.tsx
@@ -2,13 +2,13 @@ import preview from '#.storybook/preview';
 
 import { Legend } from '..';
 import { ddsProviderDecorator } from '../../../storybook';
-import { storyTypographyHtmlAttrs } from '../storyUtils';
+import { blockTgCommonArgTypes } from '../storyUtils';
 
 const meta = preview.meta({
   title: 'dds-components/Components/Typography/Legend',
   component: Legend,
   argTypes: {
-    ...storyTypographyHtmlAttrs,
+    ...blockTgCommonArgTypes,
   },
   decorators: [ddsProviderDecorator],
 });

--- a/packages/dds-components/src/components/Typography/Legend/Legend.tsx
+++ b/packages/dds-components/src/components/Typography/Legend/Legend.tsx
@@ -1,12 +1,10 @@
-import { type HTMLAttributes } from 'react';
-
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../../types';
 import { cn, optAttr } from '../../../utils';
 import {
-  type BaseTypographyProps,
+  type CommonBlockTypographyProps,
   Typography,
   type TypographyHeadingType,
 } from '../Typography';
@@ -14,13 +12,12 @@ import styles from '../typographyStyles.module.css';
 
 export type LegendProps = BaseComponentPropsWithChildren<
   HTMLLegendElement,
-  BaseTypographyProps & {
+  CommonBlockTypographyProps & {
     /**Typografistil basert på utvalget for HTML heading elementer.  */
     typographyType?: TypographyHeadingType;
     /**Setter standard spacing for `<Legend>` som er over et inputelement. */
     withMarginsOverInput?: boolean;
-  },
-  Omit<HTMLAttributes<HTMLLegendElement>, 'color'>
+  }
 >;
 
 export const Legend = ({

--- a/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../../storybook';
 import { StoryVStack } from '../../layout/Stack/utils';
 import { Paragraph } from '../Paragraph';
-import { storyTypographyHtmlAttrs } from '../storyUtils';
+import { inlineTgCommonArgTypes } from '../storyUtils';
 
 import { Link } from '.';
 
@@ -21,7 +21,7 @@ const meta = preview.meta({
     as: { control: 'text' },
     onClick: htmlEventArgType,
     target: htmlArgType,
-    ...storyTypographyHtmlAttrs,
+    ...inlineTgCommonArgTypes,
   },
   args: { onClick: fn() },
   decorators: [ddsProviderDecorator],

--- a/packages/dds-components/src/components/Typography/Link/Link.tsx
+++ b/packages/dds-components/src/components/Typography/Link/Link.tsx
@@ -10,7 +10,7 @@ import { focusable } from '../../helpers/styling/focus.module.css';
 import { Icon } from '../../Icon';
 import { OpenExternalIcon } from '../../Icon/icons';
 import {
-  type BaseTypographyProps,
+  type CommonInlineTypographyProps,
   type TypographyBodyType,
   getColorCn,
   getTypographyCn,
@@ -34,7 +34,7 @@ export type LinkProps<T extends ElementType = 'a'> =
       typographyType?: TypographyBodyType;
       /**Tvinger komponenten til å behandle `as` som en anchor tag wrapper og forwarde anchor-spesifikke props (target, rel). Bruk når custom `as` komponent wrapper en `<a>` tag. */
       isAnchor?: boolean;
-    } & BaseTypographyProps &
+    } & CommonInlineTypographyProps &
       PickedHTMLAttributes
   >;
 

--- a/packages/dds-components/src/components/Typography/Paragraph/Paragraph.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Paragraph/Paragraph.stories.tsx
@@ -2,7 +2,7 @@ import preview from '#.storybook/preview';
 
 import { ddsProviderDecorator } from '../../../storybook';
 import { StoryVStack } from '../../layout/Stack/utils';
-import { storyTypographyHtmlAttrs } from '../storyUtils';
+import { blockTgCommonArgTypes } from '../storyUtils';
 import { Typography } from '../Typography';
 
 import { Paragraph } from '.';
@@ -11,7 +11,7 @@ const meta = preview.meta({
   title: 'dds-components/Components/Typography/Paragraph',
   component: Paragraph,
   argTypes: {
-    ...storyTypographyHtmlAttrs,
+    ...blockTgCommonArgTypes,
   },
   decorators: [ddsProviderDecorator],
 });

--- a/packages/dds-components/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/packages/dds-components/src/components/Typography/Paragraph/Paragraph.tsx
@@ -1,11 +1,9 @@
-import { type HTMLAttributes } from 'react';
-
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../../types';
 import {
-  type BaseTypographyProps,
+  type CommonBlockTypographyProps,
   Typography,
   type TypographyBodyType,
   type TypographyLeadType,
@@ -18,8 +16,7 @@ export type ParagraphProps = BaseComponentPropsWithChildren<
      * @default 'BodyLongMedium'
      */
     typographyType?: TypographyBodyType | TypographyLeadType;
-  } & BaseTypographyProps,
-  Omit<HTMLAttributes<HTMLParagraphElement>, 'color'>
+  } & CommonBlockTypographyProps
 >;
 
 export const Paragraph = ({

--- a/packages/dds-components/src/components/Typography/Typography/Typography.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.stories.tsx
@@ -2,7 +2,7 @@ import preview from '#.storybook/preview';
 
 import { Typography } from '..';
 import { categoryHtml } from '../../../storybook';
-import { storyTypographyHtmlAttrs } from '../storyUtils';
+import { blockTgCommonArgTypes } from '../storyUtils';
 
 const meta = preview.meta({
   title: 'dds-components/Components/Typography/Typography',
@@ -13,7 +13,7 @@ const meta = preview.meta({
     href: { control: 'text', table: categoryHtml },
     target: { control: false, table: categoryHtml },
     as: { control: 'text' },
-    ...storyTypographyHtmlAttrs,
+    ...blockTgCommonArgTypes,
   },
 });
 

--- a/packages/dds-components/src/components/Typography/Typography/Typography.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.tsx
@@ -14,7 +14,6 @@ import {
   isCaption,
   isLegend,
 } from './Typography.utils';
-import { ElementAs } from '../../../polymorphic';
 import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
@@ -24,6 +23,7 @@ import { getTextColor, isTextColor } from '../../../utils/color';
 import { focusable } from '../../helpers/styling/focus.module.css';
 import { Icon } from '../../Icon';
 import { OpenExternalIcon } from '../../Icon/icons';
+import { Box } from '../../layout';
 import typographyStyles from '../typographyStyles.module.css';
 
 type AnchorTypographyProps = BaseComponentPropsWithChildren<
@@ -103,7 +103,7 @@ export const Typography = (props: TypographyProps) => {
   }
 
   return (
-    <ElementAs
+    <Box
       {...getBaseHTMLProps(
         id,
         cn(
@@ -136,7 +136,7 @@ export const Typography = (props: TypographyProps) => {
     >
       {children}
       {externalLinkProp && <Icon icon={OpenExternalIcon} iconSize="inherit" />}
-    </ElementAs>
+    </Box>
   );
 };
 

--- a/packages/dds-components/src/components/Typography/Typography/Typography.types.ts
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.types.ts
@@ -1,6 +1,8 @@
 import { type ElementType } from 'react';
 
+import { type ExtractStrict } from '../../../types';
 import { type TextColor } from '../../../utils/color';
+import { type ResponsiveProps } from '../../layout';
 
 export type TypographyBodyShortType =
   | 'bodyShortXsmall'
@@ -123,6 +125,28 @@ export type InlineElement =
   | 'video'
   | 'wbr';
 
+export type BlockTypographyResponsiveProps = Pick<
+  ResponsiveProps,
+  | 'textAlign'
+  | 'wordBreak'
+  | 'display'
+  | 'margin'
+  | 'marginBlock'
+  | 'maxWidth'
+  | 'width'
+  | 'minWidth'
+>;
+
+export type InlineTypographyResponsiveProps = Pick<
+  BlockTypographyResponsiveProps,
+  'wordBreak' | 'textAlign' | 'marginBlock'
+> & {
+  display?: ExtractStrict<
+    ResponsiveProps['display'],
+    'block' | 'inline' | 'inline-block'
+  >;
+};
+
 export interface BaseTypographyProps {
   /**Tekstfarge fra utvalget eller custom. **OBS!** Bruk farger fra `@dds-design-tokens` med navn i kebab-case, f.eks. `text-subtle`. */
   color?: TextColor;
@@ -134,7 +158,12 @@ export interface BaseTypographyProps {
   withMargins?: boolean;
 }
 
-export type TypographyComponentProps = BaseTypographyProps & {
+export interface CommonInlineTypographyProps
+  extends BaseTypographyProps, InlineTypographyResponsiveProps {}
+export interface CommonBlockTypographyProps
+  extends BaseTypographyProps, BlockTypographyResponsiveProps {}
+
+export type TypographyComponentProps = CommonBlockTypographyProps & {
   /**Setter `bold` styling. */
   bold?: boolean;
   /**Setter `italic` styling. */

--- a/packages/dds-components/src/components/Typography/storyUtils.tsx
+++ b/packages/dds-components/src/components/Typography/storyUtils.tsx
@@ -1,9 +1,58 @@
 import { type ArgTypes } from '@storybook/react-vite';
 
-import { commonArgTypes, htmlArgType } from '../../storybook';
+import {
+  type BlockTypographyResponsiveProps,
+  type InlineTypographyResponsiveProps,
+} from './Typography';
+import {
+  type ResponsiveArgTypes,
+  commonArgTypes,
+  htmlArgType,
+  responsivePropsArgTypes,
+} from '../../storybook';
 
-export const storyTypographyHtmlAttrs: ArgTypes = {
+const {
+  wordBreak,
+  textAlign,
+  margin,
+  marginBlock,
+  display,
+  maxWidth,
+  width,
+  minWidth,
+} = responsivePropsArgTypes;
+
+const blockTgResponsiveArgTypes: ResponsiveArgTypes<BlockTypographyResponsiveProps> =
+  {
+    wordBreak,
+    textAlign,
+    margin,
+    marginBlock,
+    display,
+    maxWidth,
+    width,
+    minWidth,
+  };
+
+const inlineTgResponsiveArgTypes: ResponsiveArgTypes<InlineTypographyResponsiveProps> =
+  {
+    wordBreak,
+    textAlign,
+    marginBlock,
+  };
+
+export const tgCommonArgTypes: ArgTypes = {
   ...commonArgTypes,
   style: htmlArgType,
   color: { control: { type: 'text' } },
+};
+
+export const inlineTgCommonArgTypes: ArgTypes = {
+  ...tgCommonArgTypes,
+  ...inlineTgResponsiveArgTypes,
+};
+
+export const blockTgCommonArgTypes: ArgTypes = {
+  ...tgCommonArgTypes,
+  ...blockTgResponsiveArgTypes,
 };

--- a/packages/dds-components/src/storybook/args.utils.tsx
+++ b/packages/dds-components/src/storybook/args.utils.tsx
@@ -12,7 +12,7 @@ export interface ArgType {
   table?: { category: string };
 }
 
-type ResponsiveArgTypes<T> = {
+export type ResponsiveArgTypes<T> = {
   [k in keyof T]: ArgType;
 };
 


### PR DESCRIPTION
## Beskrivelse

Støtte for utvalgte responsive props i alle typografikomponenter:

- `textAlign`, `wordBreak`, `display`, `margin`, `marginBlock`, `maxWidth`, `width`, `minWidth` i `<Heading>`, `<Legend>`, `<Caption>`, `<Paragraph>` og `<Typography>`.
- `textAlign`, `wordBreak`, `display`, `marginBlock` i `<Link>` og `<Label>`.

I samme slengen: rydder oppi type overloads i typografikomponenter.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
