### PR TITLE
ELSA1-888: høyde i tømmeknapper

### DIFF
--- a/.changeset/cuddly-crews-study.md
+++ b/.changeset/cuddly-crews-study.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser høyde i tømmeknapper i `<Search>`, `<NativeSelect>` og `<DatePicker>`.

--- a/packages/dds-components/src/components/Button/Button.module.css
+++ b/packages/dds-components/src/components/Button/Button.module.css
@@ -62,6 +62,7 @@
   }
 
   &.clear {
+    min-height: fit-content;
     padding: var(--dds-spacing-x0-125);
   }
 }
@@ -90,6 +91,7 @@
   }
 
   &.clear {
+    min-height: var(--dds-size-height-input-xsmall);
     padding: var(--dds-spacing-x0-25);
   }
 }
@@ -118,6 +120,7 @@
   }
 
   &.clear {
+    min-height: var(--dds-size-height-input-small);
     padding: var(--dds-spacing-x0-5);
   }
 }
@@ -146,6 +149,7 @@
   }
 
   &.clear {
+    min-height: var(--dds-size-height-input-medium);
     padding: var(--dds-spacing-x0-75);
   }
 }


### PR DESCRIPTION
## Beskrivelse

Høyden ble feil da den overlappet med border ved hover.

Før:

<img width="559" height="109" alt="bilde" src="https://github.com/user-attachments/assets/af78c637-bbea-4342-af3e-fbbc2cab9cca" />

Etter:

<img width="540" height="112" alt="bilde" src="https://github.com/user-attachments/assets/bf32e452-5036-4291-818b-5a50d4569dcd" />


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
