### PR TITLE
ELSA1-863: Oppdaterer styling i Select-komponent

### DIFF
--- a/.changeset/some-mails-clean.md
+++ b/.changeset/some-mails-clean.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Oppdaterer border, padding, og hover-farge på listelementer i 'Select'-komponenten

--- a/packages/dds-components/src/components/Select/Select.styles.ts
+++ b/packages/dds-components/src/components/Select/Select.styles.ts
@@ -232,6 +232,7 @@ export const getCustomStyles = <TOption>(
     overflowY: 'auto',
     position: 'relative',
     boxSizing: 'border-box',
+    padding: 'var(--dds-spacing-x0-125)',
     ...scrollbarStyling,
   }),
   option: (provided, state) => ({
@@ -241,16 +242,13 @@ export const getCustomStyles = <TOption>(
     alignItems: 'center',
     gap: 'var(--dds-spacing-x0-25)',
     padding: 'var(--dds-spacing-x0-75)',
+    borderRadius: 'var(--dds-border-radius-surface)',
     backgroundColor: 'var(--dds-color-surface-default)',
     ...typography.option[size],
     color: 'var(--dds-color-text-default)',
     '@media (prefers-reduced-motion: no-preference)': {
       transition:
         'color var(--dds-motion-micro-state), background-color var(--dds-motion-micro-state)',
-    },
-    '&:hover': {
-      color: 'var(--dds-color-text-default)',
-      backgroundColor: 'var(--dds-color-surface-hover-subtle)',
     },
     ...(state.isSelected && {
       backgroundColor: 'var(--dds-color-surface-selected-default)',


### PR DESCRIPTION
## Beskrivelse
- Fjerner all hovereffekter på bakgrunnsfarge på listeelementer
- Setter border-radius til 'surface' på alle listeelementer
- Legger padding 0.125rem på meny-listen

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)
