### PR TITLE
Uten issue: fikser visning av tekst i Sjekk svar-mønster

### DIFF
--- a/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswers.stories.tsx
+++ b/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswers.stories.tsx
@@ -289,11 +289,15 @@ export const CheckAnswers = () => {
             color="text-subtle"
             withMargins
           >
-            Obligatoriske felter er merket med{' '}
-            <Typography as="span" color="text-requiredfield">
-              *
-            </Typography>
-            .
+            {activeStep !== steps.length - 1 && (
+              <>
+                Obligatoriske felter er merket med{' '}
+                <Typography as="span" color="text-requiredfield">
+                  *
+                </Typography>
+                .
+              </>
+            )}
           </Paragraph>
           <VStack
             gap="x1"


### PR DESCRIPTION

## Beskrivelse

Info om markering av påkrevde felt skal ikke vises oppsummeringssiden, der er det ingen felt å fylle ut.

Før:

<img width="1072" height="1002" alt="bilde" src="https://github.com/user-attachments/assets/9db5a480-7ef6-46b9-ab7b-f288149a2c77" />

Etter:

<img width="1159" height="957" alt="bilde" src="https://github.com/user-attachments/assets/92c45f5a-95e0-4760-b849-09766ece881a" />


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
