### PR TITLE
ELSA1-874: Phoneinput disabled readonly tekstfarge

### DIFF
--- a/.changeset/common-impalas-smile.md
+++ b/.changeset/common-impalas-smile.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Oppdaterer tekst farge for landskode når `<PhoneInput/>` settes til disabled og/eller read only. Setter også opacity i `<NativeSelect/>` til 1.0 for å overskrive Chromiums default opacity chromium som er satt til 0.7.

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.module.css
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.module.css
@@ -92,3 +92,7 @@
 .calling-code {
   left: var(--dds-spacing-x0-5);
 }
+
+.calling-code--disabled {
+  color: var(--dds-color-text-subtle);
+}

--- a/packages/dds-components/src/components/PhoneInput/PhoneInput.tsx
+++ b/packages/dds-components/src/components/PhoneInput/PhoneInput.tsx
@@ -319,6 +319,8 @@ export const PhoneInput = ({
               typographyStyles[`body-short-${componentSize}`],
               inputStyles['input-group__absolute-el'],
               styles['calling-code'],
+              (commonProps.disabled || commonProps.readOnly) &&
+                styles['calling-code--disabled'],
             )}
             ref={callingCodeRef}
           >

--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.module.css
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.module.css
@@ -13,6 +13,7 @@
     }
   }
   &:disabled {
+    opacity: 1;
     cursor: not-allowed;
     color: var(--dds-color-text-subtle);
     background-color: var(--dds-color-surface-field-disabled);


### PR DESCRIPTION
## Beskrivelse

Denne PR-en oppdaterer tekstfargen til landskoden i `<PhoneInput/>` når satt til `default` eller `read only`. Gjennomsiktigheten til `<NativeSelect/>` settes også til `1` når `disabled`.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
