### PR TITLE
ELSA1-848: Flytter box shadow hover-effekten fra button til container

### DIFF
--- a/.changeset/clever-jeans-dance.md
+++ b/.changeset/clever-jeans-dance.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Box shadow i `<CardExpandable>/>` vises rundt hele containeren når button hovres (både lukket og åpen state)

--- a/packages/dds-components/src/components/Card/CardExpandable/CardExpandable.module.css
+++ b/packages/dds-components/src/components/Card/CardExpandable/CardExpandable.module.css
@@ -1,17 +1,16 @@
 .container {
   border-radius: inherit;
+
+  @media (prefers-reduced-motion: no-preference) {
+    transition: box-shadow var(--dds-motion-micro-state);
+  }
+  &:has(.header-button:hover) {
+    box-shadow: 0 0 0 2px var(--dds-color-border-action-hover);
+  }
 }
 
 .header-button {
-  @media (prefers-reduced-motion: no-preference) {
-    transition:
-      box-shadow var(--dds-motion-micro-state),
-      var(--dds-focus-transition);
-  }
-
-  &:hover {
-    box-shadow: 0 0 0 2px var(--dds-color-border-action-hover);
-  }
+  transition: var(--dds-focus-transition);
 }
 
 .header-container {


### PR DESCRIPTION

## Beskrivelse

Flytter box shadow hover-effekten fra button til container:
- Før: Box shadow vises bare rundt button ved hover
- Etter: Box shadow vises rundt hele containeren når button hovres (både lukket og åpen state)
- Viktig: Box shadow vises kun når button hovres - ikke når bruker hovrer over åpent innhold
Bruker CSS :has() selector for å detektere button hover og applisere styling på parent container.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
