### PR TITLE
Uten issue: venstrestiller header for sorted tables

### DIFF
--- a/.changeset/real-loops-double.md
+++ b/.changeset/real-loops-double.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Venstrestiller tekst i headers i tabeller med sortering

--- a/packages/dds-components/src/components/Table/normal/Table.module.css
+++ b/packages/dds-components/src/components/Table/normal/Table.module.css
@@ -148,6 +148,7 @@
   display: flex;
   align-items: center;
   color: inherit;
+  text-align: inherit;
 
   @media (prefers-reduced-motion: no-preference) {
     transition: var(--dds-focus-transition);


### PR DESCRIPTION
Tabeller har venstrestilt tekst i headere, men dette ble overskrevet i sorterte tabeller siden headeren inneholdt en Button hvor teksten sentrertes. Legger derfor til en `text-align: inherit` på sorteringsknappen i tabellen slik at den arver riktig posisjon fra headeren.

**Før**
<img width="1113" height="261" alt="Før" src="https://github.com/user-attachments/assets/4eb8ad96-ef2e-489c-be42-2345dcfe61f3" />

**Etter**
<img width="1112" height="260" alt="Etter" src="https://github.com/user-attachments/assets/efafcbcd-2ac4-42ab-bb83-2ec09f9e2508" />

## Beskrivelse

_Denne PRen endrer..._

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [ ] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
