### PR TITLE
ELSA1-912: Hindre at Button loading spinner forsvinner ut av knappen ved scroll

### DIFF
--- a/.changeset/ripe-rocks-eat.md
+++ b/.changeset/ripe-rocks-eat.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': patch
+---
+
+Fikser feil hvor Button-komponentens loading-spinner forsvinner ut av knappen ved scroll

--- a/packages/dds-components/src/components/Button/Button.module.css
+++ b/packages/dds-components/src/components/Button/Button.module.css
@@ -1,6 +1,7 @@
 :where(.button) {
   user-select: text;
   display: inline-flex;
+  position: relative;
   align-items: center;
   justify-content: center;
   width: fit-content;

--- a/packages/dds-components/src/components/InputStepper/InputStepper.module.css
+++ b/packages/dds-components/src/components/InputStepper/InputStepper.module.css
@@ -4,6 +4,11 @@
 .textInput:enabled:read-write {
   text-align: center;
   border-radius: 0;
+
+  &:focus-visible,
+  &[aria-invalid='true'] {
+    z-index: var(--dds-zindex-absolute-element);
+  }
 }
 .stepButton {
   &:focus-visible {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7001,7 +7001,7 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
     optionalDependencies:
-      vitest: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(sass@1.101.0)(terser@5.49.0))
+      vitest: 4.1.10(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@30.0.1)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(sass@1.101.0)(terser@5.49.0))
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:


### PR DESCRIPTION
## Beskrivelse

Fikser en feil hvor Button-komponentens loading-spinner forsvinner ut av knappen når man scroller på siden. Knappen manglet en position relative, mens loading-spinneren hadde position absolute, som gjorde at den beholdt sin plassering i forhold til sin første relative-forelder.

https://github.com/user-attachments/assets/67f8496e-25ee-4bc7-a258-8246d63a4fdd

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)
