### PR TITLE
ELSA1-652: Oppdaterer `borderRadius` prop i `<Skeleton>` til å bruke design tokens nøkler

### DIFF
--- a/.changeset/eight-jokes-bathe.md
+++ b/.changeset/eight-jokes-bathe.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Utvider `background` prop i `<Paper>` til å støtte verdi `surface-skeleton`.

--- a/.changeset/twenty-chicken-beg.md
+++ b/.changeset/twenty-chicken-beg.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': major
+---
+
+Prop `borderRadius` i `<Skeleton>` støtter kun verdier som tilsvarer design tokens for border radius. Se [dds-components migreringsguiden v23 til v24](https://design.domstol.no/987b33f71/p/04eb89-v23-til-v24).

--- a/packages/dds-components/src/components/Skeleton/Skeleton.module.css
+++ b/packages/dds-components/src/components/Skeleton/Skeleton.module.css
@@ -9,7 +9,6 @@
 
 .container {
   animation: ddsSkeletonAnimation var(--dds-motion-animation-skeleton);
-  background-color: var(--dds-color-surface-skeleton);
 
   @media (prefers-reduced-motion: reduce) {
     animation: none;

--- a/packages/dds-components/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/dds-components/src/components/Skeleton/Skeleton.stories.tsx
@@ -35,7 +35,7 @@ export const Overview = meta.story({
   },
   render: args => (
     <StoryVStack>
-      <Skeleton {...args} borderRadius="var(--dds-border-radius-rounded)" />
+      <Skeleton {...args} borderRadius="rounded" />
       <Skeleton {...args} width="320px" />
     </StoryVStack>
   ),
@@ -46,7 +46,7 @@ export const Example = meta.story({
     <StoryVStack>
       <Skeleton
         {...args}
-        borderRadius="var(--dds-border-radius-rounded)"
+        borderRadius="rounded"
         width="var(--dds-spacing-x4)"
         height="var(--dds-spacing-x4)"
       />
@@ -57,7 +57,7 @@ export const Example = meta.story({
         {...args}
         width="60px"
         height="var(--dds-spacing-x2-5)"
-        borderRadius="var(--dds-border-radius-button)"
+        borderRadius="button"
         style={{ marginTop: 'var(--dds-spacing-x1)' }}
       />
     </StoryVStack>
@@ -103,7 +103,7 @@ export const Responsive = meta.story({
         }}
       >
         <Skeleton
-          borderRadius="var(--dds-border-radius-rounded)"
+          borderRadius="rounded"
           width={{
             xs: '80px',
             sm: '75px',
@@ -174,7 +174,7 @@ export const Responsive = meta.story({
             xl: '110px',
           }}
           height="50px"
-          borderRadius="var(--dds-border-radius-button)"
+          borderRadius="button"
         />
       </Box>
     </VStack>

--- a/packages/dds-components/src/components/Skeleton/Skeleton.tsx
+++ b/packages/dds-components/src/components/Skeleton/Skeleton.tsx
@@ -1,24 +1,23 @@
-import { type Property } from 'csstype';
 import { type ComponentPropsWithRef } from 'react';
 
 import styles from './Skeleton.module.css';
 import { cn } from '../../utils';
-import { Box, type ResponsiveProps } from '../layout';
+import { Box, type PaperBorderRadius, type ResponsiveProps } from '../layout';
 
 export type SkeletonAppearance = 'circle' | 'rectangle';
 
 export type SkeletonProps = {
-  /**CSS border radius.
-   * @default "var(--dds-border-radius-surface)"
+  /**Hvor runde hjørner skal være. Støtter dds tokens.
+   * @default "surface"
    */
-  borderRadius?: Property.BorderRadius;
+  borderRadius?: PaperBorderRadius;
 } & Pick<ResponsiveProps, 'width' | 'height'> &
   ComponentPropsWithRef<'div'>;
 
 export const Skeleton = ({
   width,
   height,
-  borderRadius = 'var(--dds-border-radius-surface)',
+  borderRadius = 'surface',
   className,
   style,
   ref,

--- a/packages/dds-components/src/components/Skeleton/Skeleton.tsx
+++ b/packages/dds-components/src/components/Skeleton/Skeleton.tsx
@@ -1,37 +1,30 @@
 import { type ComponentPropsWithRef } from 'react';
 
 import styles from './Skeleton.module.css';
+import { type BorderRadius } from '../..';
 import { cn } from '../../utils';
-import { Box, type PaperBorderRadius, type ResponsiveProps } from '../layout';
-
-export type SkeletonAppearance = 'circle' | 'rectangle';
+import { Paper, type ResponsiveProps } from '../layout';
 
 export type SkeletonProps = {
   /**Hvor runde hjørner skal være. Støtter dds tokens.
    * @default "surface"
    */
-  borderRadius?: PaperBorderRadius;
+  borderRadius?: BorderRadius;
 } & Pick<ResponsiveProps, 'width' | 'height'> &
   ComponentPropsWithRef<'div'>;
 
 export const Skeleton = ({
-  width,
-  height,
   borderRadius = 'surface',
   className,
-  style,
-  ref,
   ...rest
 }: SkeletonProps) => {
   return (
-    <Box
-      width={width}
-      height={height}
-      ref={ref}
+    <Paper
       className={cn(className, styles.container)}
-      style={{ ...style, borderRadius }}
+      borderRadius={borderRadius}
+      background="surface-skeleton"
       {...rest}
-    ></Box>
+    />
   );
 };
 

--- a/packages/dds-components/src/components/layout/Paper/Paper.module.css
+++ b/packages/dds-components/src/components/layout/Paper/Paper.module.css
@@ -7,9 +7,6 @@
 
 :where(.container) {
   box-sizing: border-box;
-  background-color: var(--dds-color-surface-default);
-  border-radius: var(--dds-border-radius-surface);
-  margin: 0;
 }
 
 :where(.shadow--small) {
@@ -20,28 +17,4 @@
 }
 :where(.shadow--large) {
   box-shadow: var(--dds-shadow-large);
-}
-
-:where(.border-radius--button) {
-  border-radius: var(--dds-border-radius-button);
-}
-
-:where(.border-radius--surface) {
-  border-radius: var(--dds-border-radius-surface);
-}
-
-:where(.border-radius--chip) {
-  border-radius: var(--dds-border-radius-chip);
-}
-
-:where(.border-radius--input) {
-  border-radius: var(--dds-border-radius-input);
-}
-
-:where(.border-radius--rounded) {
-  border-radius: var(--dds-border-radius-rounded);
-}
-
-:where(.border-radius--0) {
-  border-radius: 0;
 }

--- a/packages/dds-components/src/components/layout/Paper/Paper.tsx
+++ b/packages/dds-components/src/components/layout/Paper/Paper.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from '../../../utils';
 import { Box } from '../../layout/Box/Box';
 import { type ResponsiveProps } from '../common';
+import surfaceStyles from '../common/surface.module.css';
 import { getCSSProperties } from '../common/utils';
 
 export type PaperElevation = Elevation;
@@ -63,7 +64,7 @@ export const Paper = <T extends ElementType = 'div'>({
           className,
           styles.container,
           elevation && styles[`shadow--${elevation}`],
-          borderRadius && styles[`border-radius--${borderRadius}`],
+          surfaceStyles[`border-radius--${borderRadius}`],
           styles.background,
           border && styles.border,
         ),

--- a/packages/dds-components/src/components/layout/common/surface.module.css
+++ b/packages/dds-components/src/components/layout/common/surface.module.css
@@ -1,0 +1,23 @@
+:where(.border-radius--button) {
+  border-radius: var(--dds-border-radius-button);
+}
+
+:where(.border-radius--surface) {
+  border-radius: var(--dds-border-radius-surface);
+}
+
+:where(.border-radius--chip) {
+  border-radius: var(--dds-border-radius-chip);
+}
+
+:where(.border-radius--input) {
+  border-radius: var(--dds-border-radius-input);
+}
+
+:where(.border-radius--rounded) {
+  border-radius: var(--dds-border-radius-rounded);
+}
+
+:where(.border-radius--0) {
+  border-radius: 0;
+}

--- a/packages/dds-components/src/types/Surface.tsx
+++ b/packages/dds-components/src/types/Surface.tsx
@@ -26,6 +26,7 @@ const BACKGROUNDS = [
   'surface-default',
   'surface-subtle',
   'surface-medium',
+  'surface-skeleton',
   'surface-inverse-default',
   'surface-danger-default',
   'surface-danger-strong',


### PR DESCRIPTION
## Beskrivelse

🚨BREAKING:

Hittil har konsumentene typisk satt hardkodet verdi som "2px", som ikke er vedlikeholdbare. Standardiserer dermed propen i samsvar med andre komponenter som bruker CSS props som tilsvarer CSS variabler fra `dds-design-tokens`. Dette betyr at vi ikke lengre støtter vilkårlige verdier for CSS border-radius, kun nøkler for design tokens.

Features:
Støtte for verdi `'surface-skeleton'` i `background` prop i `<Paper>`

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
