### PR TITLE
ELSA1-882: Verdi i `<Select isMulti>` kan gå over flere linjer

### DIFF
--- a/.changeset/lucky-goats-learn.md
+++ b/.changeset/lucky-goats-learn.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<Select isMulti>` ikke fikk plass til verdi-chips over flere linjer.

--- a/packages/dds-components/src/components/date-inputs/DatePicker/DateField/DateSegment.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/DateField/DateSegment.tsx
@@ -6,7 +6,6 @@ import type {
 import { useRef } from 'react';
 
 import { cn, spaceSeparatedIdListGenerator } from '../../../../utils';
-import inputStyles from '../../../helpers/Input/Input.module.css';
 import { Box } from '../../../layout';
 import typographyStyles from '../../../Typography/typographyStyles.module.css';
 import styles from '../../common/DateInput.module.css';
@@ -47,7 +46,6 @@ export function DateSegment({
         segmentProps.className,
         styles.segment,
         typographyStyles[`body-short-${componentSize}`],
-        inputStyles[`input--${componentSize}`],
       )}
       style={{
         ...segmentProps.style,

--- a/packages/dds-components/src/components/helpers/Input/Input.module.css
+++ b/packages/dds-components/src/components/helpers/Input/Input.module.css
@@ -108,22 +108,22 @@
 
 :where(.input--large) {
   padding: var(--dds-spacing-x0-75);
-  height: var(--dds-size-height-input-large);
+  min-height: var(--dds-size-height-input-large);
 }
 
 :where(.input--medium) {
   padding: var(--dds-spacing-x0-5) var(--dds-spacing-x0-75);
-  height: var(--dds-size-height-input-medium);
+  min-height: var(--dds-size-height-input-medium);
 }
 
 :where(.input--small) {
   padding: var(--dds-spacing-x0-25) var(--dds-spacing-x0-5);
-  height: var(--dds-size-height-input-small);
+  min-height: var(--dds-size-height-input-small);
 }
 
 :where(.input--xsmall) {
   padding: var(--dds-spacing-x0-125) var(--dds-spacing-x0-25);
-  height: var(--dds-size-height-input-xsmall);
+  min-height: var(--dds-size-height-input-xsmall);
 }
 
 :where(.input-with-icon--large) {


### PR DESCRIPTION
## Beskrivelse

Før:
<img width="433" height="167" alt="bilde" src="https://github.com/user-attachments/assets/dad265e7-da9d-4a6c-8596-4b05fc378b86" />

Etter:
<img width="422" height="168" alt="bilde" src="https://github.com/user-attachments/assets/1c52da17-9648-48e2-afe1-a18dc0a7ee3c" />

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
