### PR TITLE
ELSA1-753: Nytt mønster: skjemavalidering

### DIFF
--- a/packages/dds-components/src/components/ErrorSummary/ErrorSummary.mdx
+++ b/packages/dds-components/src/components/ErrorSummary/ErrorSummary.mdx
@@ -5,6 +5,8 @@ import meta from './ErrorSummary.stories';
 import { ErrorSummaryItem } from '.';
 import { Tabs, Tab, TabList, TabPanels, TabPanel } from '../Tabs';
 import { Divider } from '../Divider';
+import { LocalMessage } from '../LocalMessage';
+import LinkTo from '@storybook/addon-links/react';
 
 <Meta of={meta} />
 
@@ -39,5 +41,16 @@ import { Divider } from '../Divider';
 <Divider />
 
 ## Bruk
+
+<LocalMessage>
+  <p>
+    Se mer i{' '}
+    <LinkTo title="Mønstre/Skjemavalidering" story="docs">
+      Skjemavalidering-mønsteret
+    </LinkTo>
+    .
+
+  </p>
+</LocalMessage>
 
 Genrerer `<ErrorSummary>` kun hvis det er flere enn ett inputfelt på siden. Lenker skal peke til inputfelt som har feil slik at de får fokus. På denne måten kan brukeren fikse feilen med en gang.

--- a/packages/dds-components/src/components/FormSummary/FormSummary.stories.tsx
+++ b/packages/dds-components/src/components/FormSummary/FormSummary.stories.tsx
@@ -288,6 +288,7 @@ const renderFields = (n: number) => {
 };
 
 export const WithGrid = meta.story({
+  name: 'Grid',
   parameters: {
     chromatic: { disableSnapshot: true },
   },
@@ -367,6 +368,7 @@ export const WithGrid = meta.story({
 });
 
 export const WithFlex = meta.story({
+  name: 'Flex',
   parameters: {
     chromatic: { disableSnapshot: true },
   },

--- a/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswers.mdx
+++ b/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswers.mdx
@@ -45,9 +45,7 @@ Du trenger i utgangspunktet ingen egen CSS styling.
 
 ### Validering
 
-- **Generelt**: se <LinkTo title='Patterns/Form' story='docs'>Skjema-mønsteret</LinkTo>.
-- **Stegene er ikke avhengige av hverandre**: la brukeren gå fritt mellom stegene. Valider når brukeren går til oppsummeringssiden med FormSummary. Valider i tillegg ved submit og når brukeren går tilbake til steg de har vært innom.
-- **Wizard-flyt**: se Skjemavalidering-mønsteret (under arbeid); hvis f.eks. steg 1 må fylles ut for å kunne gå til steg 2, må validering i tillegg skje når brukeren prøver å gå til neste steg.
+Se <LinkTo title='Mønstre/Skjemavalidering' story='docs'>Skjemavalidering-mønsteret</LinkTo>.
 
 ## Maler
 

--- a/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswers.stories.tsx
+++ b/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswers.stories.tsx
@@ -1,5 +1,5 @@
+import preview from '#.storybook/preview';
 import { CalendarDate, Time } from '@internationalized/date';
-import { type Meta } from '@storybook/react-vite';
 import { Fragment, type SubmitEvent, useState } from 'react';
 
 import {
@@ -41,328 +41,331 @@ import {
 } from '../../../src';
 import { ddsProviderDecorator } from '../../../src/storybook';
 
-const meta: Meta = {
+const meta = preview.meta({
   title: 'Mønstre/Sjekk svar',
   parameters: {
     layout: 'fullscreen',
-    docs: { canvas: { inline: false } },
+    docs: { story: { inline: false, height: '1550px' } },
   },
   decorators: [ddsProviderDecorator],
-};
+});
 
 export default meta;
 
-export const CheckAnswers = () => {
-  const [activeStep, setActiveStep] = useState(2);
-  const [completedSteps, setCompletedSteps] = useState(new Set<number>());
-  const [progressTrackerDrawerOpen, setProgressTrackerDrawerOpen] =
-    useState(false);
+export const CheckAnswers = meta.story({
+  name: 'Sjekk svar',
+  render: () => {
+    const [activeStep, setActiveStep] = useState(2);
+    const [completedSteps, setCompletedSteps] = useState(new Set<number>());
+    const [progressTrackerDrawerOpen, setProgressTrackerDrawerOpen] =
+      useState(false);
 
-  const steps = ['Skjemasteg 1', 'Skjemasteg 2', 'Oppsummering'];
+    const steps = ['Skjemasteg 1', 'Skjemasteg 2', 'Oppsummering'];
 
-  const completeStep = (step: number, e: SubmitEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (activeStep !== 1) setCompletedSteps(s => new Set([...s, activeStep]));
-    setActiveStep(step + 1);
-  };
+    const completeStep = (step: number, e: SubmitEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      if (activeStep !== 1) setCompletedSteps(s => new Set([...s, activeStep]));
+      setActiveStep(step + 1);
+    };
 
-  const previousStep = () => {
-    setActiveStep(activeStep - 1);
-  };
+    const previousStep = () => {
+      setActiveStep(activeStep - 1);
+    };
 
-  const stepItems = steps.map((step, index) => (
-    <ProgressTracker.Item key={step} completed={completedSteps.has(index)}>
-      {step}
-    </ProgressTracker.Item>
-  ));
+    const stepItems = steps.map((step, index) => (
+      <ProgressTracker.Item key={step} completed={completedSteps.has(index)}>
+        {step}
+      </ProgressTracker.Item>
+    ));
 
-  const formSteps = [
-    <Fragment key={0}>
-      <Heading level={2} withMarginsOverInput>
-        {steps[0]}
-      </Heading>
-      <VStack
-        as="form"
-        gap="x1.5"
-        onSubmit={e => {
-          completeStep(0, e);
-        }}
-      >
-        <TextInput required label="Navn" value="Navnar Navnesen" />
-        <TextInput required label="Epostadresse" value="navnar.n@epost.no" />
-        <TextInput label="Telefonnummer" />
-
-        <HStack gap="x1.5" paddingBlock="x1.5">
-          <Button>Neste</Button>
-        </HStack>
-      </VStack>
-    </Fragment>,
-    <Box marginBlock="x1 0" key={1}>
-      <Heading level={2} withMargins>
-        {steps[1]}
-      </Heading>
-      <VStack
-        as="form"
-        gap="x1"
-        onSubmit={e => {
-          completeStep(1, e);
-        }}
-      >
-        <Fieldset>
-          <Legend withMarginsOverInput typographyType="headingMedium">
-            Møte nr 1
-          </Legend>
-          <FieldsetGroup>
-            <DatePicker
-              isRequired
-              label="Dato"
-              value={new CalendarDate(2012, 12, 12)}
-            />
-            <TimePicker isRequired label="Start" value={new Time(12, 0)} />
-            <TimePicker
-              isRequired
-              label="Slutt"
-              value={new Time(11, 0)}
-              errorMessage="Tidspunkt for slutt må være etter start."
-            />
-          </FieldsetGroup>
-        </Fieldset>
-        <Fieldset>
-          <Legend withMarginsOverInput typographyType="headingMedium">
-            Møte nr 2
-          </Legend>
-          <FieldsetGroup>
-            <DatePicker
-              isRequired
-              label="Dato"
-              errorMessage="Dato for møte må fylles ut."
-            />
-            <TimePicker isRequired label="Start" value={new Time(13, 0)} />
-            <TimePicker isRequired label="Slutt" value={new Time(14, 0)} />
-          </FieldsetGroup>
-        </Fieldset>
-        <HStack gap="x1.5" paddingBlock="x1 0">
-          <Button>Neste</Button>
-        </HStack>
-      </VStack>
-    </Box>,
-    <VStack gap="x1" key={2}>
-      <Heading level={2} withMargins>
-        Oppsummering
-      </Heading>
-      <VStack gap="x1">
-        <FormSummary>
-          <FormSummaryHeader>
-            <FormSummaryHeading level={3}>Første steg</FormSummaryHeading>
-            <FormSummaryEditButton onClick={() => setActiveStep(0)}>
-              Endre svar
-            </FormSummaryEditButton>
-          </FormSummaryHeader>
-          <FormSummaryFields>
-            <FormSummaryField>
-              <FormSummaryLabel>Navn</FormSummaryLabel>
-              <FormSummaryValue>Navnar Navnesen</FormSummaryValue>
-            </FormSummaryField>
-            <FormSummaryField>
-              <FormSummaryLabel>Epostadresse</FormSummaryLabel>
-              <FormSummaryValue>navnar.n@epost.no</FormSummaryValue>
-            </FormSummaryField>
-            <FormSummaryField>
-              <FormSummaryLabel>Telefonnummer</FormSummaryLabel>
-              <FormSummaryValue>
-                <FormSummaryEmptyValue />
-              </FormSummaryValue>
-            </FormSummaryField>
-          </FormSummaryFields>
-        </FormSummary>
-        <FormSummary>
-          <FormSummaryHeader>
-            <FormSummaryHeading level={3}>Andre steg</FormSummaryHeading>
-            <FormSummaryEditButton onClick={() => setActiveStep(1)}>
-              Endre svar
-            </FormSummaryEditButton>
-          </FormSummaryHeader>
-          <FormSummaryFields>
-            <FormSummaryField>
-              <FormSummaryLabel>Møte nr 1</FormSummaryLabel>
-              <FormSummaryValue>
-                <FormSummaryFields>
-                  <FormSummaryField>
-                    <FormSummaryLabel>Dato</FormSummaryLabel>
-                    <FormSummaryValue>12.12.2012</FormSummaryValue>
-                  </FormSummaryField>
-                  <FormSummaryField>
-                    <FormSummaryLabel>Start</FormSummaryLabel>
-                    <FormSummaryValue>12:00</FormSummaryValue>
-                  </FormSummaryField>
-                  <FormSummaryField>
-                    <FormSummaryLabel>Slutt</FormSummaryLabel>
-                    <FormSummaryValue>
-                      11:00
-                      <FormSummaryError>
-                        <Link href="/linkTilFelt">
-                          Tidspunkt for slutt må være etter start.
-                        </Link>
-                      </FormSummaryError>
-                    </FormSummaryValue>
-                  </FormSummaryField>
-                </FormSummaryFields>
-              </FormSummaryValue>
-            </FormSummaryField>
-            <FormSummaryField>
-              <FormSummaryLabel>Møte nr 2</FormSummaryLabel>
-              <FormSummaryValue>
-                <FormSummaryFields>
-                  <FormSummaryField>
-                    <FormSummaryLabel>Dato</FormSummaryLabel>
-                    <FormSummaryValue>
-                      <FormSummaryError>
-                        <Link href="/linkTilFelt">
-                          Dato for møte må fylles ut.
-                        </Link>
-                      </FormSummaryError>
-                    </FormSummaryValue>
-                  </FormSummaryField>
-                  <FormSummaryField>
-                    <FormSummaryLabel>Start</FormSummaryLabel>
-                    <FormSummaryValue>13:00</FormSummaryValue>
-                  </FormSummaryField>
-                  <FormSummaryField>
-                    <FormSummaryLabel>Slutt</FormSummaryLabel>
-                    <FormSummaryValue>14:00</FormSummaryValue>
-                  </FormSummaryField>
-                </FormSummaryFields>
-              </FormSummaryValue>
-            </FormSummaryField>
-          </FormSummaryFields>
-        </FormSummary>
-        <FormSummary>
-          <FormSummaryHeader>
-            <FormSummaryHeading level={3}>Data</FormSummaryHeading>
-
-            <Tag>Data hentet fra Et Sted</Tag>
-          </FormSummaryHeader>
-          <FormSummaryFields>
-            <FormSummaryField>
-              <FormSummaryLabel>Ledetekst</FormSummaryLabel>
-              <FormSummaryValue>Verdi</FormSummaryValue>
-            </FormSummaryField>
-          </FormSummaryFields>
-        </FormSummary>
-        <HStack gap="x1.5" paddingBlock="x1.5">
-          <Button>Send inn</Button>
-        </HStack>
-      </VStack>
-    </VStack>,
-  ];
-  return (
-    <>
-      <InternalHeader
-        applicationName="Applikasjon"
-        applicationDesc="Beskrivelse"
-        navItems={[
-          { children: 'Menypunkt', href: '//' },
-          { children: 'Menypunkt', href: '///' },
-        ]}
-        currentPageHref="//"
-        smallScreenBreakpoint="sm"
-      />
-      <Grid as="div" marginBlock="0 x1" maxWidth="1100px">
-        <GridChild
-          columnsOccupied={{
-            xs: '1/-1',
-            sm: '1/7',
-            md: '1/7',
-            lg: '1/7',
-            xl: '1/7',
+    const formSteps = [
+      <Fragment key={0}>
+        <Heading level={2} withMarginsOverInput>
+          {steps[0]}
+        </Heading>
+        <VStack
+          as="form"
+          gap="x1.5"
+          onSubmit={e => {
+            completeStep(0, e);
           }}
         >
-          <Heading withMargins level={1}>
-            Navn på skjema
-          </Heading>
-          <Paragraph typographyType="leadMedium" withMargins>
-            Dette er et eksempel på en ingress. Den består ofte av et par
-            setninger. En setning til.
-          </Paragraph>
-          <Paragraph
-            typographyType="bodyLongSmall"
-            color="text-subtle"
-            withMargins
-          >
-            {activeStep !== steps.length - 1 && (
-              <>
-                Obligatoriske felter er merket med{' '}
-                <Typography as="span" color="text-requiredfield">
-                  *
-                </Typography>
-                .
-              </>
-            )}
-          </Paragraph>
-          <VStack
-            gap="x1"
-            marginBlock={{
-              xs: '0 x1',
-              sm: '0 x1',
-              md: activeStep > 0 ? '0 x1' : '0',
-              lg: activeStep > 0 ? '0 x1' : '0',
-              xl: activeStep > 0 ? '0 x1' : '0',
+          <TextInput required label="Navn" value="Navnar Navnesen" />
+          <TextInput required label="Epostadresse" value="navnar.n@epost.no" />
+          <TextInput label="Telefonnummer" />
+
+          <HStack gap="x1.5" paddingBlock="x1.5">
+            <Button>Neste</Button>
+          </HStack>
+        </VStack>
+      </Fragment>,
+      <Box marginBlock="x1 0" key={1}>
+        <Heading level={2} withMargins>
+          {steps[1]}
+        </Heading>
+        <VStack
+          as="form"
+          gap="x1"
+          onSubmit={e => {
+            completeStep(1, e);
+          }}
+        >
+          <Fieldset>
+            <Legend withMarginsOverInput typographyType="headingMedium">
+              Møte nr 1
+            </Legend>
+            <FieldsetGroup>
+              <DatePicker
+                isRequired
+                label="Dato"
+                value={new CalendarDate(2012, 12, 12)}
+              />
+              <TimePicker isRequired label="Start" value={new Time(12, 0)} />
+              <TimePicker
+                isRequired
+                label="Slutt"
+                value={new Time(11, 0)}
+                errorMessage="Tidspunkt for slutt må være etter start."
+              />
+            </FieldsetGroup>
+          </Fieldset>
+          <Fieldset>
+            <Legend withMarginsOverInput typographyType="headingMedium">
+              Møte nr 2
+            </Legend>
+            <FieldsetGroup>
+              <DatePicker
+                isRequired
+                label="Dato"
+                errorMessage="Dato for møte må fylles ut."
+              />
+              <TimePicker isRequired label="Start" value={new Time(13, 0)} />
+              <TimePicker isRequired label="Slutt" value={new Time(14, 0)} />
+            </FieldsetGroup>
+          </Fieldset>
+          <HStack gap="x1.5" paddingBlock="x1 0">
+            <Button>Neste</Button>
+          </HStack>
+        </VStack>
+      </Box>,
+      <VStack gap="x1" key={2}>
+        <Heading level={2} withMargins>
+          Oppsummering
+        </Heading>
+        <VStack gap="x1">
+          <FormSummary>
+            <FormSummaryHeader>
+              <FormSummaryHeading level={3}>Første steg</FormSummaryHeading>
+              <FormSummaryEditButton onClick={() => setActiveStep(0)}>
+                Endre svar
+              </FormSummaryEditButton>
+            </FormSummaryHeader>
+            <FormSummaryFields>
+              <FormSummaryField>
+                <FormSummaryLabel>Navn</FormSummaryLabel>
+                <FormSummaryValue>Navnar Navnesen</FormSummaryValue>
+              </FormSummaryField>
+              <FormSummaryField>
+                <FormSummaryLabel>Epostadresse</FormSummaryLabel>
+                <FormSummaryValue>navnar.n@epost.no</FormSummaryValue>
+              </FormSummaryField>
+              <FormSummaryField>
+                <FormSummaryLabel>Telefonnummer</FormSummaryLabel>
+                <FormSummaryValue>
+                  <FormSummaryEmptyValue />
+                </FormSummaryValue>
+              </FormSummaryField>
+            </FormSummaryFields>
+          </FormSummary>
+          <FormSummary>
+            <FormSummaryHeader>
+              <FormSummaryHeading level={3}>Andre steg</FormSummaryHeading>
+              <FormSummaryEditButton onClick={() => setActiveStep(1)}>
+                Endre svar
+              </FormSummaryEditButton>
+            </FormSummaryHeader>
+            <FormSummaryFields>
+              <FormSummaryField>
+                <FormSummaryLabel>Møte nr 1</FormSummaryLabel>
+                <FormSummaryValue>
+                  <FormSummaryFields>
+                    <FormSummaryField>
+                      <FormSummaryLabel>Dato</FormSummaryLabel>
+                      <FormSummaryValue>12.12.2012</FormSummaryValue>
+                    </FormSummaryField>
+                    <FormSummaryField>
+                      <FormSummaryLabel>Start</FormSummaryLabel>
+                      <FormSummaryValue>12:00</FormSummaryValue>
+                    </FormSummaryField>
+                    <FormSummaryField>
+                      <FormSummaryLabel>Slutt</FormSummaryLabel>
+                      <FormSummaryValue>
+                        11:00
+                        <FormSummaryError>
+                          <Link href="/linkTilFelt">
+                            Tidspunkt for slutt må være etter start.
+                          </Link>
+                        </FormSummaryError>
+                      </FormSummaryValue>
+                    </FormSummaryField>
+                  </FormSummaryFields>
+                </FormSummaryValue>
+              </FormSummaryField>
+              <FormSummaryField>
+                <FormSummaryLabel>Møte nr 2</FormSummaryLabel>
+                <FormSummaryValue>
+                  <FormSummaryFields>
+                    <FormSummaryField>
+                      <FormSummaryLabel>Dato</FormSummaryLabel>
+                      <FormSummaryValue>
+                        <FormSummaryError>
+                          <Link href="/linkTilFelt">
+                            Dato for møte må fylles ut.
+                          </Link>
+                        </FormSummaryError>
+                      </FormSummaryValue>
+                    </FormSummaryField>
+                    <FormSummaryField>
+                      <FormSummaryLabel>Start</FormSummaryLabel>
+                      <FormSummaryValue>13:00</FormSummaryValue>
+                    </FormSummaryField>
+                    <FormSummaryField>
+                      <FormSummaryLabel>Slutt</FormSummaryLabel>
+                      <FormSummaryValue>14:00</FormSummaryValue>
+                    </FormSummaryField>
+                  </FormSummaryFields>
+                </FormSummaryValue>
+              </FormSummaryField>
+            </FormSummaryFields>
+          </FormSummary>
+          <FormSummary>
+            <FormSummaryHeader>
+              <FormSummaryHeading level={3}>Data</FormSummaryHeading>
+
+              <Tag>Data hentet fra Et Sted</Tag>
+            </FormSummaryHeader>
+            <FormSummaryFields>
+              <FormSummaryField>
+                <FormSummaryLabel>Ledetekst</FormSummaryLabel>
+                <FormSummaryValue>Verdi</FormSummaryValue>
+              </FormSummaryField>
+            </FormSummaryFields>
+          </FormSummary>
+          <HStack gap="x1.5" paddingBlock="x1.5">
+            <Button>Send inn</Button>
+          </HStack>
+        </VStack>
+      </VStack>,
+    ];
+    return (
+      <>
+        <InternalHeader
+          applicationName="Applikasjon"
+          applicationDesc="Beskrivelse"
+          navItems={[
+            { children: 'Menypunkt', href: '//' },
+            { children: 'Menypunkt', href: '///' },
+          ]}
+          currentPageHref="//"
+          smallScreenBreakpoint="sm"
+        />
+        <Grid as="div" marginBlock="0 x1" maxWidth="1100px">
+          <GridChild
+            columnsOccupied={{
+              xs: '1/-1',
+              sm: '1/7',
+              md: '1/7',
+              lg: '1/7',
+              xl: '1/7',
             }}
           >
-            <ShowHide showBelow="sm">
-              <DrawerGroup
-                isOpen={progressTrackerDrawerOpen}
-                setIsOpen={setProgressTrackerDrawerOpen}
-              >
+            <Heading withMargins level={1}>
+              Navn på skjema
+            </Heading>
+            <Paragraph typographyType="leadMedium" withMargins>
+              Dette er et eksempel på en ingress. Den består ofte av et par
+              setninger. En setning til.
+            </Paragraph>
+            <Paragraph
+              typographyType="bodyLongSmall"
+              color="text-subtle"
+              withMargins
+            >
+              {activeStep !== steps.length - 1 && (
+                <>
+                  Obligatoriske felter er merket med{' '}
+                  <Typography as="span" color="text-requiredfield">
+                    *
+                  </Typography>
+                  .
+                </>
+              )}
+            </Paragraph>
+            <VStack
+              gap="x1"
+              marginBlock={{
+                xs: '0 x1',
+                sm: '0 x1',
+                md: activeStep > 0 ? '0 x1' : '0',
+                lg: activeStep > 0 ? '0 x1' : '0',
+                xl: activeStep > 0 ? '0 x1' : '0',
+              }}
+            >
+              <ShowHide showBelow="sm">
+                <DrawerGroup
+                  isOpen={progressTrackerDrawerOpen}
+                  setIsOpen={setProgressTrackerDrawerOpen}
+                >
+                  <Button
+                    purpose="secondary"
+                    iconPosition="right"
+                    icon={ChevronRightIcon}
+                  >
+                    Steg {activeStep + 1} av {steps.length}{' '}
+                    <VisuallyHidden>Vis stegnavigasjon</VisuallyHidden>
+                  </Button>
+                  <Drawer>
+                    <ProgressTracker
+                      activeStep={activeStep}
+                      onStepChange={newStep => setActiveStep(newStep)}
+                    >
+                      {stepItems}
+                    </ProgressTracker>
+                  </Drawer>
+                </DrawerGroup>
+              </ShowHide>
+              {activeStep > 0 && (
                 <Button
                   purpose="secondary"
-                  iconPosition="right"
-                  icon={ChevronRightIcon}
+                  icon={ArrowLeftIcon}
+                  onClick={() => previousStep()}
                 >
-                  Steg {activeStep + 1} av {steps.length}{' '}
-                  <VisuallyHidden>Vis stegnavigasjon</VisuallyHidden>
+                  Forrige steg
                 </Button>
-                <Drawer>
-                  <ProgressTracker
-                    activeStep={activeStep}
-                    onStepChange={newStep => setActiveStep(newStep)}
-                  >
-                    {stepItems}
-                  </ProgressTracker>
-                </Drawer>
-              </DrawerGroup>
-            </ShowHide>
-            {activeStep > 0 && (
-              <Button
-                purpose="secondary"
-                icon={ArrowLeftIcon}
-                onClick={() => previousStep()}
-              >
-                Forrige steg
-              </Button>
-            )}
-          </VStack>
-          {formSteps[activeStep]}
-        </GridChild>
-        <GridChild
-          hideBelow="sm"
-          marginBlock="x4 x1"
-          columnsOccupied={{
-            xs: '1/-1',
-            sm: '1/-1',
-            md: '7/13',
-            lg: '7/13',
-            xl: '7/13',
-          }}
-        >
-          <ProgressTracker
-            activeStep={activeStep}
-            onStepChange={newStep => setActiveStep(newStep)}
+              )}
+            </VStack>
+            {formSteps[activeStep]}
+          </GridChild>
+          <GridChild
+            hideBelow="sm"
+            marginBlock="x4 x1"
+            columnsOccupied={{
+              xs: '1/-1',
+              sm: '1/-1',
+              md: '7/13',
+              lg: '7/13',
+              xl: '7/13',
+            }}
           >
-            {stepItems}
-          </ProgressTracker>
-        </GridChild>
-      </Grid>
-    </>
-  );
-};
+            <ProgressTracker
+              activeStep={activeStep}
+              onStepChange={newStep => setActiveStep(newStep)}
+            >
+              {stepItems}
+            </ProgressTracker>
+          </GridChild>
+        </Grid>
+      </>
+    );
+  },
+});

--- a/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswers.stories.tsx
+++ b/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswers.stories.tsx
@@ -42,7 +42,7 @@ import {
 import { ddsProviderDecorator } from '../../../src/storybook';
 
 const meta: Meta = {
-  title: 'Patterns/Check Answers',
+  title: 'Mønstre/Sjekk svar',
   parameters: {
     layout: 'fullscreen',
     docs: { canvas: { inline: false } },

--- a/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswersLayout.stories.tsx
+++ b/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswersLayout.stories.tsx
@@ -8,7 +8,7 @@ export {
 } from '../../../src/components/FormSummary/FormSummary.stories';
 
 const meta: Meta = {
-  title: 'Patterns/Check Answers',
+  title: 'Mønstre/Sjekk svar',
   parameters: {
     chromatic: { disableSnapshot: true },
   },

--- a/packages/dds-components/stories/patterns/Form/Form.mdx
+++ b/packages/dds-components/stories/patterns/Form/Form.mdx
@@ -24,7 +24,7 @@ import * as FormStories from './Form.stories';
 
 ## Bruksområde
 
-Skjema. Brukes i kombinasjon med <LinkTo title='Patterns/Check Answers' story='docs'>Sjekk svar-mønsteret</LinkTo> og Skjemavalidering-mønsteret (under arbeid).
+Skjema. Brukes i kombinasjon med <LinkTo title='Mønstre/Sjekk svar' story='docs'>Sjekk svar-mønsteret</LinkTo> og <LinkTo title='Mønstre/Skjemavalidering' story='docs'>Skjemavalidering-mønsteret</LinkTo>.
 
 ## Hvordan implementere?
 
@@ -49,32 +49,7 @@ Skjema-mønsteret bruker gjerne en del komponenter, layout primitives og props f
 
 ## Validering
 
-### HTML5 default
-
-Slå av default validering i nettleseren med `noValidate` attributt på `<form>`:
-
-```jsx
-<form noValidate> /* skjema... */ </form>
-```
-
-Grunnene til anbefalingen er:
-
-- Uforutsigbar oppførsel i kombinasjon med feilmeldinger fra Elsa; meldingene dekker hverandre, har ulik trigger for å dukke opp.
-- Inkompatibel med WCAG-krav. Innebygde valideringen har vage, statiske feilmeldinger og blir ofte ikke lest av skjermlesere.
-- Det visuelle inntrykket kan ikke endres, og vil ikke stemme overens med Elsa.
-
-Hva dette innebærer:
-
-- Nettleserens native validerings-popup vises ikke ved submit.
-- Submit blir ikke blokkert av required, type, pattern osv.
-- Applikasjonen har full kontroll over validering - når det skjer, feilmeldinger, fokusflyt og annonsering til skjermleser.
-
-### Når og hvordan validere?
-
-- **Generelt**: ved blur/change for hvert inputelement, bruk `errorMessage` prop for feilmeldingen. Når brukeren går inn og ut av inputfelt teller det som et forsøk på å fylle ut input.
-- **Uten steg**: se Skjemavalidering-mønsteret (under arbeid); valider ved submit og bruk ErrorSummary til å vise valideringsfeil, samt bruk `errorMessage` prop på alle felt med feil.
-- **Flere steg**: se <LinkTo title='Patterns/Check Answers' story='docs'>Sjekk svar-mønsteret</LinkTo>.
-- **Ett felt**: valider ved submit, hvis feltet har feil vis det med `errorMessage` prop og flytt fokus til feltet.
+Se <LinkTo title='Mønstre/Skjemavalidering' story='docs'>Skjemavalidering-mønsteret</LinkTo>.
 
 ## Maler
 

--- a/packages/dds-components/stories/patterns/Form/Form.stories.tsx
+++ b/packages/dds-components/stories/patterns/Form/Form.stories.tsx
@@ -35,7 +35,7 @@ import {
 import { ddsProviderDecorator } from '../../../src/storybook';
 
 const meta = preview.meta({
-  title: 'Patterns/Form',
+  title: 'Mønstre/Skjema',
   parameters: {
     layout: 'fullscreen',
     docs: {
@@ -46,6 +46,8 @@ const meta = preview.meta({
   },
   decorators: [ddsProviderDecorator],
 });
+
+export default meta;
 
 export const Form = meta.story({
   parameters: {

--- a/packages/dds-components/stories/patterns/Form/Form.stories.tsx
+++ b/packages/dds-components/stories/patterns/Form/Form.stories.tsx
@@ -50,6 +50,7 @@ const meta = preview.meta({
 export default meta;
 
 export const Form = meta.story({
+  name: 'Skjema',
   parameters: {
     docs: {
       story: {
@@ -153,6 +154,7 @@ export const Form = meta.story({
 });
 
 export const FormWithSteps = meta.story({
+  name: 'Skjema med steg',
   parameters: {
     docs: {
       story: {
@@ -413,6 +415,7 @@ export const FormWithSteps = meta.story({
 });
 
 export const FormWithStepsCustomGrid = meta.story({
+  name: 'Skjema med steg og tilpasset grid',
   parameters: {
     docs: {
       story: {
@@ -646,6 +649,7 @@ export const FormWithStepsCustomGrid = meta.story({
 });
 
 export const TwoButtons = meta.story({
+  name: 'To knapper',
   parameters: {
     docs: {
       story: {
@@ -686,6 +690,7 @@ export const TwoButtons = meta.story({
 });
 
 export const MultipleButtons = meta.story({
+  name: 'Flere knapper',
   parameters: {
     docs: {
       story: {
@@ -731,6 +736,7 @@ export const MultipleButtons = meta.story({
 });
 
 export const ExitForm = meta.story({
+  name: 'Forlate skjema',
   parameters: {
     docs: {
       story: {

--- a/packages/dds-components/stories/patterns/Validation/Validation.mdx
+++ b/packages/dds-components/stories/patterns/Validation/Validation.mdx
@@ -1,0 +1,94 @@
+import { Canvas, Controls, Meta } from '@storybook/addon-docs/blocks';
+import {
+  ComponentLinkRow,
+  Source,
+} from '@norges-domstoler/storybook-components';
+import LinkTo from '@storybook/addon-links/react';
+import {
+  Tabs,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+} from '../../../src/components/Tabs';
+import * as ValidationStories from './Validation.stories';
+
+<Meta of={ValidationStories} />
+
+# Skjema
+
+<ComponentLinkRow
+  docsHref="0426e5-skjema"
+  storybookHref={{ folder: 'patterns', comp: 'validation--form' }}
+/>
+
+## Bruksområde
+
+Skjemavalidering. Brukes i kombinasjon med <LinkTo title='Patterns/Check Answers' story='docs'>Sjekk svar-mønsteret</LinkTo> og <LinkTo title='Patterns/Form' story='docs'>Skjema-mønsteret</LinkTo>.
+
+## Hvordan implementere?
+
+Skjema-mønsteret bruker gjerne en del komponenter, layout primitives og props for å implementere typisk layout. Du trenger i utganspunktet ingen egen CSS styling.
+
+### Komponenter
+
+- **Skjemakomponenter, typografi og layout primitives**: se <LinkTo title='Patterns/Form' story='docs'>Skjema-mønsteret</LinkTo>.
+- **`<ErrorSummary>`**.
+
+## Validering
+
+### HTML5 default
+
+Slå av default validering i nettleseren med `noValidate` attributt på `<form>`:
+
+```jsx
+<form noValidate> /* skjema... */ </form>
+```
+
+Grunnene til anbefalingen er:
+
+- Uforutsigbar oppførsel i kombinasjon med feilmeldinger fra Elsa; meldingene dekker hverandre og har ulik trigger for å dukke opp.
+- Inkompatibel med WCAG-krav. Innebygde valideringen har vage, statiske feilmeldinger og blir ofte ikke lest av skjermlesere.
+- Det visuelle inntrykket kan ikke endres, og vil ikke stemme overens med Elsa.
+
+Hva dette innebærer:
+
+- Nettleserens native validerings-popup vises ikke ved submit.
+- Submit blir ikke blokkert av required, type, pattern osv.
+- Applikasjonen har full kontroll over validering - når det skjer, feilmeldinger, fokusflyt og annonsering til skjermleser.
+
+### Interaksjon med inputfelt
+
+Validering skal skje ved HTML nativ `change`-event - når brukeren endrer verdien i inputfeltet og så forlater det. Dette er for å unngå at brukeren blir møtt med feilmeldinger mens de fortsatt fyller ut feltet eller navigerer mellom feltene.
+
+**OBS!** React sin `change`-event fungerer mer som nativ HTML `input`-event: den trigges mens brukeren skriver i feltet, ikke når feltet mister fokus. Det er dermed nødvendig å kombinere React handlers `onChange` med `onBlur` for å få ønsket valideringsflyt.
+
+Hvis validering feiler, vis beskrivende feilmelding med `errorMessage` prop.
+
+### Uten steg
+
+Validering skal også skje ved innsending.
+
+- **Ett felt**: hvis validering feiler vis beskrivende feilmelding med `errorMessage` prop og flytt fokus til feltet.
+- **Uten steg**: ha med en [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions), f.eks. `<div>` med `aria-live="polite"`. Den må alltid være i DOM. Ved valideringsfeil oppdater din live region til å vise de aktuelle feilene i `<ErrorSummary>`, samt bruk `errorMessage` prop på alle felt med tilsvarende feil.
+
+### Flere steg
+
+- **Stegene er ikke avhengige av hverandre**: la brukeren gå fritt mellom stegene. Valider når brukeren går til oppsummeringssiden med FormSummary (se <LinkTo title="Mønstre/Sjekk svar">Sjekk svar-mønsteret</LinkTo> ). Valider i tillegg ved innsending og når brukeren går tilbake til steg de har vært innom.
+- **Wizard-flyt**: når stegene er avhengige av hverandre skal det valideres på slutten av hvert steg. Ha med en [live region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Guides/Live_regions), f.eks. `<div>` med `aria-live="polite"`, på slutten av hvert steg. Den må alltid være i DOM. Ved valideringsfeil oppdater din live region til å vise de aktuelle feilene i `<ErrorSummary>`, samt bruk `errorMessage` prop på alle felt med tilsvarende feil.
+
+## Maler
+
+**OBS!** For layout for større brekkpunkter se demoer/stories utenfor Docs. For at lenker til inputfelt skal fungere må du åpne story i ny fane.
+
+### Visning av feilmeldinger
+
+Dette eksempelet er statisk og viser hvordan feilmeldinger bør vises etter validering som feilet.
+
+<Canvas of={ValidationStories.SimpleWithErrors} />
+
+### Wizard-flyt
+
+Ved Wizard-flyt der stegene er avhengige av hverandre skal det valideres på slutten av hvert steg. Brukeren kan ikke hoppe til neste steg før alle feltene i det nåværende steget er fylt ut korrekt. Validering skjer også ved innsending.
+
+<Canvas of={ValidationStories.Wizard} />

--- a/packages/dds-components/stories/patterns/Validation/Validation.stories.tsx
+++ b/packages/dds-components/stories/patterns/Validation/Validation.stories.tsx
@@ -1,0 +1,522 @@
+import preview from '#.storybook/preview';
+import { Fragment, type SubmitEvent, useState } from 'react';
+
+import {
+  ArrowLeftIcon,
+  Box,
+  Button,
+  ChevronRightIcon,
+  Drawer,
+  DrawerGroup,
+  ErrorSummary,
+  ErrorSummaryItem,
+  Grid,
+  GridChild,
+  HStack,
+  Heading,
+  InternalHeader,
+  NativeSelect,
+  Paragraph,
+  ProgressTracker,
+  TextInput,
+  Typography,
+  VStack,
+  VisuallyHidden,
+} from '../../../src';
+import { ddsProviderDecorator } from '../../../src/storybook';
+
+const meta = preview.meta({
+  title: 'Mønstre/Skjemavalidering',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      story: {
+        inline: false,
+      },
+    },
+  },
+  decorators: [ddsProviderDecorator],
+});
+
+export default meta;
+
+export const SimpleWithErrors = meta.story({
+  name: 'Statisk visning av feilmeldinger',
+  parameters: {
+    docs: {
+      story: {
+        height: '1000px',
+      },
+    },
+  },
+  render: () => {
+    return (
+      <>
+        <InternalHeader
+          applicationName="Applikasjon"
+          applicationDesc="Beskrivelse"
+          navItems={[
+            { children: 'Menypunkt', href: '//' },
+            { children: 'Menypunkt', href: '///' },
+          ]}
+          smallScreenBreakpoint="sm"
+          currentPageHref="//"
+        />
+        <Grid maxWidth="60ch" marginBlock="0 x1">
+          <GridChild columnsOccupied="all">
+            <Heading level={1} withMargins>
+              Navn på skjema
+            </Heading>
+            <Paragraph withMargins typographyType="leadMedium">
+              Dette er et eksempel på en ingress. Den består ofte av et par
+              setninger. En setning til.
+            </Paragraph>
+            <Paragraph
+              withMargins
+              typographyType="bodyLongSmall"
+              color="text-subtle"
+            >
+              Obligatoriske felter er merket med{' '}
+              <Typography as="span" color="text-requiredfield">
+                *
+              </Typography>
+              .
+            </Paragraph>
+            <VStack as="form" gap="x1.5" noValidate>
+              <TextInput
+                id="ledetekst"
+                required
+                label="Ledetekst"
+                width={{ xs: '100%' }}
+                errorMessage="Ledetekst må fylles ut"
+              />
+              <TextInput
+                id="ledetekst2"
+                label="Ledetekst 2"
+                width={{ xs: '100%' }}
+                value="123"
+                errorMessage="Ledetekst 2 må inneholde 11 sifre"
+              />
+              <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
+                <option></option>
+                <option>Valg 1</option>
+                <option>Valg 2</option>
+                <option>Valg 3</option>
+              </NativeSelect>
+              <ErrorSummary>
+                <ErrorSummaryItem href="#ledetekst">
+                  Ledetekst må fylles ut
+                </ErrorSummaryItem>
+                <ErrorSummaryItem href="#ledetekst2">
+                  Ledetekst 2 må inneholde 11 sifre
+                </ErrorSummaryItem>
+              </ErrorSummary>
+              <Button>Send inn</Button>
+            </VStack>
+          </GridChild>
+        </Grid>
+      </>
+    );
+  },
+});
+
+export const Wizard = meta.story({
+  parameters: {
+    docs: {
+      story: {
+        height: '1100px',
+      },
+    },
+  },
+  render: () => {
+    type FormDataKeys =
+      | 'step1Field1'
+      | 'step1Field2'
+      | 'step2Field1'
+      | 'step2Field2';
+
+    const [activeStep, setActiveStep] = useState(0);
+    const [completedSteps, setCompletedSteps] = useState(new Set<number>());
+    const [progressTrackerDrawerOpen, setProgressTrackerDrawerOpen] =
+      useState(false);
+    const [showErrorSummary, setShowErrorSummary] = useState(false);
+
+    type FormState = Record<
+      FormDataKeys,
+      {
+        value: string;
+        changed: boolean;
+        validated: boolean;
+      }
+    >;
+
+    const initialFormState: FormState = {
+      step1Field1: { value: '', changed: false, validated: false },
+      step1Field2: { value: '', changed: false, validated: false },
+      step2Field1: { value: '', changed: false, validated: false },
+      step2Field2: { value: '', changed: false, validated: false },
+    };
+
+    const [form, setForm] = useState<FormState>(initialFormState);
+
+    const [errors, setErrors] = useState<Record<FormDataKeys, string>>({
+      step1Field1: '',
+      step1Field2: '',
+      step2Field1: '',
+      step2Field2: '',
+    });
+
+    const fields: Record<FormDataKeys, { id: string; step: number }> = {
+      step1Field1: {
+        id: 'ledetekst',
+        step: 0,
+      },
+      step1Field2: {
+        id: 'ledetekst2',
+        step: 0,
+      },
+      step2Field1: {
+        id: 'ledetekst3',
+        step: 1,
+      },
+      step2Field2: {
+        id: 'ledetekst4',
+        step: 1,
+      },
+    };
+
+    const getStepFields = (step: number) =>
+      (Object.keys(fields) as Array<FormDataKeys>).filter(
+        key => fields[key].step === step,
+      );
+
+    const steps = ['Skjemasteg 1 ', 'Skjemasteg 2'];
+
+    const getFieldError = (field: FormDataKeys, value: string): string => {
+      switch (field) {
+        case 'step1Field1':
+        case 'step2Field1':
+          return value.trim() ? '' : 'Ledetekst må fylles ut';
+
+        case 'step1Field2':
+        case 'step2Field2':
+          if (!value.trim()) {
+            return 'Ledetekst 2 må fylles ut';
+          }
+
+          return /^\d{11}$/.test(value)
+            ? ''
+            : 'Ledetekst 2 må bestå av 11 sifre';
+      }
+    };
+
+    const updateField = (field: FormDataKeys, value: string) => {
+      setForm(current => ({
+        ...current,
+        [field]: {
+          ...current[field],
+          value,
+          changed: true,
+        },
+      }));
+    };
+
+    const blurField = (field: FormDataKeys) => {
+      setForm(current => ({
+        ...current,
+        [field]: {
+          ...current[field],
+          validated: true,
+        },
+      }));
+
+      if (!form[field].changed) {
+        return;
+      }
+
+      setErrors(current => ({
+        ...current,
+        [field]: getFieldError(field, form[field].value),
+      }));
+    };
+
+    const validateStep = (step: number) => {
+      const stepFields = getStepFields(step);
+
+      const stepErrors = {} as Record<FormDataKeys, string>;
+
+      let isValid = true;
+
+      stepFields.forEach(field => {
+        const error = getFieldError(field, form[field].value);
+
+        stepErrors[field] = error;
+
+        if (error) {
+          isValid = false;
+        }
+      });
+
+      setErrors(current => ({
+        ...current,
+        ...stepErrors,
+      }));
+
+      setShowErrorSummary(!isValid);
+
+      return isValid;
+    };
+
+    const goToStep = (nextStep: number) => {
+      if (nextStep <= activeStep) {
+        setActiveStep(nextStep);
+        return;
+      }
+      if (!validateStep(activeStep)) {
+        return;
+      }
+
+      setShowErrorSummary(false);
+      setCompletedSteps(s => new Set([...s, activeStep]));
+      setActiveStep(nextStep);
+    };
+
+    const completeStep = (step: number, e: SubmitEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      goToStep(step + 1);
+    };
+
+    const previousStep = () => {
+      setActiveStep(activeStep - 1);
+    };
+
+    const summaryErrors = getStepFields(activeStep)
+      .filter(field => errors[field])
+      .map(field => ({
+        field,
+        error: errors[field],
+      }));
+
+    console.log('summaryErrors', summaryErrors);
+
+    const stepItems = steps.map((step, index) => (
+      <ProgressTracker.Item key={step} completed={completedSteps.has(index)}>
+        {step}
+      </ProgressTracker.Item>
+    ));
+
+    const formSteps = [
+      <Fragment key={0}>
+        <Heading level={2} withMargins>
+          {steps[0]}
+        </Heading>
+        <VStack
+          as="form"
+          gap="x1"
+          noValidate
+          onSubmit={e => {
+            completeStep(0, e);
+          }}
+        >
+          <TextInput
+            id="ledetekst"
+            required
+            label="Ledetekst"
+            width={{ xs: '100%' }}
+            value={form.step1Field1.value}
+            onChange={e => updateField('step1Field1', e.target.value)}
+            onBlur={() => blurField('step1Field1')}
+            errorMessage={errors.step1Field1}
+          />
+          <TextInput
+            id="ledetekst2"
+            required
+            label="Ledetekst 2"
+            width={{ xs: '100%' }}
+            value={form.step1Field2.value}
+            onChange={e => updateField('step1Field2', e.target.value)}
+            onBlur={() => blurField('step1Field2')}
+            errorMessage={errors.step1Field2}
+          />
+          <NativeSelect label="Ledetekst" width={{ xs: '100%' }}>
+            <option></option>
+            <option>Valg 1</option>
+            <option>Valg 2</option>
+            <option>Valg 3</option>
+          </NativeSelect>
+          <div aria-live="polite">
+            {showErrorSummary && summaryErrors.length > 0 && (
+              <ErrorSummary>
+                {summaryErrors.map(({ field, error }) => (
+                  <ErrorSummaryItem key={field} href={`#${fields[field].id}`}>
+                    {error}
+                  </ErrorSummaryItem>
+                ))}
+              </ErrorSummary>
+            )}
+          </div>
+          <HStack
+            gap="x1.5"
+            paddingBlock={showErrorSummary ? '0 x1.5' : 'x1.5'}
+          >
+            <Button>Neste</Button>
+          </HStack>
+        </VStack>
+      </Fragment>,
+      <Fragment key={1}>
+        <Heading level={2} withMargins>
+          {steps[1]}
+        </Heading>
+        <VStack
+          as="form"
+          gap="x1"
+          noValidate
+          onSubmit={e => {
+            completeStep(1, e);
+          }}
+        >
+          <TextInput
+            id="ledetekst3"
+            required
+            label="Ledetekst"
+            width={{ xs: '100%' }}
+            value={form.step2Field1.value}
+            onChange={e => updateField('step2Field1', e.target.value)}
+            onBlur={() => blurField('step2Field1')}
+            errorMessage={errors.step2Field1}
+          />
+          <TextInput
+            id="ledetekst4"
+            required
+            label="Ledetekst 2"
+            width={{ xs: '100%' }}
+            value={form.step2Field2.value}
+            onChange={e => updateField('step2Field2', e.target.value)}
+            onBlur={() => blurField('step2Field2')}
+            errorMessage={errors.step2Field2}
+          />
+          <div aria-live="polite">
+            {showErrorSummary && summaryErrors.length > 0 && (
+              <ErrorSummary>
+                {summaryErrors.map(({ field, error }) => (
+                  <ErrorSummaryItem key={field} href={`#${fields[field].id}`}>
+                    {error}
+                  </ErrorSummaryItem>
+                ))}
+              </ErrorSummary>
+            )}
+          </div>
+          <HStack
+            gap="x1.5"
+            paddingBlock={showErrorSummary ? 'x1 x1.5' : 'x1.5'}
+          >
+            <Button>Send inn</Button>
+          </HStack>
+        </VStack>
+      </Fragment>,
+    ];
+    return (
+      <>
+        <InternalHeader
+          applicationName="Applikasjon"
+          applicationDesc="Beskrivelse"
+          navItems={[
+            { children: 'Menypunkt', href: '//' },
+            { children: 'Menypunkt', href: '///' },
+          ]}
+          currentPageHref="//"
+          smallScreenBreakpoint="sm"
+        />
+        <Grid as="div" marginBlock="0 x1" maxWidth="1100px">
+          <GridChild
+            columnsOccupied={{
+              xs: '1/-1',
+              sm: '1/7',
+              md: '1/7',
+              lg: '1/7',
+              xl: '1/7',
+            }}
+          >
+            <Heading withMargins level={1}>
+              Navn på skjema
+            </Heading>
+            <Paragraph typographyType="leadMedium" withMargins>
+              Dette er et eksempel på en ingress. Den består ofte av et par
+              setninger. En setning til.
+            </Paragraph>
+            <Paragraph
+              typographyType="bodyLongSmall"
+              color="text-subtle"
+              withMargins
+            >
+              Obligatoriske felter er merket med{' '}
+              <Typography as="span" color="text-requiredfield">
+                *
+              </Typography>
+              .
+            </Paragraph>
+            <VStack
+              gap="x1"
+              marginBlock={{
+                xs: '0 x1',
+                sm: '0 x1',
+                md: activeStep > 0 ? '0 x1' : '0',
+                lg: activeStep > 0 ? '0 x1' : '0',
+                xl: activeStep > 0 ? '0 x1' : '0',
+              }}
+            >
+              <Box showBelow="sm">
+                <DrawerGroup
+                  isOpen={progressTrackerDrawerOpen}
+                  setIsOpen={setProgressTrackerDrawerOpen}
+                >
+                  <Button
+                    purpose="secondary"
+                    iconPosition="right"
+                    icon={ChevronRightIcon}
+                  >
+                    Steg {activeStep + 1} av {steps.length}{' '}
+                    <VisuallyHidden>Vis stegnavigasjon</VisuallyHidden>
+                  </Button>
+                  <Drawer>
+                    <ProgressTracker
+                      activeStep={activeStep}
+                      onStepChange={goToStep}
+                    >
+                      {stepItems}
+                    </ProgressTracker>
+                  </Drawer>
+                </DrawerGroup>
+              </Box>
+              {activeStep > 0 && (
+                <Button
+                  purpose="secondary"
+                  icon={ArrowLeftIcon}
+                  onClick={() => previousStep()}
+                >
+                  Forrige steg
+                </Button>
+              )}
+            </VStack>
+            {formSteps[activeStep]}
+          </GridChild>
+          <GridChild
+            hideBelow="sm"
+            marginBlock="x4 x1"
+            columnsOccupied={{
+              xs: '1/-1',
+              sm: '1/-1',
+              md: '7/13',
+              lg: '7/13',
+              xl: '7/13',
+            }}
+          >
+            <ProgressTracker activeStep={activeStep} onStepChange={goToStep}>
+              {stepItems}
+            </ProgressTracker>
+          </GridChild>
+        </Grid>
+      </>
+    );
+  },
+});


### PR DESCRIPTION
## Beskrivelse

Inkluderer retningslinjer, mal med statisk visning av feilmeldinger, mal med Wizard-flyt. Skriver litt om de andre mønstre for å samle validering under dette mønsteret, og referere fra de andre.

Verifiser dokumentasjon og malene her: https://elsa1-753-pattern-form-valid.designsystem.pages.dev/?path=/docs/m%C3%B8nstre-skjemavalidering--docs

I samme slengen: endrer navn på stories til norsk, slik at det står på norsk i sidemenyen.

Mal med statisk visning av feilmeldinger:
<img width="975" height="864" alt="bilde" src="https://github.com/user-attachments/assets/aeb3963a-8850-4f24-97af-a7928ac3bd0c" />


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
