### PR TITLE
ELSA1-870: Nettsiden hopper til toppen når Popover åpnes

### DIFF
--- a/.changeset/great-hands-give.md
+++ b/.changeset/great-hands-give.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser feil der <Popover> med portal og returnFocusOnBlur scrollet til toppen av siden.

--- a/packages/dds-components/src/components/Popover/Popover.context.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.context.tsx
@@ -9,6 +9,7 @@ import { type FloatingStyles, type UseFloatPositionOptions } from '../../hooks';
 
 interface PopoverContextType {
   floatStyling: FloatingStyles;
+  isPositioned: boolean;
   setFloatOptions: Dispatch<
     SetStateAction<UseFloatPositionOptions | undefined>
   >;

--- a/packages/dds-components/src/components/Popover/Popover.spec.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.spec.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { useRef, useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Button } from '../Button';
 
@@ -169,5 +170,86 @@ describe('<Popover>', () => {
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
+  });
+
+  describe('scrolling behavior on focus', () => {
+    // The popover used to get focus before it was positioned.
+    // When used with `portal` and `returnFocusOnBlur`, the browser scrolled to where the portal was placed in the DOM (top of page).
+    // It should wait for the popover to be positioned before focusing.
+
+    const offset = 100;
+    const expectedPosition = `${offset}px`;
+
+    const spyOnPopoverPositionWhenFocusIsCalled = (): Array<string> => {
+      const positions: Array<string> = [];
+      vi.spyOn(HTMLElement.prototype, 'focus').mockImplementation(function (
+        this: HTMLElement,
+      ) {
+        if (this.getAttribute('role') === 'dialog') {
+          positions.push(this.style.top);
+        }
+      });
+      return positions;
+    };
+
+    const WithPopoverGroup = () => (
+      <PopoverGroup>
+        <button type="button">{buttonLabel}</button>
+        <Popover portal returnFocusOnBlur offset={offset}>
+          {content}
+        </Popover>
+      </PopoverGroup>
+    );
+
+    const WithoutPopoverGroup = () => {
+      const anchorRef = useRef<HTMLButtonElement>(null);
+      const [isOpen, setIsOpen] = useState(false);
+      return (
+        <>
+          <button type="button" ref={anchorRef} onClick={() => setIsOpen(true)}>
+            {buttonLabel}
+          </button>
+          <Popover
+            anchorRef={anchorRef}
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            portal
+            returnFocusOnBlur
+            withCloseButton={false}
+            offset={offset}
+          >
+            {content}
+          </Popover>
+        </>
+      );
+    };
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it.each([
+      ['with PopoverGroup', WithPopoverGroup],
+      ['without PopoverGroup', WithoutPopoverGroup],
+    ])(
+      '%s: popover is positioned before focus is called',
+      async (_name, TestComponent) => {
+        const user = userEvent.setup();
+        const popoverPositions = spyOnPopoverPositionWhenFocusIsCalled();
+
+        render(<TestComponent />);
+
+        await user.click(screen.getByText(buttonLabel));
+
+        await waitFor(() => {
+          expect(popoverPositions.length).toBeGreaterThan(0);
+        });
+
+        for (const actualPosition of popoverPositions) {
+          // Test should fail if `isPositioned` is removed from the `useReturnFocusOnBlur` condition inside `<Popover>`.
+          expect(actualPosition).toBe(expectedPosition);
+        }
+      },
+    );
   });
 });

--- a/packages/dds-components/src/components/Popover/Popover.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.tsx
@@ -101,7 +101,11 @@ export const Popover = ({
   ref,
   ...rest
 }: PopoverProps) => {
-  const { refs, styles: positionStyles } = useFloatPosition(null, {
+  const {
+    refs,
+    styles: positionStyles,
+    isPositioned: localIsPositioned,
+  } = useFloatPosition(null, {
     offset,
     placement,
   });
@@ -113,6 +117,7 @@ export const Popover = ({
 
   const {
     floatStyling: contextFloatStyling,
+    isPositioned: contextIsPositioned,
     setFloatOptions,
     floatingRef: contextFloatingRef,
     popoverId: contextPopoverId,
@@ -134,6 +139,7 @@ export const Popover = ({
     floatingRef,
     floatStyling,
     onClose,
+    isPositioned = false,
   ] = hasContext
     ? [
         contextPopoverId,
@@ -142,6 +148,7 @@ export const Popover = ({
         contextFloatingRef,
         contextFloatStyling,
         contextOnClose,
+        contextIsPositioned,
       ]
     : [
         uniquePopoverId,
@@ -150,6 +157,7 @@ export const Popover = ({
         refs.setFloating,
         positionStyles.floating,
         propOnClose,
+        localIsPositioned,
       ];
 
   if (!hasContext) {
@@ -159,7 +167,7 @@ export const Popover = ({
   const hasTransitionedIn = useMountTransition(isOpen, 400);
 
   const popoverRef = useReturnFocusOnBlur(
-    isOpen && hasTransitionedIn && returnFocusOnBlur,
+    isOpen && hasTransitionedIn && isPositioned && returnFocusOnBlur,
     () => {
       onClose?.();
       onBlur?.();

--- a/packages/dds-components/src/components/Popover/PopoverGroup.tsx
+++ b/packages/dds-components/src/components/Popover/PopoverGroup.tsx
@@ -56,7 +56,11 @@ export const PopoverGroup = ({
   const generatedId = useId();
   const uniquePopoverId = popoverId ?? `${generatedId}-popover`;
   const [floatOptions, setFloatOptions] = useState<UseFloatPositionOptions>();
-  const { refs, styles: positionStyles } = useFloatPosition(null, floatOptions);
+  const {
+    refs,
+    styles: positionStyles,
+    isPositioned,
+  } = useFloatPosition(null, floatOptions);
 
   const handleClose = () => {
     setOpen(false);
@@ -121,6 +125,7 @@ export const PopoverGroup = ({
     <PopoverContext
       value={{
         floatStyling: positionStyles.floating,
+        isPositioned,
         setFloatOptions,
         floatingRef: combinedPopoverRef,
         popoverId: uniquePopoverId,

--- a/packages/dds-components/src/hooks/useFloatPosition/useFloatPosition.tsx
+++ b/packages/dds-components/src/hooks/useFloatPosition/useFloatPosition.tsx
@@ -55,6 +55,7 @@ export interface FloatingStyles {
 
 interface UseFloatPosition {
   refs: UseFloatingReturn['refs'];
+  isPositioned: boolean;
   styles: {
     floating: FloatingStyles;
     arrow:
@@ -142,6 +143,7 @@ export const useFloatPosition = (
     middlewareData,
     placement: actualPlacement,
     refs,
+    isPositioned,
   } = useFloating({
     placement,
     middleware,
@@ -151,6 +153,7 @@ export const useFloatPosition = (
 
   return {
     refs,
+    isPositioned,
     styles: {
       floating: {
         position: strategy,


### PR DESCRIPTION
## Beskrivelse

### Problem

Første gang popover åpnes kalles `.focus()` på den for tidlig. Da har den ikke fått posisjon av Floating UI.

Dette blir et problem når man bruker `portal` og `returnFocusOnBlur`.
Da settes fokus på et element som, mest sannsynlig, er på toppen av DOM-en og man ender opp med å scrolle til toppen av siden.

### Løsning

`useFloating` eksponerer `isPositioned`
Denne sender jeg videre til designsystemet sin `useFloatPosition`, og bruker den i `Popover` til å avgjøre når `.focus()` skal kalles.

### Testing

Har testet lokalt med npm link og domstol-no.
Enhetstester feiler uten endringen.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
