### PR TITLE
Uten issue: setter `min-height` istedenfor `height` på `<Button>`

### DIFF
--- a/packages/dds-components/src/components/Button/Button.module.css
+++ b/packages/dds-components/src/components/Button/Button.module.css
@@ -39,7 +39,7 @@
 }
 
 .button--xsmall {
-  height: var(--dds-size-height-input-xsmall);
+  min-height: var(--dds-size-height-input-xsmall);
   padding-block: var(--dds-spacing-x0-125);
   &.just-text {
     padding-inline: var(--dds-spacing-x0-5);
@@ -67,7 +67,7 @@
 }
 
 .button--small {
-  height: var(--dds-size-height-input-small);
+  min-height: var(--dds-size-height-input-small);
   padding-block: var(--dds-spacing-x0-25);
   &.just-text {
     padding-inline: var(--dds-spacing-x0-75);
@@ -95,7 +95,7 @@
 }
 
 .button--medium {
-  height: var(--dds-size-height-input-medium);
+  min-height: var(--dds-size-height-input-medium);
   padding-block: var(--dds-spacing-x0-5);
   &.just-text {
     padding-inline: var(--dds-spacing-x1);
@@ -123,7 +123,7 @@
 }
 
 .button--large {
-  height: var(--dds-size-height-input-large);
+  min-height: var(--dds-size-height-input-large);
   padding-block: var(--dds-spacing-x0-75);
   &.just-text {
     padding-inline: var(--dds-spacing-x1-5);

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.module.css
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.module.css
@@ -10,6 +10,7 @@
   cursor: pointer;
   background-color: var(--dds-color-surface-default);
   border: 1px solid;
+  height: 100%;
 
   @media (prefers-reduced-motion: no-preference) {
     transition:


### PR DESCRIPTION
## Beskrivelse

`height` gjorde at innhold over flere linjer ikke fikk plass. Fikser alle komponenter som arver `<Button>` styling.

Før:
<img width="123" height="68" alt="bilde" src="https://github.com/user-attachments/assets/3b1e1385-3b1c-4876-80fd-081220e082be" />

Etter:
<img width="126" height="97" alt="bilde" src="https://github.com/user-attachments/assets/a370fb8c-5671-4189-92ce-66d465d04634" />

## Sjekkliste

### Generelt

- [ ] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [ ] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
