### PR TITLE
ELSA1-903: rydder oppi sidemenyen i Storybook

### DIFF
--- a/.storybook/ddsTheme.ts
+++ b/.storybook/ddsTheme.ts
@@ -23,6 +23,8 @@ export default create({
 
   //UI
   appBorderRadius: theme.ddsBorderRadiusSurfaceNumberPx,
+  barSelectedColor: theme.ddsColorSurfaceActionSelected,
+  barTextColor: theme.ddsColorTextDefault,
 });
 
 /**------------------------------------------------------------------------

--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,12 +1,9 @@
 <style>
-  .sidebar-subheading.sidebar-subheading {
-    color: var(--dds-color-text-default);
-    font: var(--dds-font-heading-xsmall);
-    letter-spacing: var(--dds-font-heading-xsmall-letter-spacing);
+  .sidebar-subheading.sidebar-subheading button {
+    font-size: 1rem;
+    line-height: 1.3em;
+    font-weight: 600;
+    letter-spacing: 0em;
     text-transform: none;
-  }
-
-  .sidebar-subheading button > span:first-of-type {
-    margin-top: 10px;
   }
 </style>

--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -14,9 +14,9 @@ addons.setConfig({
       'development-utils',
       'dds-design-tokens',
       'dds-formatting',
-      'icons',
-      'patterns',
-      'playground',
+      'Ikoner',
+      'Mønstre',
+      'Playground',
     ],
   },
 });

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -51,7 +51,7 @@ export default definePreview({
     options: {
       storySort: {
         method: 'alphabetical',
-        order: ['Introduction', '*', ['Introduction', 'Changelog']],
+        order: ['Introduksjon', '*', ['Introduksjon', 'Changelog']],
       },
     },
     docs: {

--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -21,6 +21,7 @@
     ".github/**",
     ".changeset/**",
     "packages/dds-formatting/**",
-    "packages/storybook-components/**"
+    "packages/storybook-components/**",
+    ".storybook/manager*"
   ]
 }

--- a/packages/dds-components/src/components/FormSummary/FormSummary.mdx
+++ b/packages/dds-components/src/components/FormSummary/FormSummary.mdx
@@ -28,7 +28,7 @@ import {
 
 Komponent som oppsummerer utfylte felt i et skjema delt opp i steg. Består av flere delkomponenter og bruker `<dl>` som liste under panseret.
 
-Komponenten brukes i mønsteret <LinkTo title='Patterns/CheckAnswers' story='Docs'>Sjekk svar</LinkTo>.
+Komponenten brukes i mønsteret <LinkTo title='Mønstre/Sjekk svar' story='Docs'>Sjekk svar</LinkTo>.
 
 ## Delkomponenter
 

--- a/packages/dds-components/src/components/Icon/Icon.mdx
+++ b/packages/dds-components/src/components/Icon/Icon.mdx
@@ -15,7 +15,7 @@ import meta from './Icon.stories';
   storybookHref={{ folder: 'components', comp: 'icon' }}
 />
 
-`<Icon>` er en code-only komponent som tar inn et svg-ikon fra <LinkTo title="Icons/Overview" story="Overview">ikonutvalget</LinkTo> og returnerer den med riktig størrelse og annen styling. Les mer om hvilke ikoner vi bruker og retningslinjer under [Ikoner (design.domstol.no)](https://design.domstol.no/987b33f71/p/27770f-ikoner).
+`<Icon>` er en code-only komponent som tar inn et svg-ikon fra <LinkTo title="Ikoner/Oversikt" story="Oversikt">ikonutvalget</LinkTo> og returnerer den med riktig størrelse og annen styling. Les mer om hvilke ikoner vi bruker og retningslinjer under [Ikoner (design.domstol.no)](https://design.domstol.no/987b33f71/p/27770f-ikoner).
 
 ## Props
 

--- a/packages/dds-components/src/components/Icon/overview-page/icons.stories.tsx
+++ b/packages/dds-components/src/components/Icon/overview-page/icons.stories.tsx
@@ -27,299 +27,307 @@ import { CopyIcon } from '../icons/copy';
 import { type SvgIcon } from '../utils';
 
 const meta = preview.meta({
-  title: 'Icons/Overview',
+  title: 'Ikoner/Oversikt',
   tags: ['!autodocs'],
   decorators: [ddsProviderDecorator],
 });
 
-export const Overview = meta.story(() => {
-  interface IconState {
-    name: IconName;
-    icon: SvgIcon;
-  }
-
-  const hasStates = (
-    icon: SvgIcon,
-  ): icon is SvgIcon & { states: ReadonlyArray<string> } => 'states' in icon;
-
-  const [iconState, setIconState] = useState<IconState | undefined>();
-  const [currentState, setCurrentState] = useState<string | undefined>(
-    undefined,
-  );
-  const [closed, setClosed] = useState(true);
-  const [copiedUse, setCopiedUse] = useState(false);
-  const [copiedImport, setCopiedImport] = useState(false);
-  const close = () => setClosed(true);
-
-  useEffect(() => {
-    const timer = setTimeout(() => setCopiedUse(false), 2000);
-    return () => clearTimeout(timer);
-  }, [copiedUse]);
-
-  useEffect(() => {
-    const timer = setTimeout(() => setCopiedImport(false), 2000);
-    return () => clearTimeout(timer);
-  }, [copiedImport]);
-
-  const onIconClick = (props: IconState) => {
-    setIconState(props);
-    if (hasStates(props.icon)) {
-      setCurrentState(props.icon.states[0]);
-    } else {
-      setCurrentState(undefined);
+export const Oversikt = meta.story({
+  render: () => {
+    interface IconState {
+      name: IconName;
+      icon: SvgIcon;
     }
-    setClosed(false);
-  };
 
-  const availableStates: ReadonlyArray<string> =
-    iconState && hasStates(iconState.icon) ? iconState.icon.states : [];
+    const hasStates = (
+      icon: SvgIcon,
+    ): icon is SvgIcon & { states: ReadonlyArray<string> } => 'states' in icon;
 
-  const copy = (text: string) => {
-    navigator.clipboard.writeText(text);
-  };
+    const [iconState, setIconState] = useState<IconState | undefined>();
+    const [currentState, setCurrentState] = useState<string | undefined>(
+      undefined,
+    );
+    const [closed, setClosed] = useState(true);
+    const [copiedUse, setCopiedUse] = useState(false);
+    const [copiedImport, setCopiedImport] = useState(false);
+    const close = () => setClosed(true);
 
-  const trim = (name: string) => name.replace('Icon', '');
+    useEffect(() => {
+      const timer = setTimeout(() => setCopiedUse(false), 2000);
+      return () => clearTimeout(timer);
+    }, [copiedUse]);
 
-  const downloadSvg = (name: IconName, svg: string) => {
-    const blob = new Blob([svg], { type: 'image/svg+xml' });
-    const url = URL.createObjectURL(blob);
+    useEffect(() => {
+      const timer = setTimeout(() => setCopiedImport(false), 2000);
+      return () => clearTimeout(timer);
+    }, [copiedImport]);
 
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${trim(name)}.svg`;
-    a.click();
+    const onIconClick = (props: IconState) => {
+      setIconState(props);
+      if (hasStates(props.icon)) {
+        setCurrentState(props.icon.states[0]);
+      } else {
+        setCurrentState(undefined);
+      }
+      setClosed(false);
+    };
 
-    URL.revokeObjectURL(url);
-  };
+    const availableStates: ReadonlyArray<string> =
+      iconState && hasStates(iconState.icon) ? iconState.icon.states : [];
 
-  const handleCopyUse = (text: string) => {
-    copy(text);
-    setCopiedUse(true);
-  };
+    const copy = (text: string) => {
+      navigator.clipboard.writeText(text);
+    };
 
-  const handleCopyImport = (text: string) => {
-    copy(text);
-    setCopiedImport(true);
-  };
+    const trim = (name: string) => name.replace('Icon', '');
 
-  const iconOverview = () => {
-    return Object.entries(icons).map(([name, icon]) => {
-      const trimmedName = trim(name);
-      return (
-        <VStack
-          as={StylelessButton}
-          position="relative"
-          justifyContent="center"
-          alignItems="center"
-          gap="x0.75"
-          height="6rem"
-          width={{ xs: '5rem', sm: '5rem', md: '5rem', lg: '5rem', xl: '6rem' }}
-          key={name}
-          onClick={() => onIconClick({ name, icon } as IconState)}
-          title={trimmedName}
-          className={cn(styles.card, focusable)}
-        >
-          <Icon iconSize="large" icon={icon} color="icon-default" />
-          <Typography
-            typographyType="bodyShortXsmall"
-            className={styles.card__name}
+    const downloadSvg = (name: IconName, svg: string) => {
+      const blob = new Blob([svg], { type: 'image/svg+xml' });
+      const url = URL.createObjectURL(blob);
+
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${trim(name)}.svg`;
+      a.click();
+
+      URL.revokeObjectURL(url);
+    };
+
+    const handleCopyUse = (text: string) => {
+      copy(text);
+      setCopiedUse(true);
+    };
+
+    const handleCopyImport = (text: string) => {
+      copy(text);
+      setCopiedImport(true);
+    };
+
+    const iconOverview = () => {
+      return Object.entries(icons).map(([name, icon]) => {
+        const trimmedName = trim(name);
+        return (
+          <VStack
+            as={StylelessButton}
+            position="relative"
+            justifyContent="center"
+            alignItems="center"
+            gap="x0.75"
+            height="6rem"
+            width={{
+              xs: '5rem',
+              sm: '5rem',
+              md: '5rem',
+              lg: '5rem',
+              xl: '6rem',
+            }}
+            key={name}
+            onClick={() => onIconClick({ name, icon } as IconState)}
+            title={trimmedName}
+            className={cn(styles.card, focusable)}
           >
-            {trimmedName}
-          </Typography>
-          {hasStates(icon) && (
-            <Box
-              position="absolute"
-              top="0"
-              right="0"
-              className={styles.card__badge}
-              width="max-content"
-              padding="x0.125"
+            <Icon iconSize="large" icon={icon} color="icon-default" />
+            <Typography
+              typographyType="bodyShortXsmall"
+              className={styles.card__name}
             >
-              <Typography typographyType="bodyShortXsmall">
-                ✨ animert
-              </Typography>
-            </Box>
-          )}
-        </VStack>
-      );
-    });
-  };
-
-  const importCode = `import { ${iconState?.name} } from '@norges-domstoler/dds-components';`;
-  const useCode = `<Icon icon={${iconState?.name}}${availableStates.length > 0 ? ` iconState='${availableStates[0]}'` : ''} />`;
-
-  return (
-    <VStack
-      gap="x1"
-      margin="auto"
-      position="relative"
-      maxWidth={{
-        xs: '800px',
-        sm: '800px',
-        md: '800px',
-        lg: '1100px',
-        xl: '1350px',
-      }}
-    >
-      <Typography typographyType="bodyShortSmall">
-        Antall ikoner: {Object.keys(icons).length}
-      </Typography>
-      <LocalMessage>
-        Klikk på ikonet for mer info. Animerte ikoner bruker{' '}
-        <code>iconState</code> prop for å animere mellom tilstander.
-      </LocalMessage>
-      <div className={styles.overview}>{iconOverview()}</div>
-      <Modal
-        isOpen={!closed}
-        onClose={close}
-        header={
-          iconState?.name && (
-            <Heading level={2}>
-              <Icon
-                icon={iconState.icon}
-                iconSize="component"
-                className={styles.header__icon}
-              />{' '}
-              {trim(iconState.name)}
-            </Heading>
-          )
-        }
-      >
-        {iconState && (
-          <ModalBody>
-            {iconSvgs[iconState.name] && (
-              <Button
-                purpose="secondary"
-                onClick={() =>
-                  downloadSvg(iconState.name, iconSvgs[iconState.name])
-                }
-                icon={DownloadIcon}
+              {trimmedName}
+            </Typography>
+            {hasStates(icon) && (
+              <Box
+                position="absolute"
+                top="0"
+                right="0"
+                className={styles.card__badge}
+                width="max-content"
+                padding="x0.125"
               >
-                Last ned SVG
-              </Button>
-            )}
-            <Paper
-              as="section"
-              border="border-subtle"
-              background="surface-medium"
-              marginBlock="x1"
-            >
-              <HStack
-                as={Heading}
-                level={3}
-                typographyType="headingSmall"
-                justifyContent="space-between"
-                paddingInline=" x0.5"
-                alignItems="center"
-              >
-                <span>Import</span>
-                <Box
-                  as={Button}
-                  purpose="tertiary"
-                  size="small"
-                  marginInline="x0.5 0"
-                  icon={copiedImport ? CheckIcon : CopyIcon}
-                  aria-label={`Kopier${copiedImport ? 't' : ''} import`}
-                  onClick={() => handleCopyImport(importCode)}
-                />
-              </HStack>
-
-              <Paper
-                className={styles['code-paper']}
-                background="surface-default"
-                borderRadius="0"
-              >
-                <pre className={cn(styles['icon-code'], 'icon-code')}>
-                  {importCode}
-                </pre>
-              </Paper>
-            </Paper>
-            <Paper
-              as="section"
-              border="border-subtle"
-              background="surface-medium"
-              marginBlock="x1"
-            >
-              <HStack
-                as={Heading}
-                level={3}
-                typographyType="headingSmall"
-                justifyContent="space-between"
-                paddingInline=" x0.5 0"
-                alignItems="center"
-              >
-                <span>Bruk i kode</span>
-                <Box
-                  as={Button}
-                  purpose="tertiary"
-                  size="small"
-                  marginInline="x0.5"
-                  icon={copiedUse ? CheckIcon : CopyIcon}
-                  aria-label={`Kopier${copiedUse ? 't' : ''} use`}
-                  onClick={() => handleCopyUse(useCode)}
-                />
-              </HStack>
-
-              <Paper
-                className={styles['code-paper']}
-                background="surface-default"
-                borderRadius="0"
-              >
-                <pre className={cn(styles['icon-code'], 'icon-code')}>
-                  {useCode}
-                </pre>
-              </Paper>
-            </Paper>
-
-            <Heading level={3} withMargins>
-              Størrelser
-            </Heading>
-            {availableStates.length !== 0 && (
-              <Box width="fit-content" marginBlock="0 x1">
-                <ToggleBar
-                  size="xsmall"
-                  value={currentState}
-                  onChange={(_event, state) => {
-                    if (state) setCurrentState(state);
-                  }}
-                  label="Tilstand"
-                >
-                  {availableStates.map(s => (
-                    <ToggleRadio key={s} value={s} label={s} />
-                  ))}
-                </ToggleBar>
+                <Typography typographyType="bodyShortXsmall">
+                  ✨ animert
+                </Typography>
               </Box>
             )}
-            <HStack gap="x1" alignItems="end">
-              {ICON_SIZES.map(size => (
+          </VStack>
+        );
+      });
+    };
+
+    const importCode = `import { ${iconState?.name} } from '@norges-domstoler/dds-components';`;
+    const useCode = `<Icon icon={${iconState?.name}}${availableStates.length > 0 ? ` iconState='${availableStates[0]}'` : ''} />`;
+
+    return (
+      <VStack
+        gap="x1"
+        margin="auto"
+        position="relative"
+        maxWidth={{
+          xs: '800px',
+          sm: '800px',
+          md: '800px',
+          lg: '1100px',
+          xl: '1350px',
+        }}
+      >
+        <Typography typographyType="bodyShortSmall">
+          Antall ikoner: {Object.keys(icons).length}
+        </Typography>
+        <LocalMessage>
+          Klikk på ikonet for mer info. Animerte ikoner bruker{' '}
+          <code>iconState</code> prop for å animere mellom tilstander.
+        </LocalMessage>
+        <div className={styles.overview}>{iconOverview()}</div>
+        <Modal
+          isOpen={!closed}
+          onClose={close}
+          header={
+            iconState?.name && (
+              <Heading level={2}>
+                <Icon
+                  icon={iconState.icon}
+                  iconSize="component"
+                  className={styles.header__icon}
+                />{' '}
+                {trim(iconState.name)}
+              </Heading>
+            )
+          }
+        >
+          {iconState && (
+            <ModalBody>
+              {iconSvgs[iconState.name] && (
+                <Button
+                  purpose="secondary"
+                  onClick={() =>
+                    downloadSvg(iconState.name, iconSvgs[iconState.name])
+                  }
+                  icon={DownloadIcon}
+                >
+                  Last ned SVG
+                </Button>
+              )}
+              <Paper
+                as="section"
+                border="border-subtle"
+                background="surface-medium"
+                marginBlock="x1"
+              >
+                <HStack
+                  as={Heading}
+                  level={3}
+                  typographyType="headingSmall"
+                  justifyContent="space-between"
+                  paddingInline=" x0.5"
+                  alignItems="center"
+                >
+                  <span>Import</span>
+                  <Box
+                    as={Button}
+                    purpose="tertiary"
+                    size="small"
+                    marginInline="x0.5 0"
+                    icon={copiedImport ? CheckIcon : CopyIcon}
+                    aria-label={`Kopier${copiedImport ? 't' : ''} import`}
+                    onClick={() => handleCopyImport(importCode)}
+                  />
+                </HStack>
+
+                <Paper
+                  className={styles['code-paper']}
+                  background="surface-default"
+                  borderRadius="0"
+                >
+                  <pre className={cn(styles['icon-code'], 'icon-code')}>
+                    {importCode}
+                  </pre>
+                </Paper>
+              </Paper>
+              <Paper
+                as="section"
+                border="border-subtle"
+                background="surface-medium"
+                marginBlock="x1"
+              >
+                <HStack
+                  as={Heading}
+                  level={3}
+                  typographyType="headingSmall"
+                  justifyContent="space-between"
+                  paddingInline=" x0.5 0"
+                  alignItems="center"
+                >
+                  <span>Bruk i kode</span>
+                  <Box
+                    as={Button}
+                    purpose="tertiary"
+                    size="small"
+                    marginInline="x0.5"
+                    icon={copiedUse ? CheckIcon : CopyIcon}
+                    aria-label={`Kopier${copiedUse ? 't' : ''} use`}
+                    onClick={() => handleCopyUse(useCode)}
+                  />
+                </HStack>
+
+                <Paper
+                  className={styles['code-paper']}
+                  background="surface-default"
+                  borderRadius="0"
+                >
+                  <pre className={cn(styles['icon-code'], 'icon-code')}>
+                    {useCode}
+                  </pre>
+                </Paper>
+              </Paper>
+
+              <Heading level={3} withMargins>
+                Størrelser
+              </Heading>
+              {availableStates.length !== 0 && (
+                <Box width="fit-content" marginBlock="0 x1">
+                  <ToggleBar
+                    size="xsmall"
+                    value={currentState}
+                    onChange={(_event, state) => {
+                      if (state) setCurrentState(state);
+                    }}
+                    label="Tilstand"
+                  >
+                    {availableStates.map(s => (
+                      <ToggleRadio key={s} value={s} label={s} />
+                    ))}
+                  </ToggleBar>
+                </Box>
+              )}
+              <HStack gap="x1" alignItems="end">
+                {ICON_SIZES.map(size => (
+                  <VStack>
+                    <Icon
+                      icon={iconState.icon}
+                      iconSize={size}
+                      iconState={
+                        availableStates.length
+                          ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            (currentState as any)
+                          : undefined
+                      }
+                    />
+                    <StoryLabel>{size}</StoryLabel>
+                  </VStack>
+                ))}
                 <VStack>
-                  <Icon
+                  <Button
                     icon={iconState.icon}
-                    iconSize={size}
                     iconState={
-                      availableStates.length
-                        ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                          (currentState as any)
-                        : undefined
+                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                      availableStates.length ? (currentState as any) : undefined
                     }
                   />
-                  <StoryLabel>{size}</StoryLabel>
+                  <StoryLabel>I Button</StoryLabel>
                 </VStack>
-              ))}
-              <VStack>
-                <Button
-                  icon={iconState.icon}
-                  iconState={
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    availableStates.length ? (currentState as any) : undefined
-                  }
-                />
-                <StoryLabel>I Button</StoryLabel>
-              </VStack>
-            </HStack>
-          </ModalBody>
-        )}
-      </Modal>
-    </VStack>
-  );
+              </HStack>
+            </ModalBody>
+          )}
+        </Modal>
+      </VStack>
+    );
+  },
 });

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTracker.mdx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTracker.mdx
@@ -1,4 +1,5 @@
 import { ArgTypes, Meta, Canvas, Controls } from '@storybook/addon-docs/blocks';
+import LinkTo from '@storybook/addon-links/react';
 import * as ProgressTrackerStories from './ProgressTracker.stories';
 import meta from './ProgressTracker.stories';
 import * as ProgressTrackerFormStories from './ProgressTrackerForm.stories';
@@ -7,6 +8,7 @@ import {
   Source,
   ComponentLinkRow,
 } from '@norges-domstoler/storybook-components';
+
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from '../Tabs';
 
 <Meta of={meta} />
@@ -103,13 +105,19 @@ return (
       <Canvas of={ProgressTrackerStories.SmallScreen} />
     </TabPanel>
     <TabPanel>
-      Se detaljer i [Patterns |
-      Form](https://domstolene.github.io/designsystem/?path=/docs/patterns-form--docs).
+      Se detaljer i{' '}
+      <LinkTo title="Mønstre/Skjema" story="docs">
+        Skjema-mønsteret
+      </LinkTo>
+      .
       <Canvas of={ProgressTrackerFormStories.FormWithSteps} />
     </TabPanel>
     <TabPanel>
-      Se detaljer i [Patterns |
-      Form](https://domstolene.github.io/designsystem/?path=/docs/patterns-form--docs).
+      Se detaljer i{' '}
+      <LinkTo title="Mønstre/Skjema" story="docs">
+        Skjema-mønsteret
+      </LinkTo>
+      .
       <Canvas of={ProgressTrackerFormStories.FormWithStepsCustomGrid} />
     </TabPanel>
   </TabPanels>

--- a/packages/dds-components/stories/introduction.mdx
+++ b/packages/dds-components/stories/introduction.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="dds-components/Introduction" />
+<Meta title="dds-components/Introduksjon" />
 
 # @norges-domstoler/dds-components
 

--- a/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswers.mdx
+++ b/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswers.mdx
@@ -21,7 +21,7 @@ import LinkTo from '@storybook/addon-links/react';
 
 <ComponentLinkRow
   docsHref="0874d8-sjekk-svar"
-  storybookHref={{ folder: 'Patterns', comp: 'check-answers--check-answers' }}
+  storybookHref={{ folder: 'mønstre', comp: 'sjekk-svar--check-answers' }}
 />
 
 ## Bruksområde
@@ -30,13 +30,13 @@ Skjema med flere steg.
 
 ## Hvordan implementere?
 
-Dette mønsteret brukes sammen med <LinkTo title='Patterns/Form' story='docs'>Skjema-mønsteret</LinkTo> og <LinkTo title='dds-components/components/FormSummary' story='docs'> `<FormSummary>` komponenten</LinkTo>. `<FormSummary>` brukes i siste steget i skjema og kalles "Oppsummering" el.l.
+Dette mønsteret brukes sammen med <LinkTo title='Mønstre/Skjema' story='docs'>Skjema-mønsteret</LinkTo> og <LinkTo title='dds-components/components/FormSummary' story='docs'> `<FormSummary>` komponenten</LinkTo>. `<FormSummary>` brukes i siste steget i skjema og kalles "Oppsummering" el.l.
 
 Du trenger i utgangspunktet ingen egen CSS styling.
 
 ### Komponenter
 
-- **Skjemakomponenter, typografi og layout primitives**: se <LinkTo title='Patterns/Form' story='docs'>Skjema-mønsteret</LinkTo>.
+- **Skjemakomponenter, typografi og layout primitives**: se <LinkTo title='Mønstre/Skjema' story='docs'>Skjema-mønsteret</LinkTo>.
 - **`<FormSummary>`**.
 
 ### Styling

--- a/packages/dds-components/stories/patterns/Validation/Validation.mdx
+++ b/packages/dds-components/stories/patterns/Validation/Validation.mdx
@@ -24,7 +24,7 @@ import * as ValidationStories from './Validation.stories';
 
 ## Bruksområde
 
-Skjemavalidering. Brukes i kombinasjon med <LinkTo title='Patterns/Check Answers' story='docs'>Sjekk svar-mønsteret</LinkTo> og <LinkTo title='Patterns/Form' story='docs'>Skjema-mønsteret</LinkTo>.
+Skjemavalidering. Brukes i kombinasjon med <LinkTo title='Mønstre/Sjekk svar' story='docs'>Sjekk svar-mønsteret</LinkTo> og <LinkTo title='Mønstre/Skjema' story='docs'>Skjema-mønsteret</LinkTo>.
 
 ## Hvordan implementere?
 
@@ -32,7 +32,7 @@ Skjema-mønsteret bruker gjerne en del komponenter, layout primitives og props f
 
 ### Komponenter
 
-- **Skjemakomponenter, typografi og layout primitives**: se <LinkTo title='Patterns/Form' story='docs'>Skjema-mønsteret</LinkTo>.
+- **Skjemakomponenter, typografi og layout primitives**: se <LinkTo title='Mønstre/Skjema' story='docs'>Skjema-mønsteret</LinkTo>.
 - **`<ErrorSummary>`**.
 
 ## Validering

--- a/packages/dds-components/stories/patterns/introduction.mdx
+++ b/packages/dds-components/stories/patterns/introduction.mdx
@@ -1,8 +1,8 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Patterns/Introduction" />
+<Meta title="Mønstre/Introduksjon" />
 
-# Patterns
+# Mønstre
 
 Her finner du mønstre - eksempler på sammensatte komponenter og sideoppsett som dekker vanlige brukerbehov - som skjemaer, oppsummeringssider, og andre typiske interaksjonsmønstre.
 I motsetning til enkeltkomponenter, viser mønstre hvordan elementer fungerer sammen i en helhetlig kontekst.

--- a/packages/dds-formatting/stories/introduction.mdx
+++ b/packages/dds-formatting/stories/introduction.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="dds-formatting/Introduction" />
+<Meta title="dds-formatting/Introduksjon" />
 
 # @norges-domstoler/dds-formatting
 

--- a/packages/dds-tokens/stories/introduction.mdx
+++ b/packages/dds-tokens/stories/introduction.mdx
@@ -1,10 +1,10 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="dds-design-tokens/Introduction" />
+<Meta title="dds-design-tokens/Introduksjon" />
 
 # @norges-domstoler/dds-design-tokens
 
-Biblioteket inneholder design tokens brukt i [Domstolenes designsystem Elsa](https://design.domstol.no/): farger, typografi, avstander skygger og størrelser. Design tokens kan brukes i domstolenes tjenester i bl.a. global styling og custom elementer.
+Biblioteket inneholder design tokens brukt i [Domstolenes designsystem Elsa](https://design.domstol.no/): farger, typografi, avstander, skygger, størrelser osv. Design tokens kan brukes i domstolenes tjenester i bl.a. global styling og custom elementer.
 
 ## 📦 Installasjon
 

--- a/packages/development-utils/stories/introduction.mdx
+++ b/packages/development-utils/stories/introduction.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="development-utils/Introduction" />
+<Meta title="development-utils/Introduksjon" />
 
 # @norges-domstoler/development-utils
 

--- a/stories/Introduction.mdx
+++ b/stories/Introduction.mdx
@@ -4,7 +4,7 @@ import {
   CardsContainter,
 } from '@norges-domstoler/storybook-components';
 
-<Meta title="Introduction" />
+<Meta title="Introduksjon" />
 
 <style>{`
   .sbdocs-content {


### PR DESCRIPTION
## Beskrivelse

Vi bruker norsk der det gir mening:
- introduksjonen tin mønstre bør endre mappenavn fra 'Patterns' til 'Mønstre'.
- "introduksjoner" generelt
- "ikoner"

I samme slengen: fikser styling på sidemenyen.

Før:

<img width="281" height="560" alt="bilde" src="https://github.com/user-attachments/assets/27936ec4-fb0e-42b0-be66-ba90bf3cb39b" />


Etter:
<img width="367" height="576" alt="bilde" src="https://github.com/user-attachments/assets/9a03756a-ca0a-4b09-9ff8-4627d15cc140" />


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
