### PR TITLE
ELSA1-898: Sletter artefakt i CI hvis deploy mislykkes

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -7,6 +7,7 @@ jobs:
     permissions:
       pages: write
       id-token: write
+      actions: write
     environment:
       name: gh-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -30,7 +31,14 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           # Upload entire repository
-          path: "./storybook-static"
+          path: './storybook-static'
 
       - name: Deploy 🚀
         uses: actions/deploy-pages@v5
+
+      - name: Delete artifact if deployment failed
+        if: ${{ failure() }}
+        uses: geekyeggo/delete-artifact@v5
+        continue-on-error: true
+        with:
+          name: github-pages


### PR DESCRIPTION
## Beskrivelse

Hvis deploy feiler og det kjøres nytt forsøk vil det alltid resultere i flere artefakter, men det forventes kun 1. Github Actions sliter med å fjerne artefakter, så hvis f.eks. actions er nede kan man ikke kjøre på nytt. Vi sletter dermed artefaktene i CI.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
