### PR TITLE
ELSA1-889: migrerer til kebab-case for prop `typographyType`

### DIFF
--- a/.changeset/tangy-gifts-kick.md
+++ b/.changeset/tangy-gifts-kick.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': major
+---
+
+Støttede verdier for prop `typographyType` migreres fra camelCase til kebab-case. Se [dds-components migreringsguiden v23 til v24](https://design.domstol.no/987b33f71/p/04eb89-v23-til-v24).

--- a/packages/dds-components/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/dds-components/src/components/Accordion/Accordion.stories.tsx
@@ -129,14 +129,14 @@ export const Styled = meta.story({
   render: args => (
     <Accordion {...args}>
       <AccordionHeader
-        typographyType="bodyShortMedium"
+        typographyType="body-short-medium"
         className="custom-header"
         bold
       >
         Dekning av reiseutgifter
       </AccordionHeader>
       <AccordionBody className="custom-panel">
-        <Paragraph typographyType="bodyLongSmall">
+        <Paragraph typographyType="body-long-small">
           I sivile saker avtales dekning av utgifter med den part som innkalte
           deg. I straffesaker har du krav på reise- og kostgodtgjørelse (
           <Link href="#">

--- a/packages/dds-components/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/dds-components/src/components/Accordion/AccordionHeader.tsx
@@ -13,14 +13,16 @@ import { focusable } from '../helpers/styling/focus.module.css';
 import { Icon } from '../Icon';
 import { AnimatedChevronUpDownIcon } from '../Icon/icons/animated';
 import { Box } from '../layout';
-import { type StaticTypographyType, getTypographyCn } from '../Typography';
+import { type StaticTypographyType } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 export type AccordionHeaderProps = Omit<
   BaseComponentPropsWithChildren<
     HTMLButtonElement,
     {
-      /**Overskriver default teksttype. */
+      /**Overskriver default teksttype.
+       * @default 'heading-medium'
+       */
       typographyType?: StaticTypographyType;
       /**Angir om teksten skal være i "bold"-format. */
       bold?: boolean;
@@ -35,7 +37,7 @@ export const AccordionHeader = ({
   className,
   style,
   htmlProps,
-  typographyType = 'headingMedium',
+  typographyType = 'heading-medium',
   bold,
   ...rest
 }: AccordionHeaderProps) => {
@@ -64,7 +66,7 @@ export const AccordionHeader = ({
       <div
         className={cn(
           baseStyles.header__content,
-          typographyStyles[getTypographyCn(typographyType)],
+          typographyStyles[typographyType],
           bold && typographyStyles.bold,
         )}
       >

--- a/packages/dds-components/src/components/Card/Card.stories.tsx
+++ b/packages/dds-components/src/components/Card/Card.stories.tsx
@@ -73,7 +73,7 @@ export const Overview = meta.story({
       <StoryVStack>
         <Card {...args} cardType="info">
           <div className="story-container-padding">
-            <Heading level={2} typographyType="headingLarge">
+            <Heading level={2} typographyType="heading-large">
               Info
             </Heading>
             {body}
@@ -81,7 +81,7 @@ export const Overview = meta.story({
         </Card>
         <Card {...args} cardType="navigation" href="#">
           <div className="story-container-padding">
-            <Heading level={2} typographyType="headingLarge">
+            <Heading level={2} typographyType="heading-large">
               Navigation
             </Heading>
             {body}
@@ -99,7 +99,7 @@ export const Overview = meta.story({
       <StoryVStack>
         <Card {...args} cardType="info" appearance="border">
           <div className="story-container-padding">
-            <Heading level={2} typographyType="headingLarge">
+            <Heading level={2} typographyType="heading-large">
               Info
             </Heading>
             {body}
@@ -107,7 +107,7 @@ export const Overview = meta.story({
         </Card>
         <Card {...args} appearance="border" cardType="navigation" href="#">
           <div className="story-container-padding">
-            <Heading level={2} typographyType="headingLarge">
+            <Heading level={2} typographyType="heading-large">
               Navigation
             </Heading>
             {body}
@@ -190,7 +190,7 @@ export const ExpandableCustom = meta.story({
     <Card {...args} cardType="expandable" appearance="border">
       <CardExpandable>
         <CardExpandableHeader
-          typographyType="headingXsmall"
+          typographyType="heading-xsmall"
           padding="4px 12px"
           bold
           className="custom-header"
@@ -198,7 +198,7 @@ export const ExpandableCustom = meta.story({
           Dekning av reiseutgifter
         </CardExpandableHeader>
         <CardExpandableBody padding="16px 12px">
-          <Paragraph typographyType="bodyLongSmall">
+          <Paragraph typographyType="body-long-small">
             I sivile saker avtales dekning av utgifter med den part som innkalte
             deg. I straffesaker har du krav på reise- og kostgodtgjørelse (
             <Link href="#">

--- a/packages/dds-components/src/components/Card/CardExpandable/CardExpandableHeader.tsx
+++ b/packages/dds-components/src/components/Card/CardExpandable/CardExpandableHeader.tsx
@@ -13,7 +13,7 @@ import baseStyles from '../../helpers/AccordionBase/AccordionBase.module.css';
 import { focusable } from '../../helpers/styling/focus.module.css';
 import { Icon } from '../../Icon';
 import { AnimatedChevronUpDownIcon } from '../../Icon/icons/animated';
-import { type StaticTypographyType, getTypographyCn } from '../../Typography';
+import { type StaticTypographyType } from '../../Typography';
 import typographyStyles from '../../Typography/typographyStyles.module.css';
 
 export type CardExpandableHeaderProps = Omit<
@@ -38,7 +38,7 @@ export const CardExpandableHeader = ({
   style,
   htmlProps,
   padding,
-  typographyType = 'headingLarge',
+  typographyType = 'heading-large',
   bold,
   ...rest
 }: CardExpandableHeaderProps) => {
@@ -75,7 +75,7 @@ export const CardExpandableHeader = ({
         style={containerStyleVariables}
         className={cn(
           styles['header-container'],
-          typographyStyles[getTypographyCn(typographyType)],
+          typographyStyles[typographyType],
           bold && typographyStyles.bold,
         )}
       >

--- a/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectable.stories.tsx
+++ b/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectable.stories.tsx
@@ -151,7 +151,7 @@ export const ComplexContent = meta.story({
       <VStack gap="x1">
         <CardSelectable {...args}>
           <VStack gap="x0.5">
-            <Typography as="span" typographyType="headingSmall">
+            <Typography as="span" typographyType="heading-small">
               Overskrift
             </Typography>
             <Typography as="span">

--- a/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectableGroup.stories.tsx
+++ b/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectableGroup.stories.tsx
@@ -77,7 +77,7 @@ export const WithLabel = meta.story({
   render: args => {
     return (
       <VStack gap="x0.75">
-        <Typography typographyType="headingSmall" as="span" id="label-1">
+        <Typography typographyType="heading-small" as="span" id="label-1">
           Gruppeledetekst
         </Typography>
         <CardSelectableGroup {...args} aria-labelledby="label-1">
@@ -99,7 +99,7 @@ export const WithCustomTip = meta.story({
   render: args => {
     return (
       <VStack gap="x0.75">
-        <Typography typographyType="headingSmall" as="span" id="label-1">
+        <Typography typographyType="heading-small" as="span" id="label-1">
           Gruppeledetekst
         </Typography>
         <Typography id="tip-1">Hjelpetekst</Typography>
@@ -143,7 +143,7 @@ export const WithErrorMessage = meta.story({
     return (
       <>
         <VStack gap="x0.75">
-          <Typography typographyType="headingSmall" as="span" id="label-1">
+          <Typography typographyType="heading-small" as="span" id="label-1">
             Gruppeledetekst
           </Typography>
           <CardSelectableGroup {...args} aria-labelledby="label-1">
@@ -168,7 +168,7 @@ export const ControlledRadio = meta.story({
     return (
       <>
         <VStack gap="x0.75">
-          <Typography typographyType="headingSmall" as="span" id="label-1">
+          <Typography typographyType="heading-small" as="span" id="label-1">
             Gruppeledetekst
           </Typography>
           <CardSelectableGroup

--- a/packages/dds-components/src/components/CookieBanner/CookieBanner.tsx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBanner.tsx
@@ -74,7 +74,7 @@ export function CookieBanner({
     headerText && (id ?? `cookie-banner-${generatedId}-heading`);
 
   const heading = headerText ? (
-    <Heading level={2} typographyType="headingMedium" id={headingId}>
+    <Heading level={2} typographyType="heading-medium" id={headingId}>
       {headerText}
     </Heading>
   ) : (

--- a/packages/dds-components/src/components/CookieBanner/CookieBannerCheckbox.tsx
+++ b/packages/dds-components/src/components/CookieBanner/CookieBannerCheckbox.tsx
@@ -35,10 +35,10 @@ export function CookieBannerCheckbox({
       )}
     >
       <VStack gap="x0.5">
-        <Typography as="span" typographyType="headingSmall">
+        <Typography as="span" typographyType="heading-small">
           {headerText}
         </Typography>
-        <Typography as="span" typographyType="bodyLongSmall">
+        <Typography as="span" typographyType="body-long-small">
           {description}
         </Typography>
       </VStack>

--- a/packages/dds-components/src/components/Drawer/Drawer.tsx
+++ b/packages/dds-components/src/components/Drawer/Drawer.tsx
@@ -189,7 +189,7 @@ export const Drawer = ({
         {hasHeader && (
           <div id={headerId}>
             {typeof header === 'string' ? (
-              <Heading level={2} typographyType="headingLarge">
+              <Heading level={2} typographyType="heading-large">
                 {header}
               </Heading>
             ) : (

--- a/packages/dds-components/src/components/EmptyContent/EmptyContent.tsx
+++ b/packages/dds-components/src/components/EmptyContent/EmptyContent.tsx
@@ -42,7 +42,7 @@ export function EmptyContent({
         className={typographyStyles['text-color--medium']}
       >
         {headerText && (
-          <Heading level={headerHeadingLevel} typographyType="headingMedium">
+          <Heading level={headerHeadingLevel} typographyType="heading-medium">
             {headerText}
           </Heading>
         )}

--- a/packages/dds-components/src/components/ErrorSummary/ErrorSummary.tsx
+++ b/packages/dds-components/src/components/ErrorSummary/ErrorSummary.tsx
@@ -31,13 +31,13 @@ export const ErrorSummary = ({
   const { t } = useTranslation();
   const heading =
     typeof pHeading === 'string' ? (
-      <Heading level={2} typographyType="headingSmall">
+      <Heading level={2} typographyType="heading-small">
         {pHeading}
       </Heading>
     ) : pHeading ? (
       pHeading
     ) : (
-      <Heading level={2} typographyType="headingSmall">
+      <Heading level={2} typographyType="heading-small">
         {t(texts.toProceedCorrectErrors)}
       </Heading>
     );

--- a/packages/dds-components/src/components/Footer/FooterListHeader.tsx
+++ b/packages/dds-components/src/components/Footer/FooterListHeader.tsx
@@ -3,5 +3,5 @@ import { Heading, type HeadingProps } from '../Typography';
 export type FooterListHeaderProps = Omit<HeadingProps, 'level' | 'withMargins'>;
 
 export const FooterListHeader = (props: FooterListHeaderProps) => (
-  <Heading level={2} typographyType="headingSmall" {...props} />
+  <Heading level={2} typographyType="heading-small" {...props} />
 );

--- a/packages/dds-components/src/components/Icon/overview-page/icons.stories.tsx
+++ b/packages/dds-components/src/components/Icon/overview-page/icons.stories.tsx
@@ -128,7 +128,7 @@ export const Oversikt = meta.story({
           >
             <Icon iconSize="large" icon={icon} color="icon-default" />
             <Typography
-              typographyType="bodyShortXsmall"
+              typographyType="body-short-xsmall"
               className={styles.card__name}
             >
               {trimmedName}
@@ -142,7 +142,7 @@ export const Oversikt = meta.story({
                 width="max-content"
                 padding="x0.125"
               >
-                <Typography typographyType="bodyShortXsmall">
+                <Typography typographyType="body-short-xsmall">
                   ✨ animert
                 </Typography>
               </Box>
@@ -168,7 +168,7 @@ export const Oversikt = meta.story({
           xl: '1350px',
         }}
       >
-        <Typography typographyType="bodyShortSmall">
+        <Typography typographyType="body-short-small">
           Antall ikoner: {Object.keys(icons).length}
         </Typography>
         <LocalMessage>
@@ -214,7 +214,7 @@ export const Oversikt = meta.story({
                 <HStack
                   as={Heading}
                   level={3}
-                  typographyType="headingSmall"
+                  typographyType="heading-small"
                   justifyContent="space-between"
                   paddingInline=" x0.5"
                   alignItems="center"
@@ -250,7 +250,7 @@ export const Oversikt = meta.story({
                 <HStack
                   as={Heading}
                   level={3}
-                  typographyType="headingSmall"
+                  typographyType="heading-small"
                   justifyContent="space-between"
                   paddingInline=" x0.5 0"
                   alignItems="center"

--- a/packages/dds-components/src/components/InputMessage/InputMessage.tsx
+++ b/packages/dds-components/src/components/InputMessage/InputMessage.tsx
@@ -65,7 +65,7 @@ export const InputMessage = ({
     <Box {...commonProps}>
       <Typography
         {...tgCommonProps}
-        typographyType="bodyShortXsmall"
+        typographyType="body-short-xsmall"
         color="text-subtle"
       />
     </Box>

--- a/packages/dds-components/src/components/InternalHeader/InternalHeader.tsx
+++ b/packages/dds-components/src/components/InternalHeader/InternalHeader.tsx
@@ -109,7 +109,7 @@ export const InternalHeader = (props: InternalHeaderProps) => {
         rest,
       )}
     >
-      <Typography typographyType="headingSmall" bold as="span">
+      <Typography typographyType="heading-small" bold as="span">
         {applicationHref ? (
           <a
             href={applicationHref}
@@ -122,7 +122,7 @@ export const InternalHeader = (props: InternalHeaderProps) => {
           applicationName
         )}
       </Typography>
-      <Typography typographyType="bodyShortMedium" as="span">
+      <Typography typographyType="body-short-medium" as="span">
         {applicationDesc}
       </Typography>
       {(hasContextMenu || navigation !== null) && (

--- a/packages/dds-components/src/components/List/List.stories.tsx
+++ b/packages/dds-components/src/components/List/List.stories.tsx
@@ -37,7 +37,7 @@ export const Overview = meta.story({
         <div>
           <Typography
             as="div"
-            typographyType="labelMedium"
+            typographyType="label-medium"
             style={{ maxWidth: '100px' }}
           >
             {typographyType} {listType}
@@ -65,10 +65,10 @@ export const Overview = meta.story({
 
     const VariantOverview = (listType: Props['listType']) => (
       <StoryHStack>
-        {ListVariant({ typographyType: 'bodyLongXsmall', listType })}
-        {ListVariant({ typographyType: 'bodyLongSmall', listType })}
-        {ListVariant({ typographyType: 'bodyLongMedium', listType })}
-        {ListVariant({ typographyType: 'bodyLongLarge', listType })}
+        {ListVariant({ typographyType: 'body-long-xsmall', listType })}
+        {ListVariant({ typographyType: 'body-long-small', listType })}
+        {ListVariant({ typographyType: 'body-long-medium', listType })}
+        {ListVariant({ typographyType: 'body-long-large', listType })}
       </StoryHStack>
     );
     return (

--- a/packages/dds-components/src/components/List/List.tsx
+++ b/packages/dds-components/src/components/List/List.tsx
@@ -6,7 +6,7 @@ import {
   getBaseHTMLProps,
 } from '../../types';
 import { cn } from '../../utils';
-import { type TypographyBodyLongType, getTypographyCn } from '../Typography';
+import { type TypographyBodyLongType } from '../Typography';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 
 export type ListType = 'ordered' | 'unordered';
@@ -46,7 +46,7 @@ export const List = ({
         styles[`list--${listType}`],
         typographyType === 'inherit'
           ? styles['list--inherit']
-          : typographyStyles[getTypographyCn(typographyType)],
+          : typographyStyles[typographyType],
       )}
     >
       {children}

--- a/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
+++ b/packages/dds-components/src/components/LocalMessage/LocalMessage.stories.tsx
@@ -99,7 +99,7 @@ export const ComplexContent = meta.story({
   },
   render: args => (
     <LocalMessage {...args} layout="vertical" closable>
-      <Heading level={2} typographyType="headingLarge" withMargins>
+      <Heading level={2} typographyType="heading-large" withMargins>
         Dette er en viktig melding
       </Heading>
       <Paragraph withMargins>Meldingen har en liste i seg:</Paragraph>

--- a/packages/dds-components/src/components/Modal/Modal.tsx
+++ b/packages/dds-components/src/components/Modal/Modal.tsx
@@ -162,7 +162,7 @@ export const Modal = ({
               {!!header && (
                 <div id={headerId}>
                   {typeof header === 'string' ? (
-                    <Heading level={2} typographyType="headingLarge">
+                    <Heading level={2} typographyType="heading-large">
                       {header}
                     </Heading>
                   ) : (

--- a/packages/dds-components/src/components/NewsPopover/NewsPopover.tsx
+++ b/packages/dds-components/src/components/NewsPopover/NewsPopover.tsx
@@ -212,7 +212,7 @@ export const NewsPopover = ({
       width={styleUpToBreakpoint('100%', smallScreenBreakpoint, '405px')}
     >
       <HStack margin="x0.75 x3 x0.75 x0.75">
-        <Heading id={headerId} level={2} typographyType="headingSmall">
+        <Heading id={headerId} level={2} typographyType="heading-small">
           {header}
         </Heading>
       </HStack>

--- a/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
+++ b/packages/dds-components/src/components/OverflowMenu/OverflowMenu.stories.tsx
@@ -313,7 +313,7 @@ export const PortalClippingComparison = meta.story({
       <VStack>
         <HStack gap="x2" alignItems="start">
           <VStack gap="x0-5">
-            <Paragraph typographyType="bodyShortMedium">
+            <Paragraph typographyType="body-short-medium">
               Portal (default)
             </Paragraph>
             <div style={clippingBoxStyle}>
@@ -325,7 +325,7 @@ export const PortalClippingComparison = meta.story({
           </VStack>
 
           <VStack gap="x0-5">
-            <Paragraph typographyType="bodyShortMedium">Portal av</Paragraph>
+            <Paragraph typographyType="body-short-medium">Portal av</Paragraph>
             <div style={clippingBoxStyle}>
               <OverflowMenuGroup isInitiallyOpen>
                 <Button icon={MoreVerticalIcon} aria-label="Åpne meny" />

--- a/packages/dds-components/src/components/Pagination/Pagination.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.tsx
@@ -353,7 +353,7 @@ export const Pagination = ({
           />
         )}
         {withCounter && (
-          <Paragraph typographyType="bodyShortMedium">
+          <Paragraph typographyType="body-short-medium">
             {t(
               texts.showsAmountOfTotalItems(
                 activePageFirstItem,

--- a/packages/dds-components/src/components/Popover/Popover.tsx
+++ b/packages/dds-components/src/components/Popover/Popover.tsx
@@ -227,7 +227,7 @@ export const Popover = ({
       {header && (
         <div className={styles.header}>
           {typeof header === 'string' ? (
-            <Heading level={2} typographyType="headingMedium">
+            <Heading level={2} typographyType="heading-medium">
               {header}
             </Heading>
           ) : (

--- a/packages/dds-components/src/components/ProgressTracker/ProgressTrackerItem.tsx
+++ b/packages/dds-components/src/components/ProgressTracker/ProgressTrackerItem.tsx
@@ -153,7 +153,7 @@ export const ProgressTrackerItem = (props: ProgressTrackerItemProps) => {
       </Box>
       <Typography
         as="div"
-        typographyType="bodyShortMedium"
+        typographyType="body-short-medium"
         className={cn(
           styles['item-text'],
           typographyStyles['a--nested__child'],

--- a/packages/dds-components/src/components/SelectionControl/SelectionControl.styles.tsx
+++ b/packages/dds-components/src/components/SelectionControl/SelectionControl.styles.tsx
@@ -81,7 +81,7 @@ export const renderGroupLabel = ({
     return (
       <Typography
         as="span"
-        typographyType="labelMedium"
+        typographyType="label-medium"
         id={id}
         className={readOnly ? labelStyles['read-only'] : undefined}
         withMargins

--- a/packages/dds-components/src/components/SelectionControl/SelectionControl.utils.tsx
+++ b/packages/dds-components/src/components/SelectionControl/SelectionControl.utils.tsx
@@ -2,6 +2,6 @@ import { type TypographyProps } from '../Typography';
 
 export const selectionControlTypographyProps: TypographyProps = {
   color: 'inherit',
-  typographyType: 'bodyShortMedium',
+  typographyType: 'body-short-medium',
   as: 'span',
 };

--- a/packages/dds-components/src/components/SkipToContent/SkipToContent.tsx
+++ b/packages/dds-components/src/components/SkipToContent/SkipToContent.tsx
@@ -43,7 +43,7 @@ export const SkipToContent = ({
       style={style}
       top={top}
     >
-      <Link {...rest} {...htmlProps} id={id} typographyType="bodyShortMedium">
+      <Link {...rest} {...htmlProps} id={id} typographyType="body-short-medium">
         {text}
       </Link>
     </Contrast>

--- a/packages/dds-components/src/components/ToggleBar/ToggleBar.tsx
+++ b/packages/dds-components/src/components/ToggleBar/ToggleBar.tsx
@@ -56,7 +56,7 @@ export const ToggleBar = <T extends string | number = string>(
         aria-labelledby={labelId ?? htmlProps?.['aria-labelledby']}
       >
         {label && (
-          <Typography id={labelId} as="span" typographyType="labelMedium">
+          <Typography id={labelId} as="span" typographyType="label-medium">
             {label}
           </Typography>
         )}

--- a/packages/dds-components/src/components/Typography/Caption/Caption.tsx
+++ b/packages/dds-components/src/components/Typography/Caption/Caption.tsx
@@ -20,7 +20,7 @@ export const Caption = ({
   return (
     <Typography
       {...getBaseHTMLProps(id, className, style, htmlProps, rest)}
-      typographyType="headingLarge"
+      typographyType="heading-large"
       as="caption"
     >
       {children}

--- a/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Heading/Heading.stories.tsx
@@ -3,6 +3,7 @@ import preview from '#.storybook/preview';
 import { ddsProviderDecorator } from '../../../storybook';
 import { StoryVStack } from '../../layout/Stack/storybook-utils';
 import { blockTgCommonArgTypes } from '../storybook-utils/storyUtils';
+import { TG_HEADING_TYPES } from '../Typography';
 
 import { Heading } from '.';
 
@@ -51,27 +52,11 @@ export const TypographyStyles = meta.story({
   args: { level: 1 },
   render: args => (
     <StoryVStack>
-      <Heading {...args} level={1} typographyType="headingXxlarge">
-        headingXxlarge
-      </Heading>
-      <Heading {...args} level={1} typographyType="headingXlarge">
-        headingXlarge
-      </Heading>
-      <Heading {...args} level={1} typographyType="headingLarge">
-        headingLarge
-      </Heading>
-      <Heading {...args} level={1} typographyType="headingMedium">
-        headingMedium
-      </Heading>
-      <Heading {...args} level={1} typographyType="headingSmall">
-        headingSmall
-      </Heading>
-      <Heading {...args} level={1} typographyType="headingXsmall">
-        headingXsmall
-      </Heading>
-      <Heading {...args} level={1} typographyType="headingXxsmall">
-        headingXxsmall
-      </Heading>
+      {TG_HEADING_TYPES.map(tg => (
+        <Heading key={tg} {...args} typographyType={tg}>
+          {tg}
+        </Heading>
+      ))}
     </StoryVStack>
   ),
 });

--- a/packages/dds-components/src/components/Typography/Heading/Heading.tsx
+++ b/packages/dds-components/src/components/Typography/Heading/Heading.tsx
@@ -17,19 +17,19 @@ const getHeadingElement = (level: HeadingLevel): ElementType => `h${level}`;
 const getDefaultTypographyType = (h: ElementType): TypographyHeadingType => {
   switch (h) {
     case 'h1':
-      return 'headingXlarge';
+      return 'heading-xlarge';
     case 'h2':
-      return 'headingLarge';
+      return 'heading-large';
     case 'h3':
-      return 'headingMedium';
+      return 'heading-medium';
     case 'h4':
-      return 'headingSmall';
+      return 'heading-small';
     case 'h5':
-      return 'headingXsmall';
+      return 'heading-xsmall';
     case 'h6':
-      return 'headingXxsmall';
+      return 'heading-xxsmall';
     default:
-      return 'headingXlarge';
+      return 'heading-xlarge';
   }
 };
 

--- a/packages/dds-components/src/components/Typography/Label/Label.tsx
+++ b/packages/dds-components/src/components/Typography/Label/Label.tsx
@@ -64,13 +64,13 @@ export const Label = ({
   };
   const render = afterLabelContent ? (
     <Typography
-      typographyType="labelMedium"
+      typographyType="label-medium"
       as="div"
       withMargins={rest.withMargins}
     >
       <Typography
         {...labelProps}
-        typographyType="labelMedium"
+        typographyType="label-medium"
         withMargins={false}
       >
         {content}
@@ -78,7 +78,7 @@ export const Label = ({
       {afterLabelContent}
     </Typography>
   ) : (
-    <Typography {...labelProps} typographyType="labelMedium">
+    <Typography {...labelProps} typographyType="label-medium">
       {content}
     </Typography>
   );

--- a/packages/dds-components/src/components/Typography/Legend/Legend.tsx
+++ b/packages/dds-components/src/components/Typography/Legend/Legend.tsx
@@ -25,7 +25,7 @@ export const Legend = ({
   className,
   style,
   htmlProps,
-  typographyType = 'headingLarge',
+  typographyType = 'heading-large',
   withMarginsOverInput,
   withMargins,
   ...rest

--- a/packages/dds-components/src/components/Typography/Link/Link.tsx
+++ b/packages/dds-components/src/components/Typography/Link/Link.tsx
@@ -11,7 +11,6 @@ import {
   type CommonInlineTypographyProps,
   type TypographyBodyType,
   getColorCn,
-  getTypographyCn,
 } from '../Typography';
 import tgStyles from '../typographyStyles.module.css';
 
@@ -75,10 +74,10 @@ export const Link = <T extends ElementType = 'a'>({
           tgStyles.a,
           withIconStyling && tgStyles['a--with-icon'],
           withVisited && tgStyles['a--visited'],
-          typographyType && tgStyles[getTypographyCn(typographyType)],
+          typographyType && tgStyles[typographyType],
           typographyType &&
             withMargins &&
-            tgStyles[`${getTypographyCn(typographyType)}--margins`],
+            tgStyles[`${typographyType}--margins`],
           focusable,
           getColorCn(color),
         ),

--- a/packages/dds-components/src/components/Typography/Paragraph/Paragraph.stories.tsx
+++ b/packages/dds-components/src/components/Typography/Paragraph/Paragraph.stories.tsx
@@ -1,5 +1,6 @@
 import preview from '#.storybook/preview';
 
+import { TG_PARAGRAPH_TYPES } from './Paragraph';
 import { ddsProviderDecorator } from '../../../storybook';
 import { StoryVStack } from '../../layout/Stack/storybook-utils';
 import { blockTgCommonArgTypes } from '../storybook-utils/storyUtils';
@@ -25,33 +26,11 @@ export const Preview = meta.story({
 export const Overview = meta.story({
   render: args => (
     <StoryVStack>
-      <Paragraph {...args} typographyType="bodyShortXsmall">
-        {args.children || 'bodyShortXsmall'}
-      </Paragraph>
-      <Paragraph {...args} typographyType="bodyShortSmall">
-        {args.children || 'bodyShortSmall'}
-      </Paragraph>
-      <Paragraph {...args} typographyType="bodyShortMedium">
-        {args.children || 'bodyShortMedium'}
-      </Paragraph>
-      <Paragraph {...args} typographyType="bodyShortLarge">
-        {args.children || 'bodyShortLarge'}
-      </Paragraph>
-      <Paragraph {...args} typographyType="bodyLongXsmall">
-        {args.children || 'bodyLongXsmall'}
-      </Paragraph>
-      <Paragraph {...args} typographyType="bodyLongSmall">
-        {args.children || 'bodyLongSmall'}
-      </Paragraph>
-      <Paragraph {...args} typographyType="bodyLongMedium">
-        {args.children || 'bodyLongMedium'}
-      </Paragraph>
-      <Paragraph {...args} typographyType="bodyLongLarge">
-        {args.children || 'bodyLongLarge'}
-      </Paragraph>
-      <Paragraph {...args} typographyType="leadMedium">
-        {args.children || 'leadMedium'}
-      </Paragraph>
+      {TG_PARAGRAPH_TYPES.map(type => (
+        <Paragraph key={type} {...args} typographyType={type}>
+          {args.children || type}
+        </Paragraph>
+      ))}
     </StoryVStack>
   ),
 });

--- a/packages/dds-components/src/components/Typography/Paragraph/Paragraph.tsx
+++ b/packages/dds-components/src/components/Typography/Paragraph/Paragraph.tsx
@@ -4,18 +4,21 @@ import {
 } from '../../../types';
 import {
   type CommonBlockTypographyProps,
+  TG_BODY_TYPES,
+  TG_LEAD_TYPES,
   Typography,
-  type TypographyBodyType,
-  type TypographyLeadType,
 } from '../Typography';
+
+export const TG_PARAGRAPH_TYPES = [...TG_BODY_TYPES, ...TG_LEAD_TYPES] as const;
+type TypographyParagraphType = (typeof TG_PARAGRAPH_TYPES)[number];
 
 export type ParagraphProps = BaseComponentPropsWithChildren<
   HTMLParagraphElement,
   {
     /** Spesifiserer typografistil basert på utvalget for brødtekst og ingress.
-     * @default 'BodyLongMedium'
+     * @default 'body-long-medium'
      */
-    typographyType?: TypographyBodyType | TypographyLeadType;
+    typographyType?: TypographyParagraphType;
   } & CommonBlockTypographyProps
 >;
 
@@ -25,7 +28,7 @@ export const Paragraph = ({
   style,
   htmlProps,
   children,
-  typographyType = 'bodyLongMedium',
+  typographyType = 'body-long-medium',
   ...rest
 }: ParagraphProps) => {
   return (

--- a/packages/dds-components/src/components/Typography/Paragraph/index.ts
+++ b/packages/dds-components/src/components/Typography/Paragraph/index.ts
@@ -1,1 +1,1 @@
-export * from './Paragraph';
+export { Paragraph, type ParagraphProps } from './Paragraph';

--- a/packages/dds-components/src/components/Typography/Typography/Typography.spec.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.spec.tsx
@@ -10,11 +10,11 @@ describe('<Typography>', () => {
     expect(screen.getByText(text)).toBeInTheDocument();
   });
   it('renders heading', () => {
-    render(<Typography typographyType="headingSmall" />);
+    render(<Typography typographyType="heading-small" />);
     expect(screen.getByRole('heading')).toBeInTheDocument();
   });
   it('renders paragraph', () => {
-    render(<Typography typographyType="bodyLongSmall" />);
+    render(<Typography typographyType="body-long-small" />);
     expect(screen.getByRole('paragraph')).toBeInTheDocument();
   });
   it('renders button', () => {

--- a/packages/dds-components/src/components/Typography/Typography/Typography.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.tsx
@@ -10,7 +10,6 @@ import {
 import {
   getColorCn,
   getElementType,
-  getTypographyCn,
   isCaption,
   isLegend,
 } from './Typography.utils';
@@ -69,7 +68,7 @@ const isAnchorProps = (
 
 export const Typography = (props: TypographyProps) => {
   const {
-    typographyType = 'bodyLongMedium',
+    typographyType = 'body-long-medium',
     as: propAs,
     children,
     bold,
@@ -85,7 +84,6 @@ export const Typography = (props: TypographyProps) => {
   } = props;
 
   const as = propAs ? propAs : getElementType(typographyType);
-  const typographyCn = getTypographyCn(typographyType);
 
   let relProp;
   if (isAnchorProps(props)) {
@@ -100,8 +98,8 @@ export const Typography = (props: TypographyProps) => {
           className,
           getColorCn(color),
           styles.container,
-          typographyStyles[typographyCn],
-          withMargins && typographyStyles[`${typographyCn}--margins`],
+          typographyStyles[typographyType],
+          withMargins && typographyStyles[`${typographyType}--margins`],
           isLegend(as) && typographyStyles.legend,
           isCaption(as) && typographyStyles.caption,
           isCaption(as) &&

--- a/packages/dds-components/src/components/Typography/Typography/Typography.types.ts
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.types.ts
@@ -4,39 +4,50 @@ import { type ExtractStrict } from '../../../types';
 import { type TextColor } from '../../../utils/color';
 import { type ResponsiveProps } from '../../layout';
 
-export type TypographyBodyShortType =
-  | 'bodyShortXsmall'
-  | 'bodyShortSmall'
-  | 'bodyShortMedium'
-  | 'bodyShortLarge';
+export const TG_BODY_SHORT_TYPES = [
+  'body-short-xsmall',
+  'body-short-small',
+  'body-short-medium',
+  'body-short-large',
+] as const;
 
-export type TypographyBodyLongType =
-  | 'bodyLongXsmall'
-  | 'bodyLongSmall'
-  | 'bodyLongMedium'
-  | 'bodyLongLarge';
+export const TG_BODY_LONG_TYPES = [
+  'body-long-xsmall',
+  'body-long-small',
+  'body-long-medium',
+  'body-long-large',
+] as const;
 
-export type TypographyBodyType =
-  | TypographyBodyLongType
-  | TypographyBodyShortType;
+export const TG_BODY_TYPES = [
+  ...TG_BODY_SHORT_TYPES,
+  ...TG_BODY_LONG_TYPES,
+] as const;
+
+export const TG_LEAD_TYPES = ['lead-medium'] as const;
+
+export type TypographyBodyShortType = (typeof TG_BODY_SHORT_TYPES)[number];
+
+export type TypographyBodyLongType = (typeof TG_BODY_LONG_TYPES)[number];
+
+export type TypographyBodyType = (typeof TG_BODY_TYPES)[number];
 
 export const TG_HEADING_TYPES = [
-  'headingXxsmall',
-  'headingXsmall',
-  'headingSmall',
-  'headingMedium',
-  'headingLarge',
-  'headingXlarge',
-  'headingXxlarge',
+  'heading-xxsmall',
+  'heading-xsmall',
+  'heading-small',
+  'heading-medium',
+  'heading-large',
+  'heading-xlarge',
+  'heading-xxlarge',
 ] as const;
 
 export type TypographyHeadingType = (typeof TG_HEADING_TYPES)[number];
 
-export type TypographyLeadType = 'leadMedium';
+export type TypographyLeadType = (typeof TG_LEAD_TYPES)[number];
 
 export type TypographyAnchorType = 'a';
 
-export type TypographyLabelType = 'labelMedium';
+export type TypographyLabelType = 'label-medium';
 
 export type OtherTypographyType =
   | TypographyHeadingType
@@ -49,26 +60,6 @@ export type TypographyType =
   | OtherTypographyType;
 
 export type StaticTypographyType = OtherTypographyType | TypographyLabelType;
-
-export type HyphenTypographyType =
-  | 'body-short-xsmall'
-  | 'body-short-small'
-  | 'body-short-medium'
-  | 'body-short-large'
-  | 'body-long-xsmall'
-  | 'body-long-small'
-  | 'body-long-medium'
-  | 'body-long-large'
-  | 'heading-xxsmall'
-  | 'heading-xsmall'
-  | 'heading-small'
-  | 'heading-medium'
-  | 'heading-large'
-  | 'heading-xlarge'
-  | 'heading-xxlarge'
-  | 'lead-medium'
-  | 'a'
-  | 'label-medium';
 
 export type InlineElement =
   | 'a'

--- a/packages/dds-components/src/components/Typography/Typography/Typography.utils.ts
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.utils.ts
@@ -1,47 +1,42 @@
 import { type ElementType } from 'react';
 
 import {
-  type HyphenTypographyType,
   type InlineElement,
   TG_HEADING_TYPES,
   type TypographyHeadingType,
   type TypographyType,
 } from './Typography.types';
-import {
-  type TextColor,
-  convertCamelToHyphen,
-  isTextColor,
-} from '../../../utils';
+import { type TextColor, isTextColor } from '../../../utils';
 import typographyStyles from '../typographyStyles.module.css';
 
 export const getElementType = (element: TypographyType): ElementType => {
   switch (element) {
     case 'a':
       return 'a';
-    case 'headingXxsmall':
+    case 'heading-xxsmall':
       return 'h6';
-    case 'headingXsmall':
+    case 'heading-xsmall':
       return 'h5';
-    case 'headingSmall':
+    case 'heading-small':
       return 'h4';
-    case 'headingMedium':
+    case 'heading-medium':
       return 'h3';
-    case 'headingLarge':
+    case 'heading-large':
       return 'h2';
-    case 'headingXlarge':
-    case 'headingXxlarge':
+    case 'heading-xlarge':
+    case 'heading-xxlarge':
       return 'h1';
-    case 'labelMedium':
+    case 'label-medium':
       return 'label';
-    case 'bodyShortXsmall':
-    case 'bodyShortSmall':
-    case 'bodyShortMedium':
-    case 'bodyShortLarge':
-    case 'bodyLongXsmall':
-    case 'bodyLongSmall':
-    case 'bodyLongMedium':
-    case 'bodyLongLarge':
-    case 'leadMedium':
+    case 'body-short-xsmall':
+    case 'body-short-small':
+    case 'body-short-medium':
+    case 'body-short-large':
+    case 'body-long-xsmall':
+    case 'body-long-small':
+    case 'body-long-medium':
+    case 'body-long-large':
+    case 'lead-medium':
     default:
       return 'p';
   }
@@ -119,10 +114,6 @@ export const inlineElements: Array<ElementType> = [
 
 export const isInlineElement = (as: ElementType): as is InlineElement =>
   inlineElements.indexOf(as) !== -1;
-
-export function getTypographyCn(value: TypographyType): HyphenTypographyType {
-  return convertCamelToHyphen(value) as HyphenTypographyType;
-}
 
 export const getColorCn = (color?: TextColor) => {
   if (!isTextColor(color)) return null;

--- a/packages/dds-components/src/components/Typography/stories/Examples.stories.tsx
+++ b/packages/dds-components/src/components/Typography/stories/Examples.stories.tsx
@@ -13,7 +13,7 @@ export const Article = meta.story(() => {
       <Heading level={1} withMargins>
         Vitne
       </Heading>
-      <Paragraph typographyType="leadMedium" withMargins>
+      <Paragraph typographyType="lead-medium" withMargins>
         Et vitne har sett, hørt eller erfart noe av betydning for en rettssak.
         Denne siden er for deg som skal vitne i en straffesak eller en sivil
         sak.

--- a/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/Calendar.tsx
+++ b/packages/dds-components/src/components/date-inputs/DatePicker/Calendar/Calendar.tsx
@@ -85,7 +85,7 @@ export function Calendar<T extends DateValue>(props: CalendarProps<T>) {
         />
         <Heading
           level={2}
-          typographyType="headingXsmall"
+          typographyType="heading-xsmall"
           className={styles.calendar__header__month}
         >
           {title}

--- a/packages/dds-components/src/components/helpers/CharCounter/CharCounter.tsx
+++ b/packages/dds-components/src/components/helpers/CharCounter/CharCounter.tsx
@@ -23,7 +23,7 @@ export function CharCounter(props: CharCounterProps) {
       id={uniqueId}
       className={styles.container}
       as="div"
-      typographyType="bodyShortXsmall"
+      typographyType="body-short-xsmall"
       color="text-subtle"
     >
       <span aria-hidden>

--- a/packages/dds-components/src/storybook/decorators.tsx
+++ b/packages/dds-components/src/storybook/decorators.tsx
@@ -79,7 +79,9 @@ export const windowWidthDecorator = (Story: ReactNode, intro?: string) => {
           {width}px
         </span>
       </HStack>
-      {intro && <Paragraph typographyType="bodyShortSmall">{intro}</Paragraph>}
+      {intro && (
+        <Paragraph typographyType="body-short-small">{intro}</Paragraph>
+      )}
       {Story}
     </VStack>
   );

--- a/packages/dds-components/src/storybook/helpers.tsx
+++ b/packages/dds-components/src/storybook/helpers.tsx
@@ -7,5 +7,5 @@ export const labelText = (t: string) => t.charAt(0).toUpperCase() + t.slice(1);
 
 /** Storybook-hjelper: Viser enestående navn til variantene i en oversikt, uten at de er semantiske ledetekster */
 export const StoryLabel = (props: { children: ReactNode }) => (
-  <Typography {...props} as="span" typographyType="labelMedium" />
+  <Typography {...props} as="span" typographyType="label-medium" />
 );

--- a/packages/dds-components/src/utils/dom.ts
+++ b/packages/dds-components/src/utils/dom.ts
@@ -7,13 +7,6 @@ export function cn(...classNames: Array<unknown>) {
   return filtered || undefined;
 }
 
-export function convertCamelToHyphen(value: string) {
-  return value
-    .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .replace(/([a-z])([0-9])/g, '$1-$2')
-    .toLowerCase();
-}
-
 export const defaultPortalTarget = () =>
   document.getElementsByClassName('dds-themed')[0] as HTMLElement;
 

--- a/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswers.stories.tsx
+++ b/packages/dds-components/stories/patterns/CheckAnswers/CheckAnswers.stories.tsx
@@ -111,7 +111,7 @@ export const CheckAnswers = meta.story({
           }}
         >
           <Fieldset>
-            <Legend withMarginsOverInput typographyType="headingMedium">
+            <Legend withMarginsOverInput typographyType="heading-medium">
               Møte nr 1
             </Legend>
             <FieldsetGroup>
@@ -130,7 +130,7 @@ export const CheckAnswers = meta.story({
             </FieldsetGroup>
           </Fieldset>
           <Fieldset>
-            <Legend withMarginsOverInput typographyType="headingMedium">
+            <Legend withMarginsOverInput typographyType="heading-medium">
               Møte nr 2
             </Legend>
             <FieldsetGroup>
@@ -282,12 +282,12 @@ export const CheckAnswers = meta.story({
             <Heading withMargins level={1}>
               Navn på skjema
             </Heading>
-            <Paragraph typographyType="leadMedium" withMargins>
+            <Paragraph typographyType="lead-medium" withMargins>
               Dette er et eksempel på en ingress. Den består ofte av et par
               setninger. En setning til.
             </Paragraph>
             <Paragraph
-              typographyType="bodyLongSmall"
+              typographyType="body-long-small"
               color="text-subtle"
               withMargins
             >

--- a/packages/dds-components/stories/patterns/Form/Form.stories.tsx
+++ b/packages/dds-components/stories/patterns/Form/Form.stories.tsx
@@ -76,13 +76,13 @@ export const Form = meta.story({
             <Heading level={1} withMargins>
               Navn på skjema
             </Heading>
-            <Paragraph withMargins typographyType="leadMedium">
+            <Paragraph withMargins typographyType="lead-medium">
               Dette er et eksempel på en ingress. Den består ofte av et par
               setninger. En setning til.
             </Paragraph>
             <Paragraph
               withMargins
-              typographyType="bodyLongSmall"
+              typographyType="body-long-small"
               color="text-subtle"
             >
               Obligatoriske felter er merket med{' '}
@@ -199,7 +199,7 @@ export const FormWithSteps = meta.story({
           }}
         >
           <Fieldset>
-            <Legend withMarginsOverInput typographyType="headingMedium">
+            <Legend withMarginsOverInput typographyType="heading-medium">
               Overskrift for gruppe
             </Legend>
 
@@ -214,7 +214,7 @@ export const FormWithSteps = meta.story({
             </FieldsetGroup>
           </Fieldset>
           <Fieldset>
-            <Legend withMarginsOverInput typographyType="headingMedium">
+            <Legend withMarginsOverInput typographyType="heading-medium">
               Overskrift for gruppe
             </Legend>
             <FieldsetGroup>
@@ -228,7 +228,7 @@ export const FormWithSteps = meta.story({
             </FieldsetGroup>
           </Fieldset>
           <Fieldset>
-            <Legend withMarginsOverInput typographyType="headingMedium">
+            <Legend withMarginsOverInput typographyType="heading-medium">
               Adresse
             </Legend>
             <FieldsetGroup>
@@ -272,7 +272,7 @@ export const FormWithSteps = meta.story({
           }}
         >
           <Fieldset>
-            <Legend withMarginsOverInput typographyType="headingMedium">
+            <Legend withMarginsOverInput typographyType="heading-medium">
               Overskrift for gruppe
             </Legend>
             <FieldsetGroup>
@@ -286,7 +286,7 @@ export const FormWithSteps = meta.story({
             </FieldsetGroup>
           </Fieldset>
           <Fieldset>
-            <Legend withMarginsOverInput typographyType="headingMedium">
+            <Legend withMarginsOverInput typographyType="heading-medium">
               Overskrift for gruppe
             </Legend>
             <FieldsetGroup>
@@ -330,12 +330,12 @@ export const FormWithSteps = meta.story({
             <Heading withMargins level={1}>
               Navn på skjema
             </Heading>
-            <Paragraph typographyType="leadMedium" withMargins>
+            <Paragraph typographyType="lead-medium" withMargins>
               Dette er et eksempel på en ingress. Den består ofte av et par
               setninger. En setning til.
             </Paragraph>
             <Paragraph
-              typographyType="bodyLongSmall"
+              typographyType="body-long-small"
               color="text-subtle"
               withMargins
             >
@@ -458,7 +458,7 @@ export const FormWithStepsCustomGrid = meta.story({
         >
           <VStack gap="x1">
             <Fieldset>
-              <Legend withMarginsOverInput typographyType="headingMedium">
+              <Legend withMarginsOverInput typographyType="heading-medium">
                 Overskrift for gruppe
               </Legend>
               <FieldsetGroup>
@@ -472,7 +472,7 @@ export const FormWithStepsCustomGrid = meta.story({
               </FieldsetGroup>
             </Fieldset>
             <Fieldset>
-              <Legend withMarginsOverInput typographyType="headingMedium">
+              <Legend withMarginsOverInput typographyType="heading-medium">
                 Overskrift for gruppe
               </Legend>
               <FieldsetGroup>
@@ -486,7 +486,7 @@ export const FormWithStepsCustomGrid = meta.story({
               </FieldsetGroup>
             </Fieldset>
             <Fieldset>
-              <Legend withMarginsOverInput typographyType="headingMedium">
+              <Legend withMarginsOverInput typographyType="heading-medium">
                 Adresse
               </Legend>
               <FieldsetGroup>
@@ -528,7 +528,7 @@ export const FormWithStepsCustomGrid = meta.story({
           noValidate
         >
           <Fieldset>
-            <Legend withMarginsOverInput typographyType="headingMedium">
+            <Legend withMarginsOverInput typographyType="heading-medium">
               Overskrift for gruppe
             </Legend>
             <FieldsetGroup>
@@ -542,7 +542,7 @@ export const FormWithStepsCustomGrid = meta.story({
             </FieldsetGroup>
           </Fieldset>
           <Fieldset>
-            <Legend withMarginsOverInput typographyType="headingMedium">
+            <Legend withMarginsOverInput typographyType="heading-medium">
               Overskrift for gruppe
             </Legend>
             <FieldsetGroup>
@@ -577,11 +577,11 @@ export const FormWithStepsCustomGrid = meta.story({
           <GridChild>
             <VStack gap="x1">
               <Heading level={1}>Navn på skjema</Heading>
-              <Paragraph typographyType="leadMedium">
+              <Paragraph typographyType="lead-medium">
                 Dette er et eksempel på en ingress. Den består ofte av et par
                 setninger. En setning til.
               </Paragraph>
-              <Paragraph typographyType="bodyLongSmall" color="text-subtle">
+              <Paragraph typographyType="body-long-small" color="text-subtle">
                 Obligatoriske felter er merket med{' '}
                 <Typography as="span" color="text-requiredfield">
                   *
@@ -776,13 +776,13 @@ export const ExitForm = meta.story({
                 <Heading level={1} withMargins>
                   Navn på skjema
                 </Heading>
-                <Paragraph withMargins typographyType="leadMedium">
+                <Paragraph withMargins typographyType="lead-medium">
                   Dette er et eksempel på en ingress. Den består ofte av et par
                   setninger. En setning til.
                 </Paragraph>
                 <Paragraph
                   withMargins
-                  typographyType="bodyLongSmall"
+                  typographyType="body-long-small"
                   color="text-subtle"
                 >
                   Obligatoriske felter er merket med{' '}

--- a/packages/dds-components/stories/patterns/Validation/Validation.stories.tsx
+++ b/packages/dds-components/stories/patterns/Validation/Validation.stories.tsx
@@ -67,13 +67,13 @@ export const SimpleWithErrors = meta.story({
             <Heading level={1} withMargins>
               Navn på skjema
             </Heading>
-            <Paragraph withMargins typographyType="leadMedium">
+            <Paragraph withMargins typographyType="lead-medium">
               Dette er et eksempel på en ingress. Den består ofte av et par
               setninger. En setning til.
             </Paragraph>
             <Paragraph
               withMargins
-              typographyType="bodyLongSmall"
+              typographyType="body-long-small"
               color="text-subtle"
             >
               Obligatoriske felter er merket med{' '}
@@ -440,12 +440,12 @@ export const Wizard = meta.story({
             <Heading withMargins level={1}>
               Navn på skjema
             </Heading>
-            <Paragraph typographyType="leadMedium" withMargins>
+            <Paragraph typographyType="lead-medium" withMargins>
               Dette er et eksempel på en ingress. Den består ofte av et par
               setninger. En setning til.
             </Paragraph>
             <Paragraph
-              typographyType="bodyLongSmall"
+              typographyType="body-long-small"
               color="text-subtle"
               withMargins
             >

--- a/stories/Tokens/utils/ColorsGenerator.tsx
+++ b/stories/Tokens/utils/ColorsGenerator.tsx
@@ -199,12 +199,12 @@ export const DataColorsBaseGenerator = () => {
                 background: token.value,
               }}
             />
-            <Heading level={2} typographyType="headingXsmall">
+            <Heading level={2} typographyType="heading-xsmall">
               {tokenName}
             </Heading>
             <Typography
               as="span"
-              typographyType="bodyShortSmall"
+              typographyType="body-short-small"
               color="text-medium"
             >
               {token.value}
@@ -214,7 +214,7 @@ export const DataColorsBaseGenerator = () => {
       }
       categoryContainers.push(
         <div key={key1}>
-          <Heading level={2} withMargins typographyType="headingMedium">
+          <Heading level={2} withMargins typographyType="heading-medium">
             {key1}
           </Heading>
           <HStack as={StylelessList} gap="x1" maxWidth="900px" flexWrap="wrap">
@@ -261,12 +261,12 @@ export const ColorsBaseGenerator = () => {
                 background: token.value,
               }}
             />
-            <Heading level={2} typographyType="headingXsmall">
+            <Heading level={2} typographyType="heading-xsmall">
               {tokenName}
             </Heading>
             <Typography
               as="span"
-              typographyType="bodyShortSmall"
+              typographyType="body-short-small"
               color="text-medium"
             >
               {token.value}
@@ -279,7 +279,7 @@ export const ColorsBaseGenerator = () => {
           <Heading
             level={2}
             withMargins
-            typographyType="headingMedium"
+            typographyType="heading-medium"
             className="category-heading"
           >
             {key1}


### PR DESCRIPTION
## Beskrivelse

🚨 BREAKING:

Prop `typographyType` velger typografistil, og støttes i mange komponenter som `<Heading>`, `<Paragraph>`, `<List>`, `<AccordionHeader>`. Hittil har den støttet verdier med camelCase-format, som `headingMedium`, `bodyLongSmall` osv. Dette bryter med konvensjonen vår der props som setter CSS-variabler og design tokens bruker kebab-case. Denne forskjellen gjør at vi må konvertere mellom formatene når vi setter CSS for typografi, noe som fører til lavere vedlikeholdbarhet.

Vi migrerer dermed til å bruke kebab-case: `heading-medium`, `body-long-small` osv.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
