### PR TITLE
ELSA1-894: Utbedrer temavelger i stories

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -204,5 +204,7 @@
     width: fit-content;
     margin-inline-start: auto;
     margin-block-end: var(--dds-spacing-x1);
+    display: flex;
+    gap: var(--dds-spacing-x0-75);
   }
 </style>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -12,10 +12,14 @@ import { type PropsWithChildren, useEffect, useState } from 'react';
 
 import {
   DdsProvider,
-  type DdsTheme,
+  Toggle,
   ToggleBar,
   ToggleRadio,
 } from '../packages/dds-components/src';
+import {
+  type DdsThemeMain,
+  type DdsThemeMode,
+} from '../packages/dds-components/src/components/ThemeProvider/ThemeProvider';
 
 // Setter bakgrunn i Canvas basert på verdien til --dds-color-bg-default i ThemeProvider
 const setCanvasBackgroundFromTheme = (counter: number) => {
@@ -81,32 +85,45 @@ export default definePreview({
         );
       }
 
-      const [theme, setTheme] = useState<DdsTheme>('core-light');
+      const [mainTheme, setMainTheme] = useState<DdsThemeMain>('core');
+      const [mode, setMode] = useState<boolean>(false);
       nameCounter++;
+      const checkedToMode: (checked: boolean) => DdsThemeMode = (
+        checked: boolean,
+      ) => (checked ? 'dark' : 'light');
 
       useEffect(() => {
         setCanvasBackgroundFromTheme(nameCounter);
-      }, [theme]);
+      }, [mainTheme, mode]);
 
       return (
-        <DdsProvider theme={theme} language="nb">
+        <DdsProvider
+          theme={`${mainTheme}-${checkedToMode(mode)}`}
+          language="nb"
+        >
           <div
             className="theme-toggle-bar-wrapper"
             id={`theme-toggle-bar-wrapper-${nameCounter}`}
           >
+            <Toggle
+              name={`mode-toggle-${nameCounter}`}
+              htmlProps={{ 'aria-label': 'Modus' }}
+              checked={mode}
+              onChange={setMode}
+              variant="colorScheme"
+            />
             <ToggleBar
               size="xsmall"
               name={`theme-${nameCounter}`}
-              value={theme}
+              value={mainTheme}
               htmlProps={{ 'aria-label': 'Tema' }}
               onChange={(_event, theme) => {
-                if (theme) setTheme(theme);
+                if (theme) setMainTheme(theme);
               }}
+              purpose="secondary"
             >
-              <ToggleRadio value="core-light" label="core-light" />
-              <ToggleRadio value="core-dark" label="core-dark" />
-              <ToggleRadio value="public-light" label="public-light" />
-              <ToggleRadio value="public-dark" label="public-dark" />
+              <ToggleRadio value="core" label="core" />
+              <ToggleRadio value="public" label="public" />
             </ToggleBar>
           </div>
           <Story />

--- a/packages/dds-components/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/dds-components/src/components/ThemeProvider/ThemeProvider.tsx
@@ -14,6 +14,13 @@ import { cn } from '../../utils';
 export type DdsTheme = keyof typeof ddsTokens;
 const defaultTheme: DdsTheme = 'core-light';
 
+type SplitTheme<T extends string> = T extends `${infer Main}-${infer Mode}`
+  ? { main: Main; mode: Mode }
+  : never;
+
+export type DdsThemeMain = SplitTheme<DdsTheme>['main'];
+export type DdsThemeMode = SplitTheme<DdsTheme>['mode'];
+
 interface ThemeContextProps {
   theme: DdsTheme;
   el: HTMLDivElement | null;

--- a/stories/Tokens/utils/BorderRadiusGenerator.tsx
+++ b/stories/Tokens/utils/BorderRadiusGenerator.tsx
@@ -1,17 +1,15 @@
+import { type DdsThemeMain } from '#packages/dds-components/src/components/ThemeProvider/ThemeProvider';
 import jsonBase from '@norges-domstoler/dds-design-tokens/dds/tokens/Base/Elsa.json';
 import jsonC from '@norges-domstoler/dds-design-tokens/dds/tokens/Semantic/BorderRadius/Core.json';
 import jsonP from '@norges-domstoler/dds-design-tokens/dds/tokens/Semantic/BorderRadius/Public.json';
 
 import { copyButton } from './CopyButton';
 import { splitReferenceKeys, tableStyle } from './functions';
-import {
-  type ThemeMain,
-  type TokenBorderRadiusJsonObject,
-} from './Tokens.types';
+import { type TokenBorderRadiusJsonObject } from './Tokens.types';
 import { Paper } from '../../../packages/dds-components/dist';
 import { Table } from '../../../packages/dds-components/src/index';
 
-export const BorderRadiusGenerator = (theme: ThemeMain) => {
+export const BorderRadiusGenerator = (theme: DdsThemeMain) => {
   const tokenSet = theme === 'core' ? jsonC : jsonP;
   const tokens: TokenBorderRadiusJsonObject = tokenSet['dds-border-radius'];
   const baseTokens: TokenBorderRadiusJsonObject =

--- a/stories/Tokens/utils/SizeGenerator.tsx
+++ b/stories/Tokens/utils/SizeGenerator.tsx
@@ -1,10 +1,10 @@
+import { type DdsThemeMain } from '#packages/dds-components/src/components/ThemeProvider/ThemeProvider';
 import jsonBase from '@norges-domstoler/dds-design-tokens/dds/tokens/Base/Elsa.json';
 import jsonHeightC from '@norges-domstoler/dds-design-tokens/dds/tokens/Semantic/Size/Height/Core.json';
 import jsonHeightP from '@norges-domstoler/dds-design-tokens/dds/tokens/Semantic/Size/Height/Public.json';
 
 import { copyButton } from './CopyButton';
 import {
-  type ThemeMain,
   type TokenBaseSizeJsonObject,
   type TokenSemanticHeightJsonObject,
 } from './Tokens.types';
@@ -60,7 +60,7 @@ export const SizeIconGenerator = () => {
   );
 };
 
-export const SizeHeightGenerator = (theme: ThemeMain) => {
+export const SizeHeightGenerator = (theme: DdsThemeMain) => {
   const tokenSet = theme === 'core' ? jsonHeightC : jsonHeightP;
   const tokens: TokenSemanticHeightJsonObject = tokenSet['dds-size']['height'];
   const cssStyle = ` .dds-size-height-preview {

--- a/stories/Tokens/utils/Tokens.types.tsx
+++ b/stories/Tokens/utils/Tokens.types.tsx
@@ -1,6 +1,3 @@
-export type ThemeMain = 'core' | 'public';
-export type ThemeMode = 'light' | 'dark';
-
 interface Token<T = string> {
   value: T;
   type: string;

--- a/stories/Tokens/utils/TypographyGenerator.tsx
+++ b/stories/Tokens/utils/TypographyGenerator.tsx
@@ -1,3 +1,4 @@
+import { type DdsThemeMain } from '#packages/dds-components/src/components/ThemeProvider/ThemeProvider';
 import jsonBase from '@norges-domstoler/dds-design-tokens/dds/tokens/Base/Elsa.json';
 import jsonC from '@norges-domstoler/dds-design-tokens/dds/tokens/Semantic/Typography/Core.json';
 import jsonP from '@norges-domstoler/dds-design-tokens/dds/tokens/Semantic/Typography/Public.json';
@@ -10,7 +11,6 @@ import {
   tableStyle,
 } from './functions';
 import {
-  type ThemeMain,
   type TokenTypographyBaseJsonObject,
   type TokenTypographySemanticCssFont,
   type TokenTypographySemanticJsonObject,
@@ -27,7 +27,7 @@ baseTokens['dds-font-paragraph-spacing'] =
 baseTokens['dds-font-letter-spacing'] = jsonBase['dds-font-letter-spacing'];
 baseTokens['dds-font-style'] = jsonBase['dds-font-style'];
 
-export const TypographyGenerator = (theme: ThemeMain) => {
+export const TypographyGenerator = (theme: DdsThemeMain) => {
   const tokenSet = theme === 'core' ? jsonC : jsonP;
   const tokens: TokenTypographySemanticJsonObject = tokenSet['dds-font'];
 


### PR DESCRIPTION

## Beskrivelse

Splitter den i to komponenter, en for hovedtema og en for modustema. Dette gjør det mulig å velge hovedtema og modustema uavhengig av hverandre, samt sparer plass når vi utvider med tema for Høyesterett.


Før:

<img width="417" height="55" alt="bilde" src="https://github.com/user-attachments/assets/c4f12102-051f-43f8-a460-3670cc79c1f4" />

<img width="818" height="153" alt="bilde" src="https://github.com/user-attachments/assets/3fae177d-ee2b-4dba-ae65-21db5a0e26f0" />


Etter:
<img width="185" height="60" alt="bilde" src="https://github.com/user-attachments/assets/5cc60a90-9120-4e6f-8c37-467712febbdf" />

<img width="802" height="142" alt="bilde" src="https://github.com/user-attachments/assets/3025bf79-f410-48c5-a902-c0f274b204d3" />

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
