### PR TITLE
ELSA1-819: Fjerner støtte for props som indikerer ekstern lenke

### DIFF
--- a/.changeset/beige-geese-smile.md
+++ b/.changeset/beige-geese-smile.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': major
+---
+
+Fjerner støtte for `external` prop i `<Link>` og `externalLink` i `<Typography>`. Vi følger retningslinjene til uutilsynet om at lenker til eksterne sider ikke åpnes i ny fane. Dersom det er nødvendig at innholdet skal åpnes i ny fane, anbefales det at brukeren blir forhåndsvarslet direkte i lenketeksten. Se mer i [Lenker | uutilsynet](https://www.uutilsynet.no/veiledning/lenker/214) og [Elsas retningslinjer](https://design.domstol.no/987b33f71/p/411e45-link/t/43f76b).

--- a/.changeset/cool-mugs-bathe.md
+++ b/.changeset/cool-mugs-bathe.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for `withIconStyling` prop i `<Link>`. Setter styling for inline svg som er barn i `<Link>`. Brukes i kombinasjon med `<Icon>`-komponent.

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.mdx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.mdx
@@ -29,7 +29,7 @@ import meta from './CookieBanner.stories';
 
 ### Ekomloven § 3-15
 
-Bruk komponenten i samsvar med <Link external href="https://www.datatilsynet.no/personvern-pa-ulike-omrader/internett-og-apper/bruk-av-informasjonskapsler-og-andre-sporingsteknologier/"> Datatilsynets veiledning</Link>.
+Bruk komponenten i samsvar med [Datatilsynets veiledning (datatilsynet.no)](https://www.datatilsynet.no/personvern-pa-ulike-omrader/internett-og-apper/bruk-av-informasjonskapsler-og-andre-sporingsteknologier/).
 
 ### Plassering i koden
 
@@ -38,7 +38,7 @@ Brukeren skal kunne ta avgjørelser rundt informasjonskaplser som en av de førs
 ### Visuell plassering
 
 Banner bør ligge i nedre venstre hjørne, slik at den følger leserekkefølgen og er synlig nok, og samtidig ikke er i veien for resten av nettsiden. Bruk dedikerte CSS props til dette.
-Den kan gjerne plasseres med ulik avstand fra kanten av nettleservinduet for hvert brekkpunkt. <Link external href="https://domstolene.github.io/designsystem/iframe.html?args=&globals=&id=dds-components-components-cookiebanner--placement-with-checkboxes&viewMode=story"> Åpne eksempelet under i eget vindu for mer realistisk oppførsel</Link>.
+Den kan gjerne plasseres med ulik avstand fra kanten av nettleservinduet for hvert brekkpunkt. <Link target='_blank' href="https://domstolene.github.io/designsystem/iframe.html?args=&globals=&id=dds-components-components-cookiebanner--placement-with-checkboxes&viewMode=story"> Åpne eksempelet under i eget vindu for mer realistisk oppførsel (åpner ny fane)</Link>.
 
 <Canvas of={CookieBannerStories.PlacementWithCheckboxes} />
 

--- a/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
+++ b/packages/dds-components/src/components/FavStar/FavStar.stories.tsx
@@ -154,12 +154,7 @@ export const RealWorld = meta.story({
                   )}
                 </Table.Cell>
                 <Table.Cell>
-                  <Link
-                    href="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-                    external
-                  >
-                    {document.name}
-                  </Link>
+                  <Link href="domstol.no">{document.name}</Link>
                 </Table.Cell>
                 <Table.Cell>{document.from}</Table.Cell>
                 <Table.Cell>{document.to}</Table.Cell>

--- a/packages/dds-components/src/components/Icon/Icon.mdx
+++ b/packages/dds-components/src/components/Icon/Icon.mdx
@@ -15,7 +15,7 @@ import meta from './Icon.stories';
   storybookHref={{ folder: 'components', comp: 'icon' }}
 />
 
-`<Icon>` er en code-only komponent som tar inn et svg-ikon fra <LinkTo title="Icons/Overview" story="Overview">ikonutvalget</LinkTo> og returnerer den med riktig størrelse og annen styling. Les mer om hvilke ikoner vi bruker og retningslinjer under <Link href="https://design.domstol.no/987b33f71/p/27770f-ikoner" external>Ikoner</Link>.
+`<Icon>` er en code-only komponent som tar inn et svg-ikon fra <LinkTo title="Icons/Overview" story="Overview">ikonutvalget</LinkTo> og returnerer den med riktig størrelse og annen styling. Les mer om hvilke ikoner vi bruker og retningslinjer under [Ikoner (design.domstol.no)](https://design.domstol.no/987b33f71/p/27770f-ikoner).
 
 ## Props
 

--- a/packages/dds-components/src/components/Select/Select.mdx
+++ b/packages/dds-components/src/components/Select/Select.mdx
@@ -27,7 +27,7 @@ Komponenten har to varianter:
 
 ## API
 
-Komponenten bruker <Link href="https://react-select.com/home" external>React-select</Link>. Det støttes props definert i designsystemet (Elsa props) og native React-select props.
+Komponenten bruker [React-select (react-select.com)](https://react-select.com/home). Det støttes props definert i designsystemet (Elsa props) og native React-select props.
 
 <Canvas of={SelectStories.Preview} />
 
@@ -39,7 +39,7 @@ Tabellen inkluderer native HTML props som brukes til styling.
 
 ### Native React-select props
 
-Full liste over props er tilgjengelig i <Link href="https://react-select.com/props" external>react-select API</Link>. Ofte brukt native props:
+Full liste over props er tilgjengelig i [react-select API (react-select.com)](https://react-select.com/props). Ofte brukt native props:
 
 <Table.Wrapper>
   <Table size='small'>

--- a/packages/dds-components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
+++ b/packages/dds-components/src/components/Table/collapsible/CollapsibleTable.stories.tsx
@@ -384,7 +384,7 @@ export const Example = meta.story({
               <Icon icon={JordskifterettIcon} iconSize={iconSize} />
             </Table.Cell>
             <Table.Cell>
-              <Link external href="/">
+              <Link href="/">
                 Krav om sak fra Marie Luneby, Knut-Håkon Dagsvik, Sonja Luneby
                 og Petter Olaf Jensen.pdf
               </Link>
@@ -403,9 +403,7 @@ export const Example = meta.story({
             <Table.Cell>1-2</Table.Cell>
             <Table.Cell></Table.Cell>
             <Table.Cell>
-              <Link external href="/">
-                Merknader fra Knut-Håkon Dagsvik.pdf
-              </Link>
+              <Link href="/">Merknader fra Knut-Håkon Dagsvik.pdf</Link>
             </Table.Cell>
             <Table.Cell>Akershus og Oslo jordskifterett</Table.Cell>
             <Table.Cell> Maake Karl</Table.Cell>

--- a/packages/dds-components/src/components/Typography/Link/Link.mdx
+++ b/packages/dds-components/src/components/Typography/Link/Link.mdx
@@ -71,5 +71,12 @@ import { Link } from '@norges-domstoler/dds-components';
 
 ## Retningslinjer
 
-- En lenke må ha `href` prop for assisterende teknologi skal tolke elementet riktig.
-- Komponenten brukes kun til sematiske lenker, likke knapper el.l.. som ser ut som lenke.
+### Ny fane
+
+Lenker skal typisk ikke åpnes i ny fane. Unntak inkluderer forstyrring av flertrinns arbeidsflyt og lenker utenfor sikret område. I slike tilfeller brukes standard `target="_blank"` og tekstlig indikator:
+
+<Canvas of={LinkStories.NewTab} />
+
+### Ting kodes som det ser ut som
+
+En lenke må ha `href` prop for assisterende teknologi skal tolke elementet riktig. Komponenten brukes kun til sematiske lenker, ikke knapper el.l.. som ser ut som lenke. Lenke-komponenter fra rutingrammeverk er innafor.

--- a/packages/dds-components/src/components/Typography/Link/Link.spec.tsx
+++ b/packages/dds-components/src/components/Typography/Link/Link.spec.tsx
@@ -14,12 +14,12 @@ describe('<Link>', () => {
     render(<Link href="/" />);
     expect(screen.getByRole('link')).toBeInTheDocument();
   });
-  it('should open on new page', () => {
-    render(<Link href="/" external />);
+  it('should have target attr', () => {
+    render(<Link href="/" target="_blank" />);
     expect(screen.getByRole('link')).toHaveAttribute('target', '_blank');
   });
   it('has noopener noreferrer', () => {
-    render(<Link href="/" external />);
+    render(<Link href="/" />);
     expect(screen.getByRole('link')).toHaveAttribute(
       'rel',
       'noopener noreferrer',

--- a/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
@@ -12,6 +12,8 @@ import { Paragraph } from '../Paragraph';
 import { inlineTgCommonArgTypes } from '../storyUtils';
 
 import { Link } from '.';
+import { Icon } from '../../Icon';
+import { TipIcon } from '../../Icon/icons';
 
 const meta = preview.meta({
   title: 'dds-components/Components/Typography/Link',
@@ -39,17 +41,29 @@ export const Variants = meta.story({
   args: showcaseProps,
   render: args => (
     <StoryVStack>
-      <Link {...args} external>
-        External
-      </Link>
       <Link {...args} withVisited>
         Med visited styling
       </Link>
       <Link {...args} color="text-medium">
         Custom farge
       </Link>
+      <Link {...args} withIconStyling>
+        Med ikon-styling
+        <Icon icon={TipIcon} iconSize="inherit" />
+      </Link>
     </StoryVStack>
   ),
+});
+
+export const NewTab = meta.story({
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  args: {
+    ...showcaseProps,
+    children: 'Norges domstoler (åpnes i ny fane)',
+    target: '_blank',
+  },
 });
 
 export const As = meta.story({

--- a/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Link/Link.stories.tsx
@@ -7,13 +7,13 @@ import {
   htmlArgType,
   htmlEventArgType,
 } from '../../../storybook';
+import { Icon } from '../../Icon';
+import { TipIcon } from '../../Icon/icons';
 import { StoryVStack } from '../../layout/Stack/utils';
 import { Paragraph } from '../Paragraph';
 import { inlineTgCommonArgTypes } from '../storyUtils';
 
 import { Link } from '.';
-import { Icon } from '../../Icon';
-import { TipIcon } from '../../Icon/icons';
 
 const meta = preview.meta({
   title: 'dds-components/Components/Typography/Link',
@@ -86,21 +86,20 @@ export const InText = meta.story({
       aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
       voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur
       sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt
-      mollit anim id est laborum. Lorem ipsum <Link {...args} external /> dolor
-      sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-      labore et dolore <Link {...args} /> magna aliqua. Ut enim ad minim veniam,
-      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
-      consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
-      cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
-      non proident, sunt in culpa qui officia deserunt mollit anim id est
-      laborum.Lorem <Link {...args} external /> ipsum dolor sit amet,
+      mollit anim id est laborum. Lorem ipsum <Link {...args} /> dolor sit amet,
       consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
       dolore <Link {...args} /> magna aliqua. Ut enim ad minim veniam, quis
       nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
       consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
       cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
       non proident, sunt in culpa qui officia deserunt mollit anim id est
-      laborum.
+      laborum.Lorem <Link {...args} /> ipsum dolor sit amet, consectetur
+      adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+      <Link {...args} /> magna aliqua. Ut enim ad minim veniam, quis nostrud
+      exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis
+      aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+      fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+      sunt in culpa qui officia deserunt mollit anim id est laborum.
     </Paragraph>
   ),
 });

--- a/packages/dds-components/src/components/Typography/Link/Link.tsx
+++ b/packages/dds-components/src/components/Typography/Link/Link.tsx
@@ -7,8 +7,6 @@ import {
 } from '../../../types';
 import { cn, getTextColor, isTextColor } from '../../../utils';
 import { focusable } from '../../helpers/styling/focus.module.css';
-import { Icon } from '../../Icon';
-import { OpenExternalIcon } from '../../Icon/icons';
 import {
   type CommonInlineTypographyProps,
   type TypographyBodyType,
@@ -26,14 +24,19 @@ export type LinkProps<T extends ElementType = 'a'> =
   PolymorphicBaseComponentProps<
     T,
     {
-      /**Spesifiserer om lenken fører til et eksternt nettsted eller åpnes i nytt vindu. Påvirker styling og setter `target` prop. */
-      external?: boolean;
       /**Om lenken kan få `:visited`-styling. */
       withVisited?: boolean;
       /**Spesifiserer typografistil basert på utvalget for brødtekst. Arver hvis ikke oppgitt. */
       typographyType?: TypographyBodyType;
-      /**Tvinger komponenten til å behandle `as` som en anchor tag wrapper og forwarde anchor-spesifikke props (target, rel). Bruk når custom `as` komponent wrapper en `<a>` tag. */
+      /**
+       * Tvinger komponenten til å behandle `as` som en anchor tag wrapper og forwarde anchor-spesifikke props (target, rel).
+       * Bruk når custom `as` komponent wrapper en `<a>` tag.
+       * */
       isAnchor?: boolean;
+      /**Om styling for inline ikon skal gjelde.
+       * Ikon kan legges inn som barn ved siden av teksten med `<Icon>`-komponent.
+       * */
+      withIconStyling?: boolean;
     } & CommonInlineTypographyProps &
       PickedHTMLAttributes
   >;
@@ -46,12 +49,11 @@ export const Link = <T extends ElementType = 'a'>({
   typographyType,
   withMargins,
   withVisited,
-  external,
-  target,
   style,
   color,
   as: propAs,
   isAnchor: propIsAnchor,
+  withIconStyling,
   ...rest
 }: LinkProps<T>) => {
   const as = propAs ? propAs : 'a';
@@ -60,7 +62,6 @@ export const Link = <T extends ElementType = 'a'>({
   const aProps = isAnchor
     ? {
         rel: 'noopener noreferrer',
-        target: external ? '_blank' : target,
       }
     : {};
 
@@ -72,7 +73,7 @@ export const Link = <T extends ElementType = 'a'>({
         cn(
           className,
           tgStyles.a,
-          external && tgStyles['a--external'],
+          withIconStyling && tgStyles['a--with-icon'],
           withVisited && tgStyles['a--visited'],
           typographyType && tgStyles[getTypographyCn(typographyType)],
           typographyType &&
@@ -91,13 +92,6 @@ export const Link = <T extends ElementType = 'a'>({
       {...aProps}
     >
       {children}
-      {external && (
-        <Icon
-          iconSize="inherit"
-          icon={OpenExternalIcon}
-          className={tgStyles.svg}
-        />
-      )}
     </ElementAs>
   );
 };

--- a/packages/dds-components/src/components/Typography/Typography/Typography.spec.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.spec.tsx
@@ -9,10 +9,6 @@ describe('<Typography>', () => {
     render(<Typography>{text}</Typography>);
     expect(screen.getByText(text)).toBeInTheDocument();
   });
-  it('renders link', () => {
-    render(<Typography typographyType="a" href="/" />);
-    expect(screen.getByRole('link')).toBeInTheDocument();
-  });
   it('renders heading', () => {
     render(<Typography typographyType="headingSmall" />);
     expect(screen.getByRole('heading')).toBeInTheDocument();
@@ -24,5 +20,22 @@ describe('<Typography>', () => {
   it('renders button', () => {
     render(<Typography as="button" />);
     expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+  describe('<a>', () => {
+    it('renders link', () => {
+      render(<Typography typographyType="a" href="/" />);
+      expect(screen.getByRole('link')).toBeInTheDocument();
+    });
+    it('has rel attr', () => {
+      render(<Typography typographyType="a" href="/" />);
+      expect(screen.getByRole('link')).toHaveAttribute(
+        'rel',
+        'noopener noreferer',
+      );
+    });
+    it('has target attr', () => {
+      render(<Typography typographyType="a" href="/" target="_blank" />);
+      expect(screen.getByRole('link')).toHaveAttribute('target', '_blank');
+    });
   });
 });

--- a/packages/dds-components/src/components/Typography/Typography/Typography.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.tsx
@@ -21,8 +21,6 @@ import {
 import { cn } from '../../../utils';
 import { getTextColor, isTextColor } from '../../../utils/color';
 import { focusable } from '../../helpers/styling/focus.module.css';
-import { Icon } from '../../Icon';
-import { OpenExternalIcon } from '../../Icon/icons';
 import { Box } from '../../layout';
 import typographyStyles from '../typographyStyles.module.css';
 
@@ -31,9 +29,6 @@ type AnchorTypographyProps = BaseComponentPropsWithChildren<
   {
     /**nativ `href`-prop ved `typographyType='a'`.  */
     href?: string | undefined;
-
-    /** Spesifiserer om lenka er ekstern ved `typographyType='a'` eller `as='a'`.*/
-    externalLink?: boolean;
 
     /**nativ `target`-prop ved `typographyType='a'`.  */
     target?: string;
@@ -93,13 +88,8 @@ export const Typography = (props: TypographyProps) => {
   const typographyCn = getTypographyCn(typographyType);
 
   let relProp;
-  let targetProp;
-  let externalLinkProp;
   if (isAnchorProps(props)) {
-    const { externalLink, target } = props;
     relProp = as === 'a' ? 'noopener noreferer' : undefined;
-    targetProp = as !== 'a' ? undefined : externalLink ? '_blank' : target;
-    externalLinkProp = as === 'a' && externalLink ? externalLink : undefined;
   }
 
   return (
@@ -110,7 +100,6 @@ export const Typography = (props: TypographyProps) => {
           className,
           getColorCn(color),
           styles.container,
-          externalLinkProp && typographyStyles['a--external'],
           typographyStyles[typographyCn],
           withMargins && typographyStyles[`${typographyCn}--margins`],
           isLegend(as) && typographyStyles.legend,
@@ -132,10 +121,8 @@ export const Typography = (props: TypographyProps) => {
       )}
       as={as}
       rel={relProp}
-      target={targetProp}
     >
       {children}
-      {externalLinkProp && <Icon icon={OpenExternalIcon} iconSize="inherit" />}
     </Box>
   );
 };

--- a/packages/dds-components/src/components/Typography/typographyStyles.module.css
+++ b/packages/dds-components/src/components/Typography/typographyStyles.module.css
@@ -86,8 +86,7 @@
   margin-bottom: var(--dds-font-body-long-medium-paragraph-spacing);
 }
 
-:where(.a--external) > .svg,
-.a__icon {
+:where(.a--with-icon) > svg {
   display: inline;
   margin: 0.1em 0.1em -0.1em;
   transform: translateY(0.05em);

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.mdx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DatePicker.mdx
@@ -16,8 +16,8 @@ import * as DatePickerStories from './DatePicker.stories';
   storybookHref={{ folder: 'components', comp: 'datepicker' }}
 />
 
-`DatePicker`-komponenten er implementert vha. [react-aria](https://react-spectrum.adobe.com/react-aria).
-For mer utfyllende dokumentasjon av props referrerer vi deg til [`DatePicker` dokumentasjon til react-aria](https://react-spectrum.adobe.com/react-aria/DatePicker.html#props).
+`DatePicker`-komponenten er implementert vha. [react-aria (react-spectrum.adobe.com)](https://react-spectrum.adobe.com/react-aria).
+For mer utfyllende dokumentasjon av props referrerer vi deg til [react-aria DatePicker (react-spectrum.adobe.com)](https://react-spectrum.adobe.com/react-aria/DatePicker.html#props).
 
 ## Props
 

--- a/packages/dds-components/src/components/layout/Grid/Grid.mdx
+++ b/packages/dds-components/src/components/layout/Grid/Grid.mdx
@@ -32,7 +32,7 @@ Grid består av to subkomponenter:
 - **`<Grid>`** - en container-komponent for grid children som tar i bruk CSS Grid. Den definerer antall kolonner og gutters (`gap` i CSS) basert på skjermstørrelse. Den støtter også alle standard layout primitive props; se props-tabellen under "CSS properites".
 - **`<GridChild>`** - en wrapper-komponent for innhold, brukes som barn i `<Grid>`. Den spesifiserer hvilke deler av grid innholdet skal ta, både kolonner og rader. Den støtter også alle standard layout primitive props; se props-tabellen under "CSS properites".
 
-Les mer om brekkepunkter, grid tokens og hvordan vi bruker det hele i <Link href="https://design.domstol.no/987b33f71/p/442cff-grid-og-layout/b/312b16" external>Grid og layout i dokumentasjonen</Link>.
+Les mer om brekkepunkter, grid tokens og hvordan vi bruker det hele i [Grid og layout (design.domstol.no)](https://design.domstol.no/987b33f71/p/442cff-grid-og-layout/b/312b16).
 
 ## Bruk
 


### PR DESCRIPTION
## Beskrivelse

BREAKING:

Fjerner støtte for `external` prop i `<Link>` og `externalLink` i `<Typography>`. Vi følger [retningslinjene til uutilsynet](https://www.uutilsynet.no/veiledning/lenker/214) om at lenker til eksterne sider ikke åpnes i ny fane. Dersom det er nødvendig at innholdet skal åpnes i ny fane, anbefales det at brukeren blir forhåndsvarslet direkte i lenketeksten. Inkluderer tester og eksempler som gjenspeiler dette. Oppdaterer bruk av lenker i docs til å følge retningslinjer.

I samme slengen:

Støtte for `withIconStyling` prop i `<Link>`. Setter styling for inline svg som er barn i `<Link>`. Gamle stylinga til ikonet som indikerte ekstern lenke gjenbrukes slik at konsumentene kan enkelt legge inn egne ikoner uten å knekke for de som bruker ikoner allerede og ikke vil style det inline.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
