### PR TITLE
ELSA1-885: testing av CSS-variabler

### DIFF
--- a/packages/dds-components/src/components/Accordion/Accordion.module.css
+++ b/packages/dds-components/src/components/Accordion/Accordion.module.css
@@ -23,10 +23,6 @@
   }
 }
 
-.body {
-  height: var(--dds-card-accordion-body-height);
-}
-
 .chevron {
   margin-inline-end: var(--dds-spacing-x0-5);
 }

--- a/packages/dds-components/src/components/Icon/overview-page/icons.module.css
+++ b/packages/dds-components/src/components/Icon/overview-page/icons.module.css
@@ -58,5 +58,5 @@ pre.icon-code {
   text-transform: uppercase;
   scale: 90%;
   background-color: var(--dds-color-surface-highlighted-default);
-  border-radius: var(--dds-border-radius-);
+  border-radius: var(--dds-border-radius-surface);
 }

--- a/packages/dds-components/src/components/Spinner/Spinner.tsx
+++ b/packages/dds-components/src/components/Spinner/Spinner.tsx
@@ -1,5 +1,5 @@
-import { type Properties, type Property } from 'csstype';
-import { type HTMLAttributes, useId, useRef } from 'react';
+import { type Property } from 'csstype';
+import { type HTMLAttributes, useId } from 'react';
 
 import styles from './Spinner.module.css';
 import { useTranslation } from '../../i18n';
@@ -40,14 +40,6 @@ export function Spinner(props: SpinnerProps) {
 
   const { t } = useTranslation();
 
-  const mountTime = useRef(Date.now());
-  const animationDelay = -(mountTime.current % 1500);
-
-  const styleVariables: Properties = {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ['--dds-spinner-animation-delay' as any]: animationDelay,
-  };
-
   const generatedId = useId();
   const uniqueId = `${generatedId}-spinnerTitle`;
 
@@ -75,7 +67,6 @@ export function Spinner(props: SpinnerProps) {
         r="6"
         fill={getTextColor(color)}
         className={styles.jordskifterett}
-        style={styleVariables}
       />
       <rect
         x="4"
@@ -84,13 +75,11 @@ export function Spinner(props: SpinnerProps) {
         height="4"
         fill={getTextColor(color)}
         className={styles.lagmannsrett}
-        style={styleVariables}
       />
       <path
         d="M12 16.6154C16.4183 16.6154 20 12.7581 20 8H4C4 12.7581 7.58172 16.6154 12 16.6154Z"
         fill={getTextColor(color)}
         className={styles.tingrett}
-        style={styleVariables}
       />
     </svg>
   );

--- a/packages/dds-components/src/components/layout/Paper/Paper.tsx
+++ b/packages/dds-components/src/components/layout/Paper/Paper.tsx
@@ -12,7 +12,7 @@ import {
 import { cn } from '../../../utils';
 import { Box } from '../../layout/Box/Box';
 import { type ResponsiveProps } from '../common';
-import { getResponsiveCSSProperties } from '../common/utils';
+import { getCSSProperties } from '../common/utils';
 
 export type PaperElevation = Elevation;
 export type PaperBorder = BorderColor;
@@ -51,8 +51,8 @@ export const Paper = <T extends ElementType = 'div'>({
   ...rest
 }: PaperProps<T>) => {
   const styleVariables = {
-    ...getResponsiveCSSProperties(background, 'paper-background'),
-    ...getResponsiveCSSProperties(border, 'paper-border'),
+    ...getCSSProperties(background, 'paper', 'background'),
+    ...getCSSProperties(border, 'paper', 'border'),
   };
 
   return (

--- a/packages/dds-components/src/components/layout/common/layout.module.css
+++ b/packages/dds-components/src/components/layout/common/layout.module.css
@@ -31,12 +31,12 @@
 }
 
 .dds-bleed-m-i {
-  --dds-r-bleed-m-i: var(--dds-r-bleed-xs-m-i);
+  --dds-r-bleed-m-i: var(--dds-r-xs-bleed-m-i);
   margin-inline: var(--dds-r-bleed-m-i, initial);
 }
 
 .dds-bleed-m-b {
-  --dds-r-bleed-m-b: var(--dds-r-bleed-xs-m-b);
+  --dds-r-bleed-m-b: var(--dds-r-xs-bleed-m-b);
   margin-block: var(--dds-r-bleed-m-b, initial);
 }
 
@@ -207,10 +207,10 @@
     --dds-r-m-b: var(--dds-r-xs-m-b);
   }
   .dds-bleed-m-i {
-    --dds-r-bleed-m-i: var(--dds-r-bleed-xs-m-i);
+    --dds-r-bleed-m-i: var(--dds-r-xs-bleed-m-i);
   }
   .dds-bleed-m-b {
-    --dds-r-bleed-m-b: var(--dds-r-bleed-xs-m-b);
+    --dds-r-bleed-m-b: var(--dds-r-xs-bleed-m-b);
   }
   .dds-h {
     --dds-r-h: var(--dds-r-xs-h);
@@ -219,7 +219,7 @@
     --dds-r-max-h: var(--dds-r-xs-max-h);
   }
   .dds-min-h {
-    --dds-r-max-h: var(--dds-r-xs-max-h);
+    --dds-r-min-h: var(--dds-r-xs-min-h);
   }
   .dds-w {
     --dds-r-w: var(--dds-r-xs-w);
@@ -321,10 +321,10 @@
     --dds-r-m-b: var(--dds-r-sm-m-b);
   }
   .dds-bleed-m-i {
-    --dds-r-bleed-m-i: var(--dds-r-bleed-sm-m-i);
+    --dds-r-bleed-m-i: var(--dds-r-sm-bleed-m-i);
   }
   .dds-bleed-m-b {
-    --dds-r-bleed-m-b: var(--dds-r-bleed-sm-m-b);
+    --dds-r-bleed-m-b: var(--dds-r-sm-bleed-m-b);
   }
   .dds-h {
     --dds-r-h: var(--dds-r-sm-h);
@@ -333,7 +333,7 @@
     --dds-r-max-h: var(--dds-r-sm-max-h);
   }
   .dds-min-h {
-    --dds-r-max-h: var(--dds-r-sm-max-h);
+    --dds-r-min-h: var(--dds-r-sm-min-h);
   }
   .dds-w {
     --dds-r-w: var(--dds-r-sm-w);
@@ -435,10 +435,10 @@
     --dds-r-m-b: var(--dds-r-md-m-b);
   }
   .dds-bleed-m-i {
-    --dds-r-bleed-m-i: var(--dds-r-bleed-md-m-i);
+    --dds-r-bleed-m-i: var(--dds-r-md-bleed-m-i);
   }
   .dds-bleed-m-b {
-    --dds-r-bleed-m-b: var(--dds-r-bleed-md-m-b);
+    --dds-r-bleed-m-b: var(--dds-r-md-bleed-m-b);
   }
   .dds-h {
     --dds-r-h: var(--dds-r-md-h);
@@ -447,7 +447,7 @@
     --dds-r-max-h: var(--dds-r-md-max-h);
   }
   .dds-min-h {
-    --dds-r-max-h: var(--dds-r-md-max-h);
+    --dds-r-min-h: var(--dds-r-md-min-h);
   }
   .dds-w {
     --dds-r-w: var(--dds-r-md-w);
@@ -549,10 +549,10 @@
     --dds-r-m-b: var(--dds-r-lg-m-b);
   }
   .dds-bleed-m-i {
-    --dds-r-bleed-m-i: var(--dds-r-bleed-lg-m-i);
+    --dds-r-bleed-m-i: var(--dds-r-lg-bleed-m-i);
   }
   .dds-bleed-m-b {
-    --dds-r-bleed-m-b: var(--dds-r-bleed-lg-m-b);
+    --dds-r-bleed-m-b: var(--dds-r-lg-bleed-m-b);
   }
   .dds-h {
     --dds-r-h: var(--dds-r-lg-h);
@@ -561,7 +561,7 @@
     --dds-r-max-h: var(--dds-r-lg-max-h);
   }
   .dds-min-h {
-    --dds-r-max-h: var(--dds-r-lg-max-h);
+    --dds-r-min-h: var(--dds-r-lg-min-h);
   }
   .dds-w {
     --dds-r-w: var(--dds-r-lg-w);
@@ -663,10 +663,10 @@
     --dds-r-m-b: var(--dds-r-xl-m-b);
   }
   .dds-bleed-m-i {
-    --dds-r-bleed-m-i: var(--dds-r-bleed-xl-m-i);
+    --dds-r-bleed-m-i: var(--dds-r-xl-bleed-m-i);
   }
   .dds-bleed-m-b {
-    --dds-r-bleed-m-b: var(--dds-r-bleed-xl-m-b);
+    --dds-r-bleed-m-b: var(--dds-r-xl-bleed-m-b);
   }
   .dds-h {
     --dds-r-h: var(--dds-r-xl-h);

--- a/packages/dds-components/src/components/layout/common/layout.module.css.spec.ts
+++ b/packages/dds-components/src/components/layout/common/layout.module.css.spec.ts
@@ -1,0 +1,162 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const cssPath = fileURLToPath(new URL('./layout.module.css', import.meta.url));
+const css = readFileSync(cssPath, 'utf-8');
+
+const BREAKPOINTS = [
+  { name: 'xs', mediaQuery: '(max-width: 599px)' },
+  { name: 'sm', mediaQuery: '(min-width: 600px)' },
+  { name: 'md', mediaQuery: '(min-width: 960px)' },
+  { name: 'lg', mediaQuery: '(min-width: 1280px)' },
+  { name: 'xl', mediaQuery: '(min-width: 1920px)' },
+] as const;
+
+/** Returnerer top-level (non-media-query) rules som { className → ruleBody }. */
+function getTopLevelRules(cssText: string): Record<string, string> {
+  let stripped = '';
+  let depth = 0;
+  let inMedia = false;
+
+  for (let i = 0; i < cssText.length; i++) {
+    if (!inMedia && cssText.startsWith('@media', i)) {
+      inMedia = true;
+    }
+    if (cssText[i] === '{') {
+      depth++;
+      if (!inMedia) stripped += cssText[i];
+      continue;
+    }
+    if (cssText[i] === '}') {
+      depth--;
+      if (inMedia && depth === 0) {
+        inMedia = false;
+        continue;
+      }
+      if (!inMedia) stripped += cssText[i];
+      continue;
+    }
+    if (!inMedia) stripped += cssText[i];
+  }
+
+  const rules: Record<string, string> = {};
+  const re = /\.(dds-[\w-]+)\s*\{([^}]+)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(stripped)) !== null) {
+    rules[m[1]] = m[2];
+  }
+  return rules;
+}
+
+/** Returnerer @media-blokker som { mediaCondition → { className → ruleBody } }. */
+function getMediaQueryBlocks(
+  cssText: string,
+): Record<string, Record<string, string>> {
+  const blocks: Record<string, Record<string, string>> = {};
+  let i = 0;
+
+  while (i < cssText.length) {
+    const mediaIdx = cssText.indexOf('@media', i);
+    if (mediaIdx === -1) break;
+
+    const openBrace = cssText.indexOf('{', mediaIdx);
+    const condition = cssText.slice(mediaIdx + 6, openBrace).trim();
+
+    let depth = 0;
+    let end = -1;
+    for (let j = openBrace; j < cssText.length; j++) {
+      if (cssText[j] === '{') depth++;
+      if (cssText[j] === '}') {
+        depth--;
+        if (depth === 0) {
+          end = j;
+          break;
+        }
+      }
+    }
+
+    const blockContent = cssText.slice(openBrace + 1, end);
+    const rules: Record<string, string> = {};
+    const re = /\.(dds-[\w-]+)\s*\{([^}]+)\}/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(blockContent)) !== null) {
+      rules[m[1]] = m[2];
+    }
+    blocks[condition] = rules;
+    i = end + 1;
+  }
+  return blocks;
+}
+
+const topLevelRules = getTopLevelRules(css);
+const mediaBlocks = getMediaQueryBlocks(css);
+
+const topLevelRuleEntries = Object.entries(topLevelRules).map(
+  ([className, body]) => ({
+    className,
+    body,
+    suffix: className.replace(/^dds-/, ''),
+  }),
+);
+
+describe('layout.module.css', () => {
+  describe('base classes (.dds-<suffix>)', () => {
+    it.each(topLevelRuleEntries)(
+      '.dds-$suffix contains CSS-variabel --dds-r-$suffix: var(--dds-r-xs-$suffix)',
+      ({ suffix, body }) => {
+        expect(body).toContain(`--dds-r-${suffix}: var(--dds-r-xs-${suffix})`);
+      },
+    );
+
+    it.each(topLevelRuleEntries)(
+      '.dds-$suffix contains CSS-property with value var(--dds-r-$suffix, initial)',
+      ({ suffix, body }) => {
+        expect(body).toContain(`var(--dds-r-${suffix}, initial)`);
+      },
+    );
+  });
+
+  describe('@media queries', () => {
+    it('has @media rules for all breakpoints', () => {
+      for (const { mediaQuery } of BREAKPOINTS) {
+        expect(
+          Object.keys(mediaBlocks),
+          `missing @media ${mediaQuery}`,
+        ).toContain(mediaQuery);
+      }
+    });
+
+    it('has exactly 5 @media blocks (one per breakpoint)', () => {
+      expect(Object.keys(mediaBlocks)).toHaveLength(BREAKPOINTS.length);
+    });
+
+    describe.each(BREAKPOINTS)(
+      '@media $mediaQuery (breakpoint: $name)',
+      ({ name, mediaQuery }) => {
+        it('contains all .dds-<suffix> classes from top level', () => {
+          const rules = mediaBlocks[mediaQuery] ?? {};
+          for (const className of Object.keys(topLevelRules)) {
+            expect(
+              Object.keys(rules),
+              `missing .${className} in @media ${mediaQuery}`,
+            ).toContain(className);
+          }
+        });
+
+        it.each(topLevelRuleEntries)(
+          '.dds-$suffix has --dds-r-$suffix: var(--dds-r-' + name + '-$suffix)',
+          ({ className, suffix }) => {
+            const rules = mediaBlocks[mediaQuery] ?? {};
+            const body = rules[className] ?? '';
+            expect(body).toContain(
+              `--dds-r-${suffix}: var(--dds-r-${name}-${suffix})`,
+            );
+          },
+        );
+      },
+    );
+  });
+});

--- a/packages/dds-components/src/components/layout/common/utils.tsx
+++ b/packages/dds-components/src/components/layout/common/utils.tsx
@@ -91,6 +91,34 @@ const convertMultiValue = (value: string, bp?: Breakpoint, invert?: boolean) =>
 const invertValue = (v: string): string =>
   v === '0' ? '0' : `calc(-1 * ${v})`;
 
+const buildCSSKey = (
+  prefix?: string,
+  suffix?: string,
+  bp?: Breakpoint,
+): string => {
+  let key = `--${TOKEN_PREFIX}`;
+  if (prefix) key += `-${prefix}`;
+  if (bp) key += `-${bp}`;
+  if (suffix) key += `-${suffix}`;
+  return key;
+};
+
+export function getCSSProperties<T>(
+  property?: T,
+  prefix?: string,
+  suffix?: string,
+  invert?: boolean,
+): Properties | undefined {
+  if (property === undefined || property === null) return;
+
+  const properties: Properties = {};
+
+  (properties as Record<string, string>)[buildCSSKey(prefix, suffix)] =
+    convertMultiValue(property.toString(), undefined, invert);
+
+  return properties;
+}
+
 export function getResponsiveCSSProperties<T>(
   property?: ResponsiveProp<T>,
   prefix?: string,
@@ -100,18 +128,17 @@ export function getResponsiveCSSProperties<T>(
   if (!property) return;
 
   const properties: Properties = {};
-  const pPrefix = `--${TOKEN_PREFIX}-${prefix}`;
-  const pSuffix = suffix ? `-${suffix}` : '';
 
   if (isBreakpointObject(property)) {
     BREAKPOINTS.forEach(bp => {
       if (property[bp]) {
-        (properties as Record<string, string>)[`${pPrefix}-${bp}${pSuffix}`] =
-          convertMultiValue(property[bp].toString(), bp, invert);
+        (properties as Record<string, string>)[
+          buildCSSKey(prefix, suffix, bp)
+        ] = convertMultiValue(property[bp].toString(), bp, invert);
       }
     });
   } else {
-    (properties as Record<string, string>)[`${pPrefix}${pSuffix}`] =
+    (properties as Record<string, string>)[buildCSSKey(prefix, suffix)] =
       convertMultiValue(property.toString(), undefined, invert);
   }
   return properties;

--- a/packages/dds-components/src/tests/css-variable-usage.spec.ts
+++ b/packages/dds-components/src/tests/css-variable-usage.spec.ts
@@ -1,0 +1,164 @@
+// @vitest-environment node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+// Matcher gyldig --dds-* CSS variabelnavn.
+// Mønster: --dds- etterfulgt av en eller flere <word>- grupper, avsluttet med et ord.
+const TOKEN_PATTERN = String.raw`(--dds-(?:[a-z0-9]+-)*[a-z0-9]+)`;
+const VAR_RE = new RegExp(String.raw`var\(` + TOKEN_PATTERN, 'g');
+const DEF_RE = new RegExp(TOKEN_PATTERN + String.raw`\s*:`, 'g');
+const TSX_KEY_RE = new RegExp(`['"\`]` + TOKEN_PATTERN + `['"\`]`, 'g');
+
+/* Skip CSS-variabler som håndteres av layout primitive systemet (Box, Grid, Bleed, etc.).
+ * De settes som inline stiler og brukes via media-query overrides i bl.a. layout.module.css.
+ */
+const isSkippedToken = (t: string) =>
+  t.startsWith('--dds-r-') || t.startsWith('--dds-paper-');
+
+function walkDir(dir: string, ...exts: Array<string>): Array<string> {
+  const results: Array<string> = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'tests') continue;
+      results.push(...walkDir(full, ...exts));
+    } else if (
+      entry.isFile() &&
+      exts.some(ext => entry.name.endsWith(ext)) &&
+      !entry.name.endsWith('.spec.ts') &&
+      !entry.name.endsWith('.spec.tsx')
+    ) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+/** CSS-variabler referert til via var(--dds-<name>).
+ * Hopper over treff umiddelbart etterfulgt av '-$' i f.eks. .ts(x) filer — disse er delvise navn
+ * fra template literals med innebygde uttrykk, f.eks.
+ *   `var(--dds-color-icon-on-${purpose}-default)`
+ * som regexen ikke kan løse fullt ut.
+ */
+function extractVarUsages(content: string): Array<string> {
+  const results: Array<string> = [];
+  for (const m of content.matchAll(VAR_RE)) {
+    const end = m.index + m[0].length;
+    if (content[end] === '-' && content[end + 1] === '$') continue;
+    results.push(m[1]);
+  }
+  return results;
+}
+
+/** CSS-variabler: --dds-<name>: */
+function extractDefinitions(content: string): Array<string> {
+  return [...content.matchAll(DEF_RE)].map(m => m[1]);
+}
+
+/**
+ * CSS-variabler satt som inline-style keys i TSX/TS, f.eks.
+ *   ['--dds-selection-control-card-padding' as any]: value
+ */
+function extractTsxStyleKeyDefinitions(content: string): Array<string> {
+  return [...content.matchAll(TSX_KEY_RE)].map(m => m[1]);
+}
+
+const srcDir = path.join(process.cwd(), 'src');
+const tokensCssDir = path.join(
+  process.cwd(),
+  '..',
+  'dds-tokens',
+  'generated-tokens',
+  'css',
+);
+
+// ThemeProvider.module.css definerer globale CSS-variabler som API for konsumenter.
+// Disse ekskluderes.
+const THEME_PROVIDER_CSS = path.join(
+  srcDir,
+  'components',
+  'ThemeProvider',
+  'ThemeProvider.module.css',
+);
+
+const allUsedTokens = new Map<string, Set<string>>();
+const allLocallyDefinedTokens = new Map<string, Set<string>>();
+const themeProviderTokens = new Set<string>();
+
+function addToMap(map: Map<string, Set<string>>, token: string, file: string) {
+  if (!map.has(token)) map.set(token, new Set());
+  map.get(token)!.add(file);
+}
+
+// CSS
+for (const cssFile of walkDir(srcDir, '.css')) {
+  const content = fs.readFileSync(cssFile, 'utf-8');
+  const rel = `packages\\dds-components\\src\\${path.relative(srcDir, cssFile)}`;
+  for (const t of extractVarUsages(content)) addToMap(allUsedTokens, t, rel);
+  for (const t of extractDefinitions(content)) {
+    addToMap(allLocallyDefinedTokens, t, rel);
+    if (cssFile === THEME_PROVIDER_CSS) themeProviderTokens.add(t);
+  }
+}
+
+// TSX/TS: hent ut var() bruk og inline style-key definisjoner.
+for (const tsxFile of walkDir(srcDir, '.tsx', '.ts')) {
+  const content = fs.readFileSync(tsxFile, 'utf-8');
+  const rel = `packages\\dds-components\\src\\${path.relative(srcDir, tsxFile)}`;
+  for (const t of extractVarUsages(content)) addToMap(allUsedTokens, t, rel);
+  for (const t of extractTsxStyleKeyDefinitions(content))
+    addToMap(allLocallyDefinedTokens, t, rel);
+}
+
+const allTokensFromPackage = new Set<string>();
+for (const file of fs
+  .readdirSync(tokensCssDir)
+  .filter(f => f.endsWith('.css'))) {
+  const content = fs.readFileSync(path.join(tokensCssDir, file), 'utf-8');
+  for (const t of extractDefinitions(content)) allTokensFromPackage.add(t);
+}
+
+const allDefinedTokens = new Set([
+  ...allLocallyDefinedTokens.keys(),
+  ...allTokensFromPackage,
+]);
+
+describe('CSS variable usage with dds prefix', () => {
+  it('all CSS variables used in components are defined somewhere (dds-design-tokens, local CSS, or inline TSX styles)', () => {
+    const missing = [...allUsedTokens.entries()]
+      .filter(([t]) => !isSkippedToken(t))
+      .filter(([t]) => !allDefinedTokens.has(t));
+
+    const lines = missing.map(
+      ([t, files]) => `  ${t}\n    used in: ${[...files].join(', ')}`,
+    );
+    expect(
+      missing.map(([t]) => t),
+      `Components reference CSS variables that are not defined anywhere:\n${lines.join('\n')}`,
+    ).toEqual([]);
+  });
+
+  it('all CSS variables defined locally are actually used somewhere (CSS or TSX)', () => {
+    const internalTokens = [...allLocallyDefinedTokens.entries()].filter(
+      ([t]) => !themeProviderTokens.has(t),
+    );
+
+    const unused = internalTokens.filter(
+      ([t]) =>
+        !isSkippedToken(t) &&
+        !allUsedTokens.has(t) &&
+        !allTokensFromPackage.has(t),
+    );
+
+    const lines = unused.map(
+      ([t, files]) => `  ${t}\n    defined in: ${[...files].join(', ')}`,
+    );
+    expect(
+      unused.map(([t]) => t),
+      `Locally-defined CSS variables that are never used internally:\n${lines.join('\n')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Beskrivelse

Vi trenger å teste intagrasjon med CSS-variabler fra `dds-design-tokens`. Dette kan derimot ikke gjøres uten å inkludere interne variabler.

I tillegg kan vedlikehold av systemet for layout primitives være tungvint med stor fare for typos i CSS.

Lager tester som sjekker om:
- alle definerte CSS-variabler brukes
- alle CSS-variabler i bruk defineres
- layout primitive-systemet i `layout.module.css` er konsekvent og setter riktige klasser med riktige CSS-variabler for alle brekkpunkter

### Unntak

Variabler med template literals, vanskelig å resolve

### Ellers

- Fikser feil som ble oppdaget av testene.
- Ny funksjon i layout utils som behandler ikke-responsive CSS properties, utbedrer med det lesbarher i `<Paper>`

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
