### PR TITLE
ELSA1-883: fikser story som failer i prod og preview build

### DIFF
--- a/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.stories.tsx
+++ b/packages/dds-components/src/components/Select/NativeSelect/NativeSelect.stories.tsx
@@ -33,6 +33,8 @@ const meta = preview.meta({
   decorators: [ddsProviderDecorator],
 });
 
+export default meta;
+
 const options = [
   { value: 'Alternativ 1', label: 'Alternativ 1' },
   { value: 'Alternativ 2', label: 'Alternativ 2' },

--- a/packages/dds-components/src/tests/internationalized-date.test.ts
+++ b/packages/dds-components/src/tests/internationalized-date.test.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import semver from 'semver';
 import { describe, expect, it } from 'vitest';
 
-import packageJson from '../package.json';
+import packageJson from '../../package.json';
 
 function readPackageJson(pkgName: string) {
   const pkgPath = path.join(

--- a/packages/dds-components/src/tests/storybook-mdx.spec.ts
+++ b/packages/dds-components/src/tests/storybook-mdx.spec.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+function walkDir(dir: string, ext: string): Array<string> {
+  const results: Array<string> = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walkDir(full, ext));
+    } else if (entry.isFile() && entry.name.endsWith(ext)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const srcDir = path.join(process.cwd(), 'src');
+
+// For hver .stories.tsx fil ta basenavnet og sjekk om en matchende .mdx eksisterer.
+// E.g. "NativeSelect.stories.tsx" → ser etter "NativeSelect.mdx" i samme katalog.
+function hasMatchingMdx(storiesFile: string): boolean {
+  const dir = path.dirname(storiesFile);
+  const base = path.basename(storiesFile).replace(/\.stories\.tsx$/, '');
+  return fs.existsSync(path.join(dir, `${base}.mdx`));
+}
+
+describe('stories files with a matching MDX file must have export default meta', () => {
+  const storiesFiles = walkDir(srcDir, '.stories.tsx').filter(hasMatchingMdx);
+
+  for (const storiesFile of storiesFiles) {
+    it(`${path.relative(srcDir, storiesFile)} has export default`, () => {
+      const content = fs.readFileSync(storiesFile, 'utf-8');
+      expect(
+        content,
+        `'${path.relative(srcDir, storiesFile)}' is missing 'export default meta'. ` +
+          `This causes <Meta of={...} /> to fail in production and branch preview Storybook builds.`,
+      ).toMatch(/^export default\b/m);
+    });
+  }
+});


### PR DESCRIPTION
## Beskrivelse

Cloudflare er strengere enn lokal build på CSF exports og krever at det er en export default meta i stories som blir referert til i en MDX med `<Meta of={...} />`. Lager også en test som sjekker dette.

Før i NativeSelect docs:

<img width="900" height="1141" alt="bilde" src="https://github.com/user-attachments/assets/9b79c6a0-1d2d-4f16-8181-bae7211805b1" />

Etter:
<img width="957" height="1087" alt="bilde" src="https://github.com/user-attachments/assets/8b4b35be-7f98-4d46-8a20-754cdd6edb3e" />

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
