### PR TITLE
Uten issue: Legger til støtte for lokale AI-modeller

### DIFF
--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -2,7 +2,8 @@
   "$schema": "https://opencode.ai/config.json",
   "lsp": true,
   "share": "disabled",
-  "enabled_providers": ["github-copilot"],
+  "enabled_providers": ["github-copilot", "lmstudio"],
+  "small_model": "github-copilot/claude-haiku-4.5",
   "permission": {
     "bash": {
       "git commit": "ask",
@@ -20,6 +21,26 @@
     "chrome-devtools": {
       "type": "local",
       "command": ["npx", "chrome-devtools-mcp@latest"],
-    }
-  }
+    },
+  },
+  "provider": {
+    "lmstudio": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "LM Studio",
+      "options": {
+        "baseURL": "http://localhost:1234/v1",
+        "apiKey": "",
+      },
+      "models": {
+        "qwen3": {
+          "name": "Qwen3",
+          // Denne skal fungere med alle typer qwen3-modeller, f.eks. qwen3.6-35b-a3b
+          "limit": {
+            "context": 262144,
+            "output": 65568,
+          },
+        },
+      },
+    },
+  },
 }


### PR DESCRIPTION
## Beskrivelse
Med denne config'n så kan man bruke LM Studio med lokal Qwen3.6-modell i repoet. Legger også inn at Claude Haiku skal brukes som default for alle enklere oppgaver i Opencode, for å minimere kostnader.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)