### PR TITLE
Uten issue: Fikser multiline styling i `<inlineEditTextArea>`

### DIFF
--- a/.changeset/fuzzy-baboons-find.md
+++ b/.changeset/fuzzy-baboons-find.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<InlineEditTextArea>` ikke fikk multiline styling.

--- a/packages/dds-components/src/components/InlineEdit/InlineEdit.module.css
+++ b/packages/dds-components/src/components/InlineEdit/InlineEdit.module.css
@@ -37,6 +37,7 @@
 
 .inline-textarea {
   resize: vertical;
+  height: initial;
 }
 
 /* Sentrerer ikonet i forhold til første linjen med tekst */

--- a/packages/dds-components/src/components/InlineEdit/InlineEdit.utils.tsx
+++ b/packages/dds-components/src/components/InlineEdit/InlineEdit.utils.tsx
@@ -57,6 +57,7 @@ export const inlineTextareaCns = (
 ) => [
   ...inlineInputCns(hasErrorState, showEditingIcon),
   typographyStyles['body-long-medium'],
+  styles['inline-textarea'],
   utilStyles.scrollbar,
 ];
 


### PR DESCRIPTION
## Beskrivelse

Før:
<img width="182" height="326" alt="bilde" src="https://github.com/user-attachments/assets/acce04f1-da51-4b2d-ae29-b4979805aa13" />

Etter:
<img width="190" height="477" alt="bilde" src="https://github.com/user-attachments/assets/909db848-4648-403b-a914-f4c42602685e" />


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
