### PR TITLE
ELSA1-873: feil fontstørrelse i `<ButtonGroup>`

### DIFF
--- a/.changeset/rich-bats-occur.md
+++ b/.changeset/rich-bats-occur.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der fontstørrelsen ikke fulgte komponentstørrelsen i `<ButtonGroup>`.

--- a/packages/dds-components/src/components/Button/Button.tsx
+++ b/packages/dds-components/src/components/Button/Button.tsx
@@ -17,7 +17,7 @@ export const Button = <I extends SvgIcon, T extends ElementType = 'button'>({
   as: propAs,
   children,
   purpose = 'primary',
-  size = 'medium',
+  size: propSize = 'medium',
   iconPosition = 'left',
   loading,
   loadingTooltip,
@@ -44,12 +44,13 @@ export const Button = <I extends SvgIcon, T extends ElementType = 'button'>({
   const isIconButton = !hasLabel && hasIcon;
   const isTextButton = hasLabel && !hasIcon;
   const noContent = !hasLabel && !hasIcon;
+  const size = groupSize ?? propSize;
 
   const buttonCn = cn(
     className,
     styles.button,
     styles[`button--${groupPurpose ? groupPurpose : purpose}`],
-    styles[`button--${groupSize ? groupSize : size}`],
+    styles[`button--${size}`],
     isTextButton && styles['just-text'],
     ...(hasLabelAndIcon
       ? [styles['with-text-and-icon'], styles[`with-icon-${iconPosition}`]]


### PR DESCRIPTION
## Beskrivelse

Den fulgte ikke komponentstørrelsen fra context.

Før:
<img width="460" height="376" alt="bilde" src="https://github.com/user-attachments/assets/fa5c8c4a-66fd-4ecb-b1fa-515a492966b0" />

Etter:
<img width="456" height="357" alt="bilde" src="https://github.com/user-attachments/assets/5f2130f1-0176-4751-aea9-a780d3b9c5de" />

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
