### PR TITLE
ELSA1-864: clipping av OverflowMenu vid bruk av boxshadow

### DIFF
--- a/.changeset/spotty-fans-stare.md
+++ b/.changeset/spotty-fans-stare.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Legger til `portal` og `parentElement` props/funksjonalitet i `OverflowMenu.tsx` for å unngå klipping. `portal` gjør at menyen rendres i body, og `parentElement` gjør at menyen rendres i det elementet som er satt som parentElement. Default verdi for `portal=true`, og default verdi for `parentElement=themeProviderRef`. Hvis `portal=true`, vil `parentElement` bli ignorert. Hvis `portal=false`, vil `parentElement` bli brukt hvis det er satt, ellers vil menyen rendres i det elementet som `OverflowMenu.tsx` er plassert i.

--- a/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/dds-components/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -108,7 +108,7 @@ export const Breadcrumbs = ({
                   : t(texts.showHidden)
               }
             />
-            <OverflowMenu>
+            <OverflowMenu portal={false}>
               <OverflowMenuList>{bChildrenTruncated}</OverflowMenuList>
             </OverflowMenu>
           </OverflowMenuGroup>

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.spec.tsx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.spec.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
+
+import { portalRender } from '../../test.utils';
 
 import { InternalHeader } from '.';
 
@@ -14,7 +16,7 @@ const link = {
 describe('<InternalHeader>', () => {
   it('displays application name', () => {
     const appName = 'appName';
-    render(<InternalHeader applicationName={appName} />);
+    portalRender(<InternalHeader applicationName={appName} />);
     const appNameElement = screen.getByText(appName);
     expect(appNameElement).toBeInTheDocument();
   });
@@ -25,7 +27,7 @@ describe('<InternalHeader>', () => {
       children: 'action',
       onClick: event,
     };
-    render(<InternalHeader contextMenuItems={[element]} />);
+    portalRender(<InternalHeader contextMenuItems={[element]} />);
     const contextMenuButton = screen.getByRole('button');
     await userEvent.click(contextMenuButton!);
     const contextMenuLink = screen.getByRole('menuitem');
@@ -34,7 +36,7 @@ describe('<InternalHeader>', () => {
   });
 
   it('has a link in navigation', () => {
-    render(<InternalHeader navItems={[link]} />);
+    portalRender(<InternalHeader navItems={[link]} />);
     const navigationLink = screen.getByRole('link');
     expect(navigationLink).toHaveAttribute('href', href);
   });
@@ -45,13 +47,13 @@ describe('<InternalHeader>', () => {
       ...link,
       target: target,
     };
-    render(<InternalHeader navItems={[element]} />);
+    portalRender(<InternalHeader navItems={[element]} />);
     const navigationLink = screen.getByRole('link');
     expect(navigationLink).toHaveAttribute('target', target);
   });
 
   it('has a link in context menu', async () => {
-    render(<InternalHeader contextMenuItems={[link]} />);
+    portalRender(<InternalHeader contextMenuItems={[link]} />);
 
     const contextMenuButton = screen.getByRole('button');
     await userEvent.click(contextMenuButton);
@@ -61,7 +63,9 @@ describe('<InternalHeader>', () => {
   });
 
   it('has a nav link in context menu', async () => {
-    render(<InternalHeader navItems={[link]} smallScreenBreakpoint="xl" />);
+    portalRender(
+      <InternalHeader navItems={[link]} smallScreenBreakpoint="xl" />,
+    );
     const burgerButton = screen.getByRole('button');
     await userEvent.click(burgerButton);
     const navigationLink = screen.getByRole('menuitem', {
@@ -76,7 +80,7 @@ describe('<InternalHeader>', () => {
       children: name,
     };
 
-    render(<InternalHeader user={user} />);
+    portalRender(<InternalHeader user={user} />);
     const element = screen.getByText(name);
     expect(element).toBeInTheDocument();
   });
@@ -89,7 +93,7 @@ describe('<InternalHeader>', () => {
       href: href,
     };
 
-    render(<InternalHeader user={user} />);
+    portalRender(<InternalHeader user={user} />);
     const element = screen.getByText(name);
     expect(element).toHaveAttribute('href', href);
   });

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.mdx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.mdx
@@ -168,6 +168,14 @@ const onOpen = () => {
 </OverflowMenuGroup>
 `} />
 
+### Portal og clipping
+
+`<OverflowMenu>` bruker portal som default for å unngå clipping fra parent med begrenset høyde/bredde eller `overflow: hidden`. Hvis du trenger at menyen skal rendres inline i samme container kan du bruke `portal={false}`.
+
+<Canvas>
+  <Story of={OverflowMenuStories.PortalClippingComparison} />
+</Canvas>
+
 ### Kontrollert
 
 <Source

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.spec.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.spec.tsx
@@ -1,7 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
+import { portalRender } from '../../test.utils';
 import { Button } from '../Button';
 
 import {
@@ -43,18 +44,18 @@ function TestComponent({ link, item, span }: props) {
 
 describe('<OverflowMenu>', () => {
   it('renders context menu item as link', () => {
-    render(<TestComponent link={link} />);
+    portalRender(<TestComponent link={link} />);
     const aElement = screen.getByText(text);
     expect(aElement).toBeInTheDocument();
     expect(aElement).toHaveAttribute('href', href);
   });
   it('renders static username', () => {
-    render(<TestComponent span={{ children: text }} />);
+    portalRender(<TestComponent span={{ children: text }} />);
     const element = screen.getByText(text);
     expect(element).toBeInTheDocument();
   });
   it('should show OverflowMenu on button click', async () => {
-    render(<TestComponent />);
+    portalRender(<TestComponent />);
     const menu = screen.queryByRole('menu');
     expect(menu).not.toBeInTheDocument();
     const menuButton = screen.getByRole('button');
@@ -67,7 +68,7 @@ describe('<OverflowMenu>', () => {
 
   it('calls onClose event on button click', async () => {
     const event = vi.fn();
-    render(
+    portalRender(
       <OverflowMenuGroup onClose={event}>
         <Button />
         <OverflowMenu />
@@ -84,7 +85,7 @@ describe('<OverflowMenu>', () => {
 
   it('calls onOpen event button click', async () => {
     const event = vi.fn();
-    render(
+    portalRender(
       <OverflowMenuGroup onOpen={event}>
         <Button />
         <OverflowMenu />
@@ -98,7 +99,7 @@ describe('<OverflowMenu>', () => {
   });
 
   it('hides menu after Esc keydown', async () => {
-    render(<TestComponent />);
+    portalRender(<TestComponent />);
     const menuButton = screen.getByRole('button');
     await userEvent.click(menuButton!);
     const menuOpened = screen.getByRole('menu');
@@ -110,9 +111,44 @@ describe('<OverflowMenu>', () => {
     expect(elQuery).not.toBeInTheDocument();
   });
 
+  it('renders menu in portal by default', async () => {
+    const { container } = portalRender(
+      <div data-testid="host">
+        <OverflowMenuGroup>
+          <Button />
+          <OverflowMenu />
+        </OverflowMenuGroup>
+      </div>,
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+    const menu = screen.getByRole('menu');
+    const host = screen.getByTestId('host');
+    expect(menu).toBeInTheDocument();
+    expect(host.contains(menu)).toBe(false);
+    expect(container.contains(menu)).toBe(true);
+  });
+
+  it('renders menu inline when portal is disabled', async () => {
+    portalRender(
+      <div data-testid="host">
+        <OverflowMenuGroup>
+          <Button />
+          <OverflowMenu portal={false} />
+        </OverflowMenuGroup>
+      </div>,
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+    const menu = screen.getByRole('menu');
+    const host = screen.getByTestId('host');
+    expect(menu).toBeInTheDocument();
+    expect(host.contains(menu)).toBe(true);
+  });
+
   describe('<OverflowMenuButton>', () => {
     it('renders context menu item as button', () => {
-      render(<TestComponent item={item} />);
+      portalRender(<TestComponent item={item} />);
       const buttonElement = screen.getByRole('button');
       expect(buttonElement).toBeInTheDocument();
     });
@@ -120,7 +156,7 @@ describe('<OverflowMenu>', () => {
     it('calls onClick event from context menu', async () => {
       const event = vi.fn();
       const item = { children: text, onClick: event };
-      render(<TestComponent item={item} />);
+      portalRender(<TestComponent item={item} />);
 
       const menuButton = screen.getByRole('button');
       await userEvent.click(menuButton);
@@ -131,7 +167,7 @@ describe('<OverflowMenu>', () => {
     });
     it('calls onClickAsync and close menu after it resolves', async () => {
       const asyncClick = vi.fn(() => Promise.resolve());
-      render(
+      portalRender(
         <TestComponent item={{ children: text, onClickAsync: asyncClick }} />,
       );
 
@@ -156,7 +192,7 @@ describe('<OverflowMenu>', () => {
           }),
       );
 
-      render(
+      portalRender(
         <TestComponent item={{ children: text, onClickAsync: asyncClick }} />,
       );
 
@@ -185,7 +221,7 @@ describe('<OverflowMenu>', () => {
           }),
       );
 
-      render(
+      portalRender(
         <TestComponent item={{ children: text, onClickAsync: asyncClick }} />,
       );
 

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -13,10 +13,10 @@ import {
   PersonIcon,
   TrashIcon,
 } from '../Icon/icons';
-import { VStack } from '../layout';
+import { HStack, VStack } from '../layout';
 import { Table } from '../Table';
 import { Paragraph } from '../Typography';
-import { OverflowMenuToggle } from './components/OverflowMenuToggle';
+import { OverflowMenuToggle } from './components';
 
 import {
   OverflowMenu,
@@ -279,6 +279,63 @@ export const WithinTable = meta.story({
             </Table.Row>
           </Table.Body>
         </Table>
+      </VStack>
+    );
+  },
+});
+
+export const PortalClippingComparison = meta.story({
+  parameters: {
+    docs: { story: { height: '540px' } },
+    chromatic: { disableSnapshot: true },
+  },
+  render: args => {
+    const clippingBoxStyle = {
+      border: '1px solid var(--dds-color-border-subtle)',
+      borderRadius: 'var(--dds-border-radius-surface)',
+      width: '220px',
+      height: '120px',
+      overflow: 'hidden' as const,
+      padding: 'var(--dds-spacing-x0-5)',
+      position: 'relative' as const,
+    };
+
+    const menuContent = (
+      <OverflowMenuList>
+        <OverflowMenuLink icon={EditIcon}>Rediger</OverflowMenuLink>
+        <OverflowMenuButton icon={TrashIcon} purpose="danger">
+          Slett
+        </OverflowMenuButton>
+      </OverflowMenuList>
+    );
+
+    return (
+      <VStack>
+        <HStack gap="x2" alignItems="start">
+          <VStack gap="x0-5">
+            <Paragraph typographyType="bodyShortMedium">
+              Portal (default)
+            </Paragraph>
+            <div style={clippingBoxStyle}>
+              <OverflowMenuGroup isInitiallyOpen>
+                <Button icon={MoreVerticalIcon} aria-label="Åpne meny" />
+                <OverflowMenu {...args}>{menuContent}</OverflowMenu>
+              </OverflowMenuGroup>
+            </div>
+          </VStack>
+
+          <VStack gap="x0-5">
+            <Paragraph typographyType="bodyShortMedium">Portal av</Paragraph>
+            <div style={clippingBoxStyle}>
+              <OverflowMenuGroup isInitiallyOpen>
+                <Button icon={MoreVerticalIcon} aria-label="Åpne meny" />
+                <OverflowMenu {...args} portal={false}>
+                  {menuContent}
+                </OverflowMenu>
+              </OverflowMenuGroup>
+            </div>
+          </VStack>
+        </HStack>
       </VStack>
     );
   },

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 
 import { useOverflowMenuContext } from './OverflowMenu.context';
 import styles from './OverflowMenu.module.css';
@@ -7,6 +8,7 @@ import { getBaseHTMLProps } from '../../types';
 import { cn } from '../../utils';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { Paper } from '../layout';
+import { ThemeContext } from '../ThemeProvider';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 import { type OverflowMenuProps } from '.';
@@ -14,6 +16,8 @@ import { type OverflowMenuProps } from '.';
 export const OverflowMenu = ({
   placement = 'bottom-end',
   offset = 2,
+  parentElement,
+  portal = true,
   className,
   htmlProps = {},
   ref,
@@ -22,13 +26,20 @@ export const OverflowMenu = ({
 }: OverflowMenuProps) => {
   const { isOpen, floatStyling, setFloatOptions, menuRef, menuId } =
     useOverflowMenuContext();
+  const themeContext = useContext(ThemeContext);
+
+  if (portal && !themeContext) {
+    throw new Error('OverflowMenu must be used within a DdsProvider');
+  }
+
+  const portalTarget = parentElement ?? themeContext?.el;
 
   useEffect(() => {
     setFloatOptions?.({ placement, offset });
   }, [placement, offset]);
   const openCn = isOpen ? 'open' : 'closed';
 
-  return (
+  const menu = (
     <Paper
       overflowY="auto"
       minWidth="180px"
@@ -54,6 +65,8 @@ export const OverflowMenu = ({
       border="border-default"
     />
   );
+
+  return portal && portalTarget ? createPortal(menu, portalTarget) : menu;
 };
 
 OverflowMenu.displayName = 'OverflowMenu';

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.types.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.types.tsx
@@ -39,6 +39,17 @@ export type OverflowMenuProps = Omit<
        * @default 2
        */
       offset?: number;
+      /**Angir rotnode hvor menyen skal rendres hvis portal=false.
+       * Hvis parentElement ikke er satt vil menyen rendres i det elementet som OverflowMenu er plassert i.
+       * Hvis portal er true, vil parentElement bli ignorert.
+       * @default themeProviderRef
+       */
+      parentElement?: HTMLElement;
+      /**Angir om menyen skal rendres i en portal eller ikke.
+       * Hvis portal er false, vil parentElement bli brukt hvis det er satt.
+       * @default true
+       */
+      portal?: boolean;
     }
   >,
   'id'

--- a/packages/dds-components/src/components/SplitButton/SplitButton.spec.tsx
+++ b/packages/dds-components/src/components/SplitButton/SplitButton.spec.tsx
@@ -1,6 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
+
+import { portalRender } from '../../test.utils';
 
 import {
   SplitButton,
@@ -20,12 +22,16 @@ const item: SplitButtonSecondaryActionsProps = [
 
 describe('<SplitButton>', () => {
   it('renders two buttons', () => {
-    render(<SplitButton primaryAction={primary} secondaryActions={item} />);
+    portalRender(
+      <SplitButton primaryAction={primary} secondaryActions={item} />,
+    );
     const buttons = screen.getAllByRole('button');
     expect(buttons).toHaveLength(2);
   });
   it('shows OverflowMenu on menu button click', async () => {
-    render(<SplitButton primaryAction={primary} secondaryActions={item} />);
+    portalRender(
+      <SplitButton primaryAction={primary} secondaryActions={item} />,
+    );
     const menu = screen.queryByRole('menu');
     expect(menu).not.toBeInTheDocument();
     const menuButton = screen.getByLabelText('Flere handlinger');
@@ -38,7 +44,7 @@ describe('<SplitButton>', () => {
 
   it('calls onclick event from primary action button', async () => {
     const event = vi.fn();
-    render(
+    portalRender(
       <SplitButton
         primaryAction={{ children: primaryText, onClick: event }}
         secondaryActions={item}
@@ -53,7 +59,7 @@ describe('<SplitButton>', () => {
 
   it('calls onclick event from context menu', async () => {
     const event = vi.fn();
-    render(
+    portalRender(
       <SplitButton
         primaryAction={primary}
         secondaryActions={[{ children: itemText, onClick: event }]}
@@ -67,7 +73,9 @@ describe('<SplitButton>', () => {
   });
 
   it('hides menu after Esc keydown', async () => {
-    render(<SplitButton secondaryActions={item} primaryAction={primary} />);
+    portalRender(
+      <SplitButton secondaryActions={item} primaryAction={primary} />,
+    );
     const menuButton = screen.getByLabelText('Flere handlinger');
     fireEvent.click(menuButton!);
     const menuOpened = screen.getByRole('menu');


### PR DESCRIPTION
## Beskrivelse
### Problem:
Da hover triggerd boxshadow for ett element under renderes boxshadow i en annen paint/stack context enn menyen så context boundaries slår rå z-index → boxshadow dekker OverflowMenu.

### Løsning:
- OverflowMenu rendres nå i portal som standard for å unngå clipping fra overflow: hidden/stacking context 
- Nye props i OverflowMenu: `portal?: boolean (default true)` og `parentElement?: HTMLElement` for å styre portal-target 

- Tester lagt til for å verifisere:
  - default portal-rendering (meny havner utenfor host/container),
  - inline rendering når portal={false} 

- Ny Storybook-story som viser side-by-side forskjell:
  - `portal=true` (default) vs `portal=false` av i en container med overflow: hidden
  
- Docs oppdatert med seksjon “Portal og clipping” og referanse til story
- Changeset lagt til med minor bump for @norges-domstoler/dds-components 

I storybook:
<img width="678" height="404" alt="storybook-overflowmenu" src="https://github.com/user-attachments/assets/927aeece-9469-48fb-a8a2-876b14735cd8" />


I nya Lovisa: 
<img width="1005" height="209" alt="nyaLovisa-overflowmenu" src="https://github.com/user-attachments/assets/27bb4ceb-26fa-494d-b226-d64412d70e04" />


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357) (Tildelt selv)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)