### PR TITLE
ELSA1-552: pointer events i `<DatePicker>`

### DIFF
--- a/.changeset/salty-donuts-cross.md
+++ b/.changeset/salty-donuts-cross.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser bug der datosegmentene fikk fokus selv ved klikk utenfor i `<DatePicker>`.

--- a/packages/dds-components/src/components/date-inputs/common/DateInput.module.css
+++ b/packages/dds-components/src/components/date-inputs/common/DateInput.module.css
@@ -1,7 +1,15 @@
+.date-group {
+  pointer-events: none;
+  label,
+  .input-group {
+    pointer-events: auto;
+  }
+}
 .date-segment-container {
   display: flex;
   flex-direction: row;
   font-family: var(--dds-font-family-monospace);
+  user-select: none;
 }
 
 .segment {

--- a/packages/dds-components/src/components/date-inputs/common/DateInput.tsx
+++ b/packages/dds-components/src/components/date-inputs/common/DateInput.tsx
@@ -72,7 +72,7 @@ export function DateInput({
   return (
     <div
       {...groupProps}
-      className={cn(className, inputStyles.container)}
+      className={cn(className, inputStyles.container, styles['date-group'])}
       ref={ref}
     >
       {renderLabel({
@@ -88,6 +88,7 @@ export function DateInput({
         className={cn(
           inputStyles['input-group'],
           tgStyles[`body-short-${componentSize}`],
+          styles['input-group'],
         )}
       >
         {button}


### PR DESCRIPTION
## Beskrivelse

`<DatePicker>` sine spin buttons ble påvirket av enkelte pointer events (fokus, highlight) ved klikk utenfor. Dette problemet kommer fra `@react-aria/datepicker` biblioteket. Fikser med en CSS workaround.

Før:

https://github.com/user-attachments/assets/f08ba224-d8c2-4932-95f8-428962b6bcc1

Etter:

https://github.com/user-attachments/assets/19d4b21d-7448-4a40-851f-20391fd44cf0

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
