### PR TITLE
ELSA1-668: Nye CSS props i `<Grid>` og `<GridChild>`

### DIFF
--- a/.changeset/clear-bushes-win.md
+++ b/.changeset/clear-bushes-win.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Ny prop `defaultPageLayout` i `<Grid>`. Tillater å slå av default styling som implementerer standard sideoppsett slik det er i Figma.

--- a/.changeset/nice-paws-burn.md
+++ b/.changeset/nice-paws-burn.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `justifySelf` prop i `<GridChild>` satt CSS `grid-row` istedenfor `justify-self`.

--- a/.changeset/proud-foxes-marry.md
+++ b/.changeset/proud-foxes-marry.md
@@ -1,0 +1,16 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for nye CSS props i layout primitives:
+
+- `<Grid>`:
+  - `display` med verdiene `'grid'` (default) og `'inline-grid'`
+  - `grid`
+  - `gridAutoColumns`
+  - `gridAutoFlow`
+  - `gridAutoRows`
+  - `gridTemplate`
+  - `gridTemplateAreas`
+  - `gridTemplateRows`
+- `<GridChild>`: `gridArea`

--- a/.changeset/quiet-words-clap.md
+++ b/.changeset/quiet-words-clap.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Tar i bruk `<Grid>` under panseret der relevant på tvers a komponenter.

--- a/.changeset/violet-cases-sip.md
+++ b/.changeset/violet-cases-sip.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der `<Icon>` ikke registrerte styling fra `style` prop.

--- a/packages/dds-components/src/components/Icon/Icon.tsx
+++ b/packages/dds-components/src/components/Icon/Icon.tsx
@@ -77,9 +77,7 @@ export function Icon<I extends SvgIcon = SvgIcon>(props: IconProps<I>) {
 
   return (
     <C
-      {...getBaseHTMLProps(id, className, style, htmlProps, {
-        ...rest,
-      })}
+      {...getBaseHTMLProps(id, className, style, htmlProps, rest)}
       height={size}
       width={size}
       fill={color}

--- a/packages/dds-components/src/components/Icon/utils/SvgWrapper.tsx
+++ b/packages/dds-components/src/components/Icon/utils/SvgWrapper.tsx
@@ -15,6 +15,7 @@ export function SvgWrapper({
   // destructure for å unngå at `iconState` blir sendt videre til svg-elementet som ugyldig custom attribute.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   iconState: _iconState,
+  style,
   ...props
 }: SvgProps & { iconState?: string }) {
   return (
@@ -25,6 +26,7 @@ export function SvgWrapper({
       viewBox={`0 0 ${size} ${size}`}
       className={cn(className, styles.svg)}
       style={{
+        ...style,
         height: height ? height : sizeCSS,
         width: width ? width : sizeCSS,
       }}

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.module.css
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.module.css
@@ -7,73 +7,21 @@
 .container--info {
   border-color: var(--dds-color-border-info);
   background-color: var(--dds-color-surface-info-default);
-
-  .icon {
-    color: var(--dds-color-icon-on-info-default);
-  }
 }
 .container--warning {
   border-color: var(--dds-color-border-warning);
   background-color: var(--dds-color-surface-warning-default);
-
-  .icon {
-    color: var(--dds-color-icon-on-warning-default);
-  }
 }
 .container--danger {
   border-color: var(--dds-color-border-danger);
   background-color: var(--dds-color-surface-danger-default);
-
-  .icon {
-    color: var(--dds-color-icon-on-danger-default);
-  }
 }
 .container--success {
   border-color: var(--dds-color-border-success);
   background-color: var(--dds-color-surface-success-default);
-
-  .icon {
-    color: var(--dds-color-icon-on-success-default);
-  }
 }
 
 .container--tips {
   border-color: var(--dds-color-border-info);
   background-color: var(--dds-color-surface-info-default);
-
-  .icon {
-    color: var(--dds-color-icon-on-info-default);
-  }
-}
-
-.container--horisontal {
-  grid-template-areas: 'icon text';
-  grid-template-columns: min-content 1fr;
-}
-
-.container--horisontal--closable {
-  grid-template-areas: 'icon text closeButton';
-  grid-template-columns: min-content 1fr min-content;
-}
-
-.container--vertical {
-  grid-template-areas: 'icon icon' 'text text';
-  grid-template-columns: 1fr min-content;
-}
-
-.container--vertical--closable {
-  grid-template-areas: 'icon closeButton' 'text text';
-  grid-template-columns: 1fr;
-}
-
-.container__text {
-  grid-area: text;
-}
-
-.container__icon {
-  grid-area: icon;
-}
-
-.container__button {
-  grid-area: closeButton;
 }

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.tsx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.tsx
@@ -19,7 +19,8 @@ import {
   TipIcon,
   WarningIcon,
 } from '../Icon/icons';
-import { Box, type ResponsiveProps } from '../layout';
+import { Grid, GridChild, type ResponsiveProps } from '../layout';
+import { type ResponsiveGridProps } from '../layout/common/Responsive.types';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 export const L_MESSAGE_PURPOSES = createPurposes(
@@ -77,22 +78,45 @@ export const LocalMessage = ({
 }: LocalMessageProps) => {
   const { t } = useTranslation();
 
-  const [isClosed, setClosed] = useState(false);
+  const [isOpen, setOpen] = useState(true);
 
-  if (isClosed) {
-    return <></>;
-  }
+  type GridLayout =
+    | LocalMessageLayout
+    | 'horisontal-closable'
+    | 'vertical-closable';
 
-  return (
-    <Box
+  const gridLayout: GridLayout = closable ? `${layout}-closable` : layout;
+
+  const containerGridTemplateStyles: Record<
+    GridLayout,
+    Partial<ResponsiveGridProps>
+  > = {
+    horisontal: {
+      gridTemplateAreas: `"icon text"`,
+      gridTemplateColumns: 'min-content 1fr',
+    },
+    'horisontal-closable': {
+      gridTemplateAreas: `"icon text close-btn"`,
+      gridTemplateColumns: 'min-content 1fr min-content',
+    },
+    vertical: {
+      gridTemplateAreas: `"icon" "text"`,
+      gridTemplateColumns: '1fr',
+    },
+    'vertical-closable': {
+      gridTemplateAreas: `"icon close-btn" "text text"`,
+      gridTemplateColumns: '1fr min-content',
+    },
+  };
+
+  return isOpen ? (
+    <Grid
       {...getBaseHTMLProps(
         id,
         cn(
           className,
           typographyStyles['body-short-medium'],
           styles.container,
-          styles[`container--${layout}`],
-          closable && styles[`container--${layout}--closable`],
           styles[`container--${purpose}`],
         ),
         style,
@@ -100,31 +124,36 @@ export const LocalMessage = ({
         rest,
       )}
       width={width}
-      display="grid"
       padding="x0.75 x0.75 x0.75 x0.5"
-      gap="x0.5"
+      rowGap="x0.5"
+      columnGap="x0.5"
+      marginInline="x0"
+      {...containerGridTemplateStyles[gridLayout]}
     >
-      <Icon
+      <GridChild
+        as={Icon}
+        gridArea="icon"
         iconSize="component"
         icon={icons[purpose]}
-        className={cn(styles.icon, styles.container__icon)}
+        color={`var(--dds-color-icon-on-${purpose === 'tips' ? 'info' : purpose}-default)`}
       />
-      <div className={styles.container__text}>{children}</div>
+      <GridChild gridArea="text">{children}</GridChild>
       {closable && (
-        <Button
+        <GridChild
+          as={Button}
+          gridArea="close-btn"
           icon={CloseIcon}
           purpose="tertiary"
           onClick={() => {
-            setClosed(true);
+            setOpen(false);
             onClose?.();
           }}
           size="xsmall"
           aria-label={t(commonTexts.closeMessage)}
-          className={styles.container__button}
         />
       )}
-    </Box>
-  );
+    </Grid>
+  ) : null;
 };
 
 LocalMessage.displayName = 'LocalMessage';

--- a/packages/dds-components/src/components/Pagination/Pagination.module.css
+++ b/packages/dds-components/src/components/Pagination/Pagination.module.css
@@ -1,20 +1,3 @@
-.list {
-  display: grid;
-  grid-auto-flow: column;
-  margin: 0;
-  padding: 0;
-  gap: var(--dds-spacing-x0-75);
-}
-
-.list__item {
-  display: inline-grid;
-  align-content: center;
-}
-
-.indicators {
-  grid-auto-flow: column;
-}
-
 .truncation-icon {
   color: var(--dds-color-icon-medium);
   min-width: calc(1ch + (2 * var(--dds-spacing-x0-75)));

--- a/packages/dds-components/src/components/Pagination/Pagination.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.tsx
@@ -6,7 +6,6 @@ import { useControllableState } from '../../hooks/useControllableState';
 import { createTexts, useTranslation } from '../../i18n';
 import { commonTexts } from '../../i18n/commonTexts';
 import { type BaseComponentProps, getBaseHTMLProps } from '../../types';
-import { cn } from '../../utils';
 import { Button } from '../Button';
 import utilStyles from '../helpers/styling/utilStyles.module.css';
 import { Icon } from '../Icon';
@@ -17,7 +16,13 @@ import {
   ChevronRightIcon,
   MoreHorizontalIcon,
 } from '../Icon/icons';
-import { Box, type Breakpoint, ShowHide } from '../layout';
+import {
+  Box,
+  type BoxProps,
+  type Breakpoint,
+  Grid,
+  type GridProps,
+} from '../layout';
 import { styleUpToBreakpoint } from '../layout/common/utils';
 import { Select } from '../Select';
 import { Paragraph } from '../Typography';
@@ -143,12 +148,28 @@ export const Pagination = ({
     }
   };
 
+  const listItemProps: Partial<BoxProps<'li'>> = {
+    as: 'li',
+    display: 'inline-grid',
+    alignContent: 'center',
+  };
+
+  const listProps: Partial<GridProps<'ol'>> = {
+    as: 'ol',
+    defaultPageLayout: false,
+    hideBelow: smallScreenBreakpoint,
+    gridAutoFlow: 'column',
+    margin: 0,
+    padding: 0,
+    gap: 'x0.75',
+  };
+
   const listItems =
     items.length > 0
       ? items.map((item, i) => {
           const isActive = item === activePage;
           return (
-            <li key={`pagination-item-${i}`} className={styles.list__item}>
+            <Box {...listItemProps} key={`pagination-item-${i}`}>
               {item !== 'truncator' && typeof item === 'number' ? (
                 <Button
                   purpose={isActive ? 'primary' : 'secondary'}
@@ -170,7 +191,7 @@ export const Pagination = ({
                   className={styles['truncation-icon']}
                 />
               )}
-            </li>
+            </Box>
           );
         })
       : undefined;
@@ -215,42 +236,28 @@ export const Pagination = ({
           ...baseHTMLProps,
         })}
     >
-      <ShowHide
-        as="ol"
-        hideBelow={smallScreenBreakpoint}
-        className={styles.list}
-      >
-        <li
-          className={cn(
-            styles.list__item,
-            isOnFirstPage && utilStyles.invisible,
-          )}
+      <Grid {...listProps} hideBelow={smallScreenBreakpoint}>
+        <Box
+          {...listItemProps}
+          className={isOnFirstPage ? utilStyles.invisible : undefined}
           aria-hidden={isOnFirstPage}
         >
           {previousPageButton}
-        </li>
+        </Box>
         {listItems}
-        <li
-          className={cn(
-            styles.list__item,
-            isOnLastPage && utilStyles.invisible,
-          )}
+        <Box
+          {...listItemProps}
+          className={isOnLastPage ? utilStyles.invisible : undefined}
           aria-hidden={isOnLastPage}
         >
           {nextPageButton}
-        </li>
-      </ShowHide>
+        </Box>
+      </Grid>
       {!!smallScreenBreakpoint && (
-        <ShowHide
-          as="ol"
-          showBelow={smallScreenBreakpoint}
-          className={styles.list}
-        >
-          <li
-            className={cn(
-              styles.list__item,
-              isOnFirstPage && utilStyles.invisible,
-            )}
+        <Grid {...listProps} showBelow={smallScreenBreakpoint}>
+          <Box
+            {...listItemProps}
+            className={isOnFirstPage ? utilStyles.invisible : undefined}
             aria-hidden={isOnFirstPage}
           >
             <Button
@@ -262,17 +269,15 @@ export const Pagination = ({
               }}
               aria-label={t(texts.firstPage)}
             />
-          </li>
-          <li
-            className={cn(
-              styles.list__item,
-              isOnFirstPage && utilStyles.invisible,
-            )}
+          </Box>
+          <Box
+            {...listItemProps}
+            className={isOnFirstPage ? utilStyles.invisible : undefined}
             aria-hidden={isOnFirstPage}
           >
             {previousPageButton}
-          </li>
-          <li className={styles.list__item}>
+          </Box>
+          <Box {...listItemProps}>
             <Button
               size="small"
               onClick={event => {
@@ -281,21 +286,17 @@ export const Pagination = ({
             >
               {activePage}
             </Button>
-          </li>
-          <li
-            className={cn(
-              styles.list__item,
-              isOnLastPage && utilStyles.invisible,
-            )}
+          </Box>
+          <Box
+            {...listItemProps}
+            className={isOnLastPage ? utilStyles.invisible : undefined}
             aria-hidden={isOnLastPage}
           >
             {nextPageButton}
-          </li>
-          <li
-            className={cn(
-              styles.list__item,
-              isOnLastPage && utilStyles.invisible,
-            )}
+          </Box>
+          <Box
+            {...listItemProps}
+            className={isOnLastPage ? utilStyles.invisible : undefined}
             aria-hidden={isOnLastPage}
           >
             <Button
@@ -307,8 +308,8 @@ export const Pagination = ({
               }}
               aria-label={t(texts.lastPage)}
             />
-          </li>
-        </ShowHide>
+          </Box>
+        </Grid>
       )}
     </Box>
   ) : null;
@@ -331,11 +332,11 @@ export const Pagination = ({
       alignItems={styleUpToBreakpoint('center', smallScreenBreakpoint)}
       {...baseHTMLProps}
     >
-      <Box
-        display="grid"
+      <Grid
+        defaultPageLayout={false}
         gap="x0.5"
         alignItems="center"
-        className={styles.indicators}
+        gridAutoFlow="column"
       >
         {withSelect && (
           <Select
@@ -363,7 +364,7 @@ export const Pagination = ({
             )}
           </Paragraph>
         )}
-      </Box>
+      </Grid>
       {navigation}
     </Box>
   );

--- a/packages/dds-components/src/components/Pagination/Pagination.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.tsx
@@ -159,8 +159,8 @@ export const Pagination = ({
     defaultPageLayout: false,
     hideBelow: smallScreenBreakpoint,
     gridAutoFlow: 'column',
-    margin: 0,
-    padding: 0,
+    margin: 'x0',
+    padding: 'x0',
     gap: 'x0.75',
   };
 

--- a/packages/dds-components/src/components/Pagination/Pagination.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.tsx
@@ -157,7 +157,6 @@ export const Pagination = ({
   const listProps: Partial<GridProps<'ol'>> = {
     as: 'ol',
     defaultPageLayout: false,
-    hideBelow: smallScreenBreakpoint,
     gridAutoFlow: 'column',
     margin: 'x0',
     padding: 'x0',

--- a/packages/dds-components/src/components/Search/Search.module.css
+++ b/packages/dds-components/src/components/Search/Search.module.css
@@ -1,8 +1,3 @@
-.with-button-container {
-  display: grid;
-  grid-template-columns: 1fr auto;
-}
-
 .input {
   &[type='search']::-webkit-search-decoration,
   &[type='search']::-webkit-search-cancel-button,

--- a/packages/dds-components/src/components/Search/Search.tsx
+++ b/packages/dds-components/src/components/Search/Search.tsx
@@ -172,11 +172,10 @@ export const Search = ({
       <div>
         {showSearchButton ? (
           <Grid
+            defaultPageLayout={false}
             className={className}
             width={width}
             columnGap="x0.5"
-            rowGap="0"
-            marginInline="0"
             gridTemplateColumns="1fr auto"
             style={style}
           >

--- a/packages/dds-components/src/components/Tabs/TabList.tsx
+++ b/packages/dds-components/src/components/Tabs/TabList.tsx
@@ -17,6 +17,7 @@ import { useCombinedRef, useRoveFocus } from '../../hooks';
 import { cn, combineHandlers } from '../../utils';
 import { focusable } from '../helpers/styling/focus.module.css';
 import { scrollbar } from '../helpers/styling/utilStyles.module.css';
+import { Grid } from '../layout';
 
 export type TabListProps = ComponentPropsWithRef<'div'>;
 
@@ -91,9 +92,19 @@ export const TabList = ({
     ['--dds-tab-widths' as any]: widths.join(' '),
   };
 
+  const gridLayout = widths
+    ? {
+        gridTemplateColumns: 'var(--dds-tab-widths)',
+      }
+    : {
+        gridAutoColumns: '1fr',
+        gridAutoFlow: 'column',
+      };
+
   return (
     <TabWidthContextProvider onChangeWidths={setWidths}>
-      <div
+      <Grid
+        defaultPageLayout={false}
         {...rest}
         ref={combinedRef}
         role="tablist"
@@ -101,13 +112,9 @@ export const TabList = ({
         tabIndex={0}
         onFocus={handleOnFocus}
         onBlur={handleOnBlur}
-        className={cn(
-          styles['tab-row'],
-          !widths && styles['tab-row--standard-widths'],
-          styles['tab-row--custom-widths'],
-          focusable,
-          scrollbar,
-        )}
+        overflowX="auto"
+        {...gridLayout}
+        className={cn(styles['tab-row'], focusable, scrollbar)}
         style={{ ...style, ...customWidths }}
       >
         {tabListChildren}
@@ -117,7 +124,7 @@ export const TabList = ({
             {...addTabButtonProps}
           />
         )}
-      </div>
+      </Grid>
     </TabWidthContextProvider>
   );
 };

--- a/packages/dds-components/src/components/Tabs/Tabs.module.css
+++ b/packages/dds-components/src/components/Tabs/Tabs.module.css
@@ -1,6 +1,4 @@
 .tab-row {
-  display: grid;
-  overflow-x: auto;
   scroll-snap-type: x mandatory;
   border-bottom: 1px solid var(--dds-color-border-subtle);
 
@@ -12,15 +10,6 @@
   &:focus-visible button {
     outline: none;
   }
-}
-
-.tab-row--standard-widths {
-  grid-auto-flow: column;
-  grid-auto-columns: 1fr;
-}
-
-.tab-row--custom-widths {
-  grid-template-columns: var(--dds-tab-widths);
 }
 
 .tab {

--- a/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.stories.tsx
@@ -195,7 +195,7 @@ export const DifferentWidths = meta.story({
     <>
       <Paragraph withMargins>
         Dette er et eksempel på hvordan du kan sette egne bredder på hver tab
-        med <code>width</code>-attributtet. Det støttes de samme enhetene som i
+        med <code>width</code>-attributtet. Det støttes de samme enhetene som i{' '}
         <code>grid-template-columns</code> i CSS.
       </Paragraph>
       <Tabs {...args}>

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.module.css
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.module.css
@@ -1,9 +1,3 @@
-.bar {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: 1fr;
-}
-
 .content {
   word-break: break-word;
   box-sizing: border-box;

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.tsx
@@ -1,11 +1,10 @@
 import { type ChangeEvent, useId, useState } from 'react';
 
 import { ToggleBarContext } from './ToggleBar.context';
-import styles from './ToggleBar.module.css';
 import { type ToggleBarProps, type ToggleBarValue } from './ToggleBar.types';
 import { getBaseHTMLProps } from '../../types';
 import { combineHandlers } from '../../utils';
-import { VStack } from '../layout';
+import { Grid, VStack } from '../layout';
 import { Typography } from '../Typography';
 
 export const ToggleBar = <T extends string | number = string>(
@@ -61,7 +60,13 @@ export const ToggleBar = <T extends string | number = string>(
             {label}
           </Typography>
         )}
-        <div className={styles.bar}>{children}</div>
+        <Grid
+          defaultPageLayout={false}
+          gridAutoFlow="column"
+          gridAutoColumns="1fr"
+        >
+          {children}
+        </Grid>
       </VStack>
     </ToggleBarContext>
   );

--- a/packages/dds-components/src/components/layout/Grid/Grid.module.css
+++ b/packages/dds-components/src/components/layout/Grid/Grid.module.css
@@ -1,7 +1,43 @@
 /*Grid*/
+
+.dds-grid {
+  --dds-r-grid: var(--dds-r-xs-grid);
+  grid: var(--dds-r-grid);
+}
+
 .dds-grid-template-columns {
   --dds-r-grid-template-columns: var(--dds-r-xs-grid-template-columns);
   grid-template-columns: var(--dds-r-grid-template-columns);
+}
+
+.dds-grid-auto-flow {
+  --dds-r-grid-auto-flow: var(--dds-r-xs-grid-auto-flow);
+  grid-auto-flow: var(--dds-r-grid-auto-flow);
+}
+
+.dds-grid-auto-columns {
+  --dds-r-grid-auto-columns: var(--dds-r-xs-grid-auto-columns);
+  grid-auto-columns: var(--dds-r-grid-auto-columns);
+}
+
+.dds-grid-auto-rows {
+  --dds-r-grid-auto-rows: var(--dds-r-xs-grid-auto-rows);
+  grid-auto-rows: var(--dds-r-grid-auto-rows);
+}
+
+.dds-grid-template {
+  --dds-r-grid-template: var(--dds-r-xs-grid-template);
+  grid-template: var(--dds-r-grid-template);
+}
+
+.dds-grid-template-rows {
+  --dds-r-grid-template-rows: var(--dds-r-xs-grid-template-rows);
+  grid-template-rows: var(--dds-r-grid-template-rows);
+}
+
+.dds-grid-template-areas {
+  --dds-r-grid-template-areas: var(--dds-r-xs-grid-template-areas);
+  grid-template-areas: var(--dds-r-grid-template-areas);
 }
 
 /*GridChild*/
@@ -16,9 +52,14 @@
   grid-row: var(--dds-r-grid-row);
 }
 
+.dds-grid-area {
+  --dds-r-grid-area: var(--dds-r-xs-grid-area);
+  grid-area: var(--dds-r-grid-area);
+}
+
 .dds-j-self {
   --dds-r-j-self: var(--dds-r-xs-j-self);
-  grid-row: var(--dds-r-j-self);
+  justify-self: var(--dds-r-j-self);
 }
 
 .child--first-half {
@@ -33,6 +74,27 @@
   .dds-grid-template-columns {
     --dds-r-grid-template-columns: var(--dds-r-xs-grid-template-columns);
   }
+  .dds-grid {
+    --dds-r-grid: var(--dds-r-xs-grid);
+  }
+  .dds-grid-auto-columns {
+    --dds-r-grid-auto-columns: var(--dds-r-xs-grid-auto-columns);
+  }
+  .dds-grid-auto-rows {
+    --dds-r-grid-auto-rows: var(--dds-r-xs-grid-auto-rows);
+  }
+  .dds-grid-auto-flow {
+    --dds-r-grid-auto-flow: var(--dds-r-xs-grid-auto-flow);
+  }
+  .dds-grid-template {
+    --dds-r-grid-template: var(--dds-r-xs-grid-template);
+  }
+  .dds-grid-template-rows {
+    --dds-r-grid-template-rows: var(--dds-r-xs-grid-template-rows);
+  }
+  .dds-grid-template-areas {
+    --dds-r-grid-template-areas: var(--dds-r-xs-grid-template-areas);
+  }
   .dds-grid-column {
     --dds-r-grid-column: var(--dds-r-xs-grid-column);
   }
@@ -41,6 +103,9 @@
   }
   .dds-grid-row {
     --dds-r-grid-row: var(--dds-r-xs-grid-row);
+  }
+  .dds-grid-area {
+    --dds-r-grid-area: var(--dds-r-xs-grid-area);
   }
   .dds-j-self {
     --dds-r-j-self: var(--dds-r-xs-j-self);
@@ -51,6 +116,27 @@
   .dds-grid-template-columns {
     --dds-r-grid-template-columns: var(--dds-r-sm-grid-template-columns);
   }
+  .dds-grid {
+    --dds-r-grid: var(--dds-r-sm-grid);
+  }
+  .dds-grid-auto-columns {
+    --dds-r-grid-auto-columns: var(--dds-r-sm-grid-auto-columns);
+  }
+  .dds-grid-auto-rows {
+    --dds-r-grid-auto-rows: var(--dds-r-sm-grid-auto-rows);
+  }
+  .dds-grid-auto-flow {
+    --dds-r-grid-auto-flow: var(--dds-r-sm-grid-auto-flow);
+  }
+  .dds-grid-template {
+    --dds-r-grid-template: var(--dds-r-sm-grid-template);
+  }
+  .dds-grid-template-rows {
+    --dds-r-grid-template-rows: var(--dds-r-sm-grid-template-rows);
+  }
+  .dds-grid-template-areas {
+    --dds-r-grid-template-areas: var(--dds-r-sm-grid-template-areas);
+  }
   .dds-grid-column {
     --dds-r-grid-column: var(--dds-r-sm-grid-column);
   }
@@ -59,6 +145,9 @@
   }
   .dds-grid-row {
     --dds-r-grid-row: var(--dds-r-sm-grid-row);
+  }
+  .dds-grid-area {
+    --dds-r-grid-area: var(--dds-r-sm-grid-area);
   }
   .dds-j-self {
     --dds-r-j-self: var(--dds-r-sm-j-self);
@@ -69,6 +158,27 @@
   .dds-grid-template-columns {
     --dds-r-grid-template-columns: var(--dds-r-md-grid-template-columns);
   }
+  .dds-grid {
+    --dds-r-grid: var(--dds-r-md-grid);
+  }
+  .dds-grid-auto-columns {
+    --dds-r-grid-auto-columns: var(--dds-r-md-grid-auto-columns);
+  }
+  .dds-grid-auto-rows {
+    --dds-r-grid-auto-rows: var(--dds-r-md-grid-auto-rows);
+  }
+  .dds-grid-auto-flow {
+    --dds-r-grid-auto-flow: var(--dds-r-md-grid-auto-flow);
+  }
+  .dds-grid-template {
+    --dds-r-grid-template: var(--dds-r-md-grid-template);
+  }
+  .dds-grid-template-rows {
+    --dds-r-grid-template-rows: var(--dds-r-md-grid-template-rows);
+  }
+  .dds-grid-template-areas {
+    --dds-r-grid-template-areas: var(--dds-r-md-grid-template-areas);
+  }
   .dds-grid-column {
     --dds-r-grid-column: var(--dds-r-md-grid-column);
   }
@@ -77,6 +187,9 @@
   }
   .dds-grid-row {
     --dds-r-grid-row: var(--dds-r-md-grid-row);
+  }
+  .dds-grid-area {
+    --dds-r-grid-area: var(--dds-r-md-grid-area);
   }
   .dds-j-self {
     --dds-r-j-self: var(--dds-r-md-j-self);
@@ -87,6 +200,27 @@
   .dds-grid-template-columns {
     --dds-r-grid-template-columns: var(--dds-r-lg-grid-template-columns);
   }
+  .dds-grid {
+    --dds-r-grid: var(--dds-r-lg-grid);
+  }
+  .dds-grid-auto-columns {
+    --dds-r-grid-auto-columns: var(--dds-r-lg-grid-auto-columns);
+  }
+  .dds-grid-auto-rows {
+    --dds-r-grid-auto-rows: var(--dds-r-lg-grid-auto-rows);
+  }
+  .dds-grid-auto-flow {
+    --dds-r-grid-auto-flow: var(--dds-r-lg-grid-auto-flow);
+  }
+  .dds-grid-template {
+    --dds-r-grid-template: var(--dds-r-lg-grid-template);
+  }
+  .dds-grid-template-rows {
+    --dds-r-grid-template-rows: var(--dds-r-lg-grid-template-rows);
+  }
+  .dds-grid-template-areas {
+    --dds-r-grid-template-areas: var(--dds-r-lg-grid-template-areas);
+  }
   .dds-grid-column {
     --dds-r-grid-column: var(--dds-r-lg-grid-column);
   }
@@ -95,6 +229,9 @@
   }
   .dds-grid-row {
     --dds-r-grid-row: var(--dds-r-lg-grid-row);
+  }
+  .dds-grid-area {
+    --dds-r-grid-area: var(--dds-r-lg-grid-area);
   }
   .dds-j-self {
     --dds-r-j-self: var(--dds-r-lg-j-self);
@@ -105,6 +242,27 @@
   .dds-grid-template-columns {
     --dds-r-grid-template-columns: var(--dds-r-xl-grid-template-columns);
   }
+  .dds-grid {
+    --dds-r-grid: var(--dds-r-xl-grid);
+  }
+  .dds-grid-auto-columns {
+    --dds-r-grid-auto-columns: var(--dds-r-xl-grid-auto-columns);
+  }
+  .dds-grid-auto-rows {
+    --dds-r-grid-auto-rows: var(--dds-r-xl-grid-auto-rows);
+  }
+  .dds-grid-auto-flow {
+    --dds-r-grid-auto-flow: var(--dds-r-xl-grid-auto-flow);
+  }
+  .dds-grid-template {
+    --dds-r-grid-template: var(--dds-r-xl-grid-template);
+  }
+  .dds-grid-template-rows {
+    --dds-r-grid-template-rows: var(--dds-r-xl-grid-template-rows);
+  }
+  .dds-grid-template-areas {
+    --dds-r-grid-template-areas: var(--dds-r-xl-grid-template-areas);
+  }
   .dds-grid-column {
     --dds-r-grid-column: var(--dds-r-xl-grid-column);
   }
@@ -113,6 +271,9 @@
   }
   .dds-grid-row {
     --dds-r-grid-row: var(--dds-r-xl-grid-row);
+  }
+  .dds-grid-area {
+    --dds-r-grid-area: var(--dds-r-xl-grid-area);
   }
   .dds-j-self {
     --dds-r-j-self: var(--dds-r-xl-j-self);

--- a/packages/dds-components/src/components/layout/Grid/Grid.stories.tsx
+++ b/packages/dds-components/src/components/layout/Grid/Grid.stories.tsx
@@ -1,7 +1,7 @@
 import preview from '#.storybook/preview';
 
 import {
-  categoryCss,
+  CSSArgType,
   ddsProviderDecorator,
   responsivePropsArgTypes,
   windowWidthDecorator,
@@ -24,7 +24,14 @@ const meta = preview.meta({
   component: Grid,
   argTypes: {
     ...responsivePropsArgTypes,
-    gridTemplateColumns: { control: 'text', table: categoryCss },
+    gridTemplateColumns: CSSArgType,
+    grid: CSSArgType,
+    gridAutoColumns: CSSArgType,
+    gridAutoFlow: CSSArgType,
+    gridAutoRows: CSSArgType,
+    gridTemplate: CSSArgType,
+    gridTemplateAreas: CSSArgType,
+    gridTemplateRows: CSSArgType,
   },
   decorators: [ddsProviderDecorator],
 });

--- a/packages/dds-components/src/components/layout/Grid/Grid.tsx
+++ b/packages/dds-components/src/components/layout/Grid/Grid.tsx
@@ -1,4 +1,3 @@
-import { type Property } from 'csstype';
 import { type ElementType } from 'react';
 
 import styles from './Grid.module.css';
@@ -8,10 +7,7 @@ import {
 } from '../../../types';
 import { cn } from '../../../utils';
 import { Box } from '../Box';
-import {
-  type ResponsiveGridProps,
-  type ResponsiveProp,
-} from '../common/Responsive.types';
+import { type ResponsiveGridProps } from '../common/Responsive.types';
 import { getResponsiveCSSProperties } from '../common/utils';
 
 export type GridProps<T extends ElementType = 'div'> =
@@ -27,7 +23,11 @@ export type GridProps<T extends ElementType = 'div'> =
         xl: 'repeat(var(--dds-grid-xl-count), minmax(0, 1fr))',
         }
         */
-      gridTemplateColumns?: ResponsiveProp<Property.GridTemplateColumns>;
+      gridTemplateColumns?: ResponsiveGridProps['gridTemplateColumns'];
+      /** Om standard styling for sideoppsett skal brukes.
+       * @default true
+       */
+      defaultPageLayout?: boolean;
     } & ResponsiveGridProps
   >;
 
@@ -35,6 +35,7 @@ export const Grid = <T extends ElementType = 'div'>({
   id,
   className,
   htmlProps,
+  defaultPageLayout = true,
   display = 'grid',
   grid,
   gridAutoColumns,
@@ -43,34 +44,56 @@ export const Grid = <T extends ElementType = 'div'>({
   gridTemplate,
   gridTemplateAreas,
   gridTemplateRows,
-  gridTemplateColumns = {
-    xs: 'repeat(var(--dds-grid-xs-count), minmax(0, 1fr))',
-    sm: 'repeat(var(--dds-grid-sm-count), minmax(0, 1fr))',
-    md: 'repeat(var(--dds-grid-md-count), minmax(0, 1fr))',
-    lg: 'repeat(var(--dds-grid-lg-count), minmax(0, 1fr))',
-    xl: 'repeat(var(--dds-grid-xl-count), minmax(0, 1fr))',
-  },
-  columnGap = {
-    xs: 'var(--dds-grid-xs-gutter-size)',
-    sm: 'var(--dds-grid-sm-gutter-size)',
-    md: 'var(--dds-grid-md-gutter-size)',
-    lg: 'var(--dds-grid-lg-gutter-size)',
-    xl: 'var(--dds-grid-xl-gutter-size)',
-  },
-  rowGap = {
-    xs: 'var(--dds-grid-xs-gutter-size)',
-    sm: 'var(--dds-grid-sm-gutter-size)',
-    md: 'var(--dds-grid-md-gutter-size)',
-    lg: 'var(--dds-grid-lg-gutter-size)',
-    xl: 'var(--dds-grid-xl-gutter-size)',
-  },
-  marginInline = { xs: 'x2', sm: 'x2', md: 'x4', lg: 'x6', xl: 'x10' },
+  gridTemplateColumns,
+  columnGap,
+  rowGap,
+  marginInline,
   style,
   ...rest
 }: GridProps<T>) => {
+  const defaultLayoutStyles = {
+    gridTemplateColumns: gridTemplateColumns
+      ? gridTemplateColumns
+      : defaultPageLayout
+        ? {
+            xs: 'repeat(var(--dds-grid-xs-count), minmax(0, 1fr))',
+            sm: 'repeat(var(--dds-grid-sm-count), minmax(0, 1fr))',
+            md: 'repeat(var(--dds-grid-md-count), minmax(0, 1fr))',
+            lg: 'repeat(var(--dds-grid-lg-count), minmax(0, 1fr))',
+            xl: 'repeat(var(--dds-grid-xl-count), minmax(0, 1fr))',
+          }
+        : undefined,
+    columnGap: columnGap
+      ? columnGap
+      : defaultPageLayout
+        ? {
+            xs: 'var(--dds-grid-xs-gutter-size)',
+            sm: 'var(--dds-grid-sm-gutter-size)',
+            md: 'var(--dds-grid-md-gutter-size)',
+            lg: 'var(--dds-grid-lg-gutter-size)',
+            xl: 'var(--dds-grid-xl-gutter-size)',
+          }
+        : undefined,
+    rowGap: rowGap
+      ? rowGap
+      : defaultPageLayout
+        ? {
+            xs: 'var(--dds-grid-xs-gutter-size)',
+            sm: 'var(--dds-grid-sm-gutter-size)',
+            md: 'var(--dds-grid-md-gutter-size)',
+            lg: 'var(--dds-grid-lg-gutter-size)',
+            xl: 'var(--dds-grid-xl-gutter-size)',
+          }
+        : undefined,
+    marginInline: marginInline
+      ? marginInline
+      : defaultPageLayout
+        ? { xs: 'x2', sm: 'x2', md: 'x4', lg: 'x6', xl: 'x10' }
+        : undefined,
+  };
   const styleVariables = {
     ...getResponsiveCSSProperties(
-      gridTemplateColumns,
+      defaultLayoutStyles.gridTemplateColumns,
       'r',
       'grid-template-columns',
     ),
@@ -86,13 +109,15 @@ export const Grid = <T extends ElementType = 'div'>({
       'grid-template-areas',
     ),
   };
+
   return (
     <Box
       {...getBaseHTMLProps(
         id,
         cn(
           className,
-          gridTemplateColumns && styles['dds-grid-template-columns'],
+          defaultLayoutStyles.gridTemplateColumns &&
+            styles['dds-grid-template-columns'],
           grid && styles['dds-grid'],
           gridAutoColumns && styles['dds-grid-auto-columns'],
           gridAutoFlow && styles['dds-grid-auto-flow'],
@@ -106,9 +131,9 @@ export const Grid = <T extends ElementType = 'div'>({
         rest,
       )}
       display={display}
-      marginInline={marginInline}
-      columnGap={columnGap}
-      rowGap={rowGap}
+      marginInline={defaultLayoutStyles.marginInline}
+      columnGap={defaultLayoutStyles.columnGap}
+      rowGap={defaultLayoutStyles.rowGap}
     />
   );
 };

--- a/packages/dds-components/src/components/layout/Grid/Grid.tsx
+++ b/packages/dds-components/src/components/layout/Grid/Grid.tsx
@@ -1,43 +1,48 @@
 import { type Property } from 'csstype';
 import { type ElementType } from 'react';
 
+import styles from './Grid.module.css';
 import {
   type PolymorphicBaseComponentProps,
   getBaseHTMLProps,
 } from '../../../types';
 import { cn } from '../../../utils';
 import { Box } from '../Box';
-import styles from './Grid.module.css';
 import {
+  type ResponsiveGridProps,
   type ResponsiveProp,
-  type ResponsiveProps,
 } from '../common/Responsive.types';
 import { getResponsiveCSSProperties } from '../common/utils';
 
 export type GridProps<T extends ElementType = 'div'> =
   PolymorphicBaseComponentProps<
     T,
-    Omit<
-      {
-        /** CSS `grid-template-columns`. Støtter standardverdier per brekkpunkt eller samme for alle skjermstørrelser.
+    {
+      /** CSS `grid-template-columns`. Støtter standardverdier per brekkpunkt eller samme for alle skjermstørrelser.
          * @default {
-              xs: 'repeat(var(--dds-grid-xs-count), minmax(0, 1fr))',
-              sm: 'repeat(var(--dds-grid-sm-count), minmax(0, 1fr))',
-              md: 'repeat(var(--dds-grid-md-count), minmax(0, 1fr))',
-              lg: 'repeat(var(--dds-grid-lg-count), minmax(0, 1fr))',
-              xl: 'repeat(var(--dds-grid-xl-count), minmax(0, 1fr))',
-            }
-         */
-        gridTemplateColumns?: ResponsiveProp<Property.GridTemplateColumns>;
-      } & ResponsiveProps,
-      'display'
-    >
+        xs: 'repeat(var(--dds-grid-xs-count), minmax(0, 1fr))',
+        sm: 'repeat(var(--dds-grid-sm-count), minmax(0, 1fr))',
+        md: 'repeat(var(--dds-grid-md-count), minmax(0, 1fr))',
+        lg: 'repeat(var(--dds-grid-lg-count), minmax(0, 1fr))',
+        xl: 'repeat(var(--dds-grid-xl-count), minmax(0, 1fr))',
+        }
+        */
+      gridTemplateColumns?: ResponsiveProp<Property.GridTemplateColumns>;
+    } & ResponsiveGridProps
   >;
 
 export const Grid = <T extends ElementType = 'div'>({
   id,
   className,
   htmlProps,
+  display = 'grid',
+  grid,
+  gridAutoColumns,
+  gridAutoFlow,
+  gridAutoRows,
+  gridTemplate,
+  gridTemplateAreas,
+  gridTemplateRows,
   gridTemplateColumns = {
     xs: 'repeat(var(--dds-grid-xs-count), minmax(0, 1fr))',
     sm: 'repeat(var(--dds-grid-sm-count), minmax(0, 1fr))',
@@ -69,17 +74,38 @@ export const Grid = <T extends ElementType = 'div'>({
       'r',
       'grid-template-columns',
     ),
+    ...getResponsiveCSSProperties(grid, 'r', 'grid'),
+    ...getResponsiveCSSProperties(gridAutoColumns, 'r', 'grid-auto-columns'),
+    ...getResponsiveCSSProperties(gridAutoFlow, 'r', 'grid-auto-flow'),
+    ...getResponsiveCSSProperties(gridAutoRows, 'r', 'grid-auto-rows'),
+    ...getResponsiveCSSProperties(gridTemplate, 'r', 'grid-template'),
+    ...getResponsiveCSSProperties(gridTemplateRows, 'r', 'grid-template-rows'),
+    ...getResponsiveCSSProperties(
+      gridTemplateAreas,
+      'r',
+      'grid-template-areas',
+    ),
   };
   return (
     <Box
-      display="grid"
       {...getBaseHTMLProps(
         id,
-        cn(className, styles['dds-grid-template-columns']),
+        cn(
+          className,
+          gridTemplateColumns && styles['dds-grid-template-columns'],
+          grid && styles['dds-grid'],
+          gridAutoColumns && styles['dds-grid-auto-columns'],
+          gridAutoFlow && styles['dds-grid-auto-flow'],
+          gridAutoRows && styles['dds-grid-auto-rows'],
+          gridTemplate && styles['dds-grid-template'],
+          gridTemplateRows && styles['dds-grid-template-rows'],
+          gridTemplateAreas && styles['dds-grid-template-areas'],
+        ),
         { ...style, ...styleVariables },
         htmlProps,
         rest,
       )}
+      display={display}
       marginInline={marginInline}
       columnGap={columnGap}
       rowGap={rowGap}

--- a/packages/dds-components/src/components/layout/Grid/Grid.tsx
+++ b/packages/dds-components/src/components/layout/Grid/Grid.tsx
@@ -10,6 +10,24 @@ import { Box } from '../Box';
 import { type ResponsiveGridProps } from '../common/Responsive.types';
 import { getResponsiveCSSProperties } from '../common/utils';
 
+const DEFAULT_PAGE_LAYOUT = {
+  gridTemplateColumns: {
+    xs: 'repeat(var(--dds-grid-xs-count), minmax(0, 1fr))',
+    sm: 'repeat(var(--dds-grid-sm-count), minmax(0, 1fr))',
+    md: 'repeat(var(--dds-grid-md-count), minmax(0, 1fr))',
+    lg: 'repeat(var(--dds-grid-lg-count), minmax(0, 1fr))',
+    xl: 'repeat(var(--dds-grid-xl-count), minmax(0, 1fr))',
+  },
+  gutterSize: {
+    xs: 'var(--dds-grid-xs-gutter-size)',
+    sm: 'var(--dds-grid-sm-gutter-size)',
+    md: 'var(--dds-grid-md-gutter-size)',
+    lg: 'var(--dds-grid-lg-gutter-size)',
+    xl: 'var(--dds-grid-xl-gutter-size)',
+  },
+  marginInline: { xs: 'x2', sm: 'x2', md: 'x4', lg: 'x6', xl: 'x10' },
+} as const;
+
 export type GridProps<T extends ElementType = 'div'> =
   PolymorphicBaseComponentProps<
     T,
@@ -25,6 +43,7 @@ export type GridProps<T extends ElementType = 'div'> =
         */
       gridTemplateColumns?: ResponsiveGridProps['gridTemplateColumns'];
       /** Om standard styling for sideoppsett skal brukes.
+       * Ved `true` settes overskrivbare standard verdier for `grid-template-columns`, `marginInline`, `rowGap` og `columnGap` som er tilpasset sideoppsett.
        * @default true
        */
       defaultPageLayout?: boolean;
@@ -51,49 +70,15 @@ export const Grid = <T extends ElementType = 'div'>({
   style,
   ...rest
 }: GridProps<T>) => {
-  const defaultLayoutStyles = {
-    gridTemplateColumns: gridTemplateColumns
-      ? gridTemplateColumns
-      : defaultPageLayout
-        ? {
-            xs: 'repeat(var(--dds-grid-xs-count), minmax(0, 1fr))',
-            sm: 'repeat(var(--dds-grid-sm-count), minmax(0, 1fr))',
-            md: 'repeat(var(--dds-grid-md-count), minmax(0, 1fr))',
-            lg: 'repeat(var(--dds-grid-lg-count), minmax(0, 1fr))',
-            xl: 'repeat(var(--dds-grid-xl-count), minmax(0, 1fr))',
-          }
-        : undefined,
-    columnGap: columnGap
-      ? columnGap
-      : defaultPageLayout
-        ? {
-            xs: 'var(--dds-grid-xs-gutter-size)',
-            sm: 'var(--dds-grid-sm-gutter-size)',
-            md: 'var(--dds-grid-md-gutter-size)',
-            lg: 'var(--dds-grid-lg-gutter-size)',
-            xl: 'var(--dds-grid-xl-gutter-size)',
-          }
-        : undefined,
-    rowGap: rowGap
-      ? rowGap
-      : defaultPageLayout
-        ? {
-            xs: 'var(--dds-grid-xs-gutter-size)',
-            sm: 'var(--dds-grid-sm-gutter-size)',
-            md: 'var(--dds-grid-md-gutter-size)',
-            lg: 'var(--dds-grid-lg-gutter-size)',
-            xl: 'var(--dds-grid-xl-gutter-size)',
-          }
-        : undefined,
-    marginInline: marginInline
-      ? marginInline
-      : defaultPageLayout
-        ? { xs: 'x2', sm: 'x2', md: 'x4', lg: 'x6', xl: 'x10' }
-        : undefined,
-  };
+  const pageDefaults = defaultPageLayout ? DEFAULT_PAGE_LAYOUT : null;
+  const resolvedGridTemplateColumns =
+    gridTemplateColumns ?? pageDefaults?.gridTemplateColumns;
+  const resolvedColumnGap = columnGap ?? pageDefaults?.gutterSize;
+  const resolvedRowGap = rowGap ?? pageDefaults?.gutterSize;
+  const resolvedMarginInline = marginInline ?? pageDefaults?.marginInline;
   const styleVariables = {
     ...getResponsiveCSSProperties(
-      defaultLayoutStyles.gridTemplateColumns,
+      resolvedGridTemplateColumns,
       'r',
       'grid-template-columns',
     ),
@@ -116,8 +101,7 @@ export const Grid = <T extends ElementType = 'div'>({
         id,
         cn(
           className,
-          defaultLayoutStyles.gridTemplateColumns &&
-            styles['dds-grid-template-columns'],
+          resolvedGridTemplateColumns && styles['dds-grid-template-columns'],
           grid && styles['dds-grid'],
           gridAutoColumns && styles['dds-grid-auto-columns'],
           gridAutoFlow && styles['dds-grid-auto-flow'],
@@ -131,9 +115,9 @@ export const Grid = <T extends ElementType = 'div'>({
         rest,
       )}
       display={display}
-      marginInline={defaultLayoutStyles.marginInline}
-      columnGap={defaultLayoutStyles.columnGap}
-      rowGap={defaultLayoutStyles.rowGap}
+      marginInline={resolvedMarginInline}
+      columnGap={resolvedColumnGap}
+      rowGap={resolvedRowGap}
     />
   );
 };

--- a/packages/dds-components/src/components/layout/Grid/GridChild.stories.tsx
+++ b/packages/dds-components/src/components/layout/Grid/GridChild.stories.tsx
@@ -1,7 +1,7 @@
 import preview from '#.storybook/preview';
 
 import { Paper } from '..';
-import { categoryCss, responsivePropsArgTypes } from '../../../storybook';
+import { CSSArgType, responsivePropsArgTypes } from '../../../storybook';
 
 import { Grid, GridChild } from '.';
 
@@ -9,10 +9,11 @@ const meta = preview.meta({
   title: 'dds-components/Layout Primitives/Grid/GridChild',
   component: GridChild,
   argTypes: {
-    gridRow: { control: 'text' },
-    justifySelf: { control: 'text', table: categoryCss },
     columnsOccupied: { control: 'text' },
     ...responsivePropsArgTypes,
+    gridRow: CSSArgType,
+    justifySelf: CSSArgType,
+    gridArea: CSSArgType,
   },
 });
 

--- a/packages/dds-components/src/components/layout/Grid/GridChild.tsx
+++ b/packages/dds-components/src/components/layout/Grid/GridChild.tsx
@@ -34,6 +34,8 @@ export type GridChildProps<T extends ElementType = 'div'> =
       justifySelf?: ResponsiveProp<Property.JustifySelf>;
       /**CSS `grid-row`. Støtter verdi per brekkpunkt eller samme for alle skjermstørrelser. */
       gridRow?: ResponsiveProp<Property.GridRow>;
+      /**CSS `grid-area`. Støtter verdi per brekkpunkt eller samme for alle skjermstørrelser. */
+      gridArea?: ResponsiveProp<Property.GridArea>;
     } & Omit<ResponsiveProps, 'display'>
   >;
 
@@ -43,12 +45,14 @@ export const GridChild = <T extends ElementType = 'div'>({
   htmlProps,
   style,
   gridRow,
+  gridArea,
   justifySelf,
   columnsOccupied,
   ...rest
 }: GridChildProps<T>) => {
   const styleVariables: Properties = {
     ...getResponsiveCSSProperties(gridRow, 'r', 'grid-row'),
+    ...getResponsiveCSSProperties(gridArea, 'r', 'grid-area'),
     ...getResponsiveCSSProperties(justifySelf, 'r', 'j-self'),
     ...getResponsiveCSSProperties(columnsOccupied, 'r', 'grid-column'),
   };
@@ -61,6 +65,7 @@ export const GridChild = <T extends ElementType = 'div'>({
           className,
           styles['child-col-count'],
           gridRow && styles['dds-grid-row'],
+          gridArea && styles['dds-grid-area'],
           justifySelf && styles['dds-j-self'],
           columnsOccupied && styles['dds-grid-column'],
           columnsOccupied === 'firstHalf' && styles['child--first-half'],

--- a/packages/dds-components/src/components/layout/common/Responsive.types.tsx
+++ b/packages/dds-components/src/components/layout/common/Responsive.types.tsx
@@ -116,8 +116,11 @@ export type ResponsiveStackProps = Omit<
   'display' | 'flexDirection'
 >;
 
-export type ResponsiveGridProps = Omit<PrimitiveLayoutProps, 'display'> & {
+export type ResponsiveGridProps = Omit<ResponsiveProps, 'display'> & {
+  /** CSS `display`.  Støtter verdi per brekkpunkt eller samme for alle skjermstørrelser. */
   display?: ExtractStrict<Property.Display, 'grid' | 'inline-grid'>;
+  /** CSS `grid-template-columns`. Støtter standardverdier per brekkpunkt eller samme for alle skjermstørrelser. */
+  gridTemplateColumns?: ResponsiveProp<Property.GridTemplateColumns>;
   /** CSS `grid`. Støtter standardverdier per brekkpunkt eller samme for alle skjermstørrelser. */
   grid?: ResponsiveProp<Property.Grid>;
   /** CSS `grid-auto-columns`. Støtter standardverdier per brekkpunkt eller samme for alle skjermstørrelser. */

--- a/packages/dds-components/src/components/layout/common/Responsive.types.tsx
+++ b/packages/dds-components/src/components/layout/common/Responsive.types.tsx
@@ -1,5 +1,7 @@
 import { type Property } from 'csstype';
 
+import { type ExtractStrict } from '../../..';
+
 export const BREAKPOINTS = ['xs', 'sm', 'md', 'lg', 'xl'] as const;
 export type Breakpoint = (typeof BREAKPOINTS)[number];
 
@@ -113,6 +115,25 @@ export type ResponsiveStackProps = Omit<
   ResponsiveProps,
   'display' | 'flexDirection'
 >;
+
+export type ResponsiveGridProps = Omit<PrimitiveLayoutProps, 'display'> & {
+  display?: ExtractStrict<Property.Display, 'grid' | 'inline-grid'>;
+  /** CSS `grid`. Støtter standardverdier per brekkpunkt eller samme for alle skjermstørrelser. */
+  grid?: ResponsiveProp<Property.Grid>;
+  /** CSS `grid-auto-columns`. Støtter standardverdier per brekkpunkt eller samme for alle skjermstørrelser. */
+  gridAutoColumns?: ResponsiveProp<Property.GridAutoColumns>;
+  /** CSS `grid-auto-rows`. Støtter standardverdier per brekkpunkt eller samme for alle skjermstørrelser. */
+  gridAutoRows?: ResponsiveProp<Property.GridAutoRows>;
+  /** CSS `grid-auto-flow`. Støtter standardverdier per brekkpunkt eller samme for alle skjermstørrelser. */
+  gridAutoFlow?: ResponsiveProp<Property.GridAutoFlow>;
+  /** CSS `grid-template-rows`. Støtter standardverdier per brekkpunkt eller samme for alle skjermstørrelser. */
+  gridTemplateRows?: ResponsiveProp<Property.GridTemplateRows>;
+  /** CSS `grid-template`. Støtter standardverdier per brekkpunkt eller samme for alle skjermstørrelser. */
+  gridTemplate?: ResponsiveProp<Property.GridTemplate>;
+  /** CSS `grid-template-areas`. Støtter standardverdier per brekkpunkt eller samme for alle skjermstørrelser. */
+  gridTemplateAreas?: ResponsiveProp<Property.GridTemplateAreas>;
+};
+
 export type ResponsiveBleedProps = PrimitiveLayoutProps & {
   /**Setter negativ CSS `margin-inline`, overskriver prop `marginInline`. Støtter standardverdier og dds spacing tokens skala, per brekkpunkt eller samme for alle skjermstørrelser.*/
   bleedMarginInline?: ResponsiveProp<Property.MarginInline | SpacingScale>;


### PR DESCRIPTION
## Beskrivelse

Layout primitives manglet noen CSS props relatert til grid.

I `<Grid>`:
- `display` med verdiene `'grid'` (default) og `'inline-grid'`
- `grid`
- `gridAutoColumns`
- `gridAutoFlow`
- `gridAutoRows`
- `gridTemplate`
- `gridTemplateAreas`
- `gridTemplateRows`

I `<GridChild>`: `gridArea`

Andre relaterte endringer:

- Ny prop `defaultPageLayout` i `<Grid>`. Tillater å slå av default styling som implementerer standard sideoppsett slik det er i Figma.
- Tar i bruk `<Grid>` under panseret der relevant på tvers a komponenter.
- Fikser bug der `justifySelf` prop i `<GridChild>` satt CSS `grid-row` istedenfor `justify-self`.
- Fikser bug der `<Icon>` ikke registrerte styling fra `style` prop.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
