### PR TITLE
ELSA1-910: Støtte for `typographyType` prop i `<Caption>`

### DIFF
--- a/.changeset/fair-showers-yell.md
+++ b/.changeset/fair-showers-yell.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for `typographyType` prop i `<Caption>`. Den tillater alle typografistiler med `'heading'` prefiks.

--- a/packages/dds-components/src/components/Typography/Caption/Caption.tsx
+++ b/packages/dds-components/src/components/Typography/Caption/Caption.tsx
@@ -2,14 +2,24 @@ import {
   type BaseComponentPropsWithChildren,
   getBaseHTMLProps,
 } from '../../../types';
-import { type CommonBlockTypographyProps, Typography } from '../Typography';
+import {
+  type CommonBlockTypographyProps,
+  Typography,
+  type TypographyHeadingType,
+} from '../Typography';
 
 export type CaptionProps = BaseComponentPropsWithChildren<
   HTMLTableCaptionElement,
-  CommonBlockTypographyProps
+  {
+    /**Typografistil basert på utvalget for HTML heading elementer.
+     * @default 'heading-large'
+     */
+    typographyType?: TypographyHeadingType;
+  } & CommonBlockTypographyProps
 >;
 
 export const Caption = ({
+  typographyType = 'heading-large',
   id,
   className,
   style,
@@ -20,7 +30,7 @@ export const Caption = ({
   return (
     <Typography
       {...getBaseHTMLProps(id, className, style, htmlProps, rest)}
-      typographyType="heading-large"
+      typographyType={typographyType}
       as="caption"
     >
       {children}


### PR DESCRIPTION

## Beskrivelse

Den tillater alle typografistiler med `'heading'` prefiks.


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
