### PR TITLE
ELSA1-914: FooterLogo kan ta inn custom logoelement 

### DIFF
--- a/.changeset/pretty-eyes-clap.md
+++ b/.changeset/pretty-eyes-clap.md
@@ -1,0 +1,5 @@
+---
+'@norges-domstoler/dds-components': minor
+---
+
+Støtte for custom bildeelement i `<FooterLogo>` via ny prop: `children`.

--- a/packages/dds-components/src/components/Footer/Footer.mdx
+++ b/packages/dds-components/src/components/Footer/Footer.mdx
@@ -24,7 +24,7 @@ import { Divider } from '../Divider';
 For å bygge layout brukes komponentene `<Grid>` og `<GridChild>` sammen med Footer-subkomponenter, som sørger for fritt struktur og gjennomgående design på tvers av implementasjoner.
 Via bruk av `<Grid>` kan du enkelt sette brekkpunkter for innholdet.
 
-Følgende subkomponenter er tilgjengelige:
+Følgende delkomponenter er tilgjengelige:
 
 - `<Footer>` - selve `<footer>`. Bruker mørk bagrunn og sørger for at alle tekster og ikoner brukt via Elsa-komponenter har kontrasterende farge.
 - `<FooterLogo>` - logo til domstolene. plasseres til venstre.
@@ -54,7 +54,7 @@ Følgende subkomponenter er tilgjengelige:
       <Controls of={FooterStories.Preview} />
     </TabPanel>
     <TabPanel>
-      `<FooterLogo>`. Kan overskrives til egen logo ved behov.
+      `<FooterLogo>`. Viser default logo. Tar inn HTML `<img>` props, eller `children` for custom logo-element istedet.
 
       <Canvas of={FooterStories.Logo} />
       <ArgTypes of={FooterLogo} />

--- a/packages/dds-components/src/components/Footer/Footer.spec.tsx
+++ b/packages/dds-components/src/components/Footer/Footer.spec.tsx
@@ -20,6 +20,18 @@ describe('<Footer>', () => {
       screen.getByRole('img', { name: /norges domstoler/i }),
     ).toBeInTheDocument();
   });
+  it('renders custom logo', () => {
+    render(
+      <Footer>
+        <FooterLogo>
+          <div>Custom Logo</div>
+        </FooterLogo>
+      </Footer>,
+    );
+    expect(
+      screen.getByText(/custom logo/i, { selector: 'div' }),
+    ).toBeInTheDocument();
+  });
   it('renders footer list', () => {
     render(
       <Footer>

--- a/packages/dds-components/src/components/Footer/Footer.stories.tsx
+++ b/packages/dds-components/src/components/Footer/Footer.stories.tsx
@@ -289,6 +289,27 @@ export const Logo = meta.story({
   ),
 });
 
+export const CustomLogo = meta.story({
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  decorators: [
+    Story => (
+      <>
+        <Story />
+        {exampleStyle}
+      </>
+    ),
+  ],
+  render: args => (
+    <Footer {...args} className="story-padding">
+      <FooterLogo>
+        <img alt="Elsa" src="Elsa-logo-hoy.png" />
+      </FooterLogo>
+    </Footer>
+  ),
+});
+
 export const ListHeader = meta.story({
   parameters: {
     chromatic: { disableSnapshot: true },

--- a/packages/dds-components/src/components/Footer/FooterLogo.tsx
+++ b/packages/dds-components/src/components/Footer/FooterLogo.tsx
@@ -8,21 +8,31 @@ type HideBreakpoint = 'xs' | 'sm' | 'md';
 export type FooterLogoProps = ComponentPropsWithRef<'img'> & {
   /**Brekkepunkt når logoen skal skjules på mindre skjerm. */
   hideBreakpoint?: HideBreakpoint;
+  /**Custom logo som ikke er HTML `<img>`. Settes istedenfor `<img>` props. */
+  children?: ComponentPropsWithRef<'div'>['children'];
 };
 
-export const FooterLogo = ({ hideBreakpoint, ...rest }: FooterLogoProps) => {
+export const FooterLogo = ({
+  children,
+  hideBreakpoint,
+  ...rest
+}: FooterLogoProps) => {
   return (
     <Box
       hideBelow={hideBreakpoint ? hideBreakpoint : undefined}
       width="fit-content"
     >
-      <img
-        height={80}
-        width={151}
-        alt="norges domstoler"
-        src={Logo}
-        {...rest}
-      />
+      {children ? (
+        children
+      ) : (
+        <img
+          height={80}
+          width={151}
+          alt="norges domstoler"
+          src={Logo}
+          {...rest}
+        />
+      )}
     </Box>
   );
 };

--- a/packages/dds-components/src/components/Footer/FooterLogo.tsx
+++ b/packages/dds-components/src/components/Footer/FooterLogo.tsx
@@ -5,12 +5,19 @@ import { Box } from '../layout/Box/Box';
 
 type HideBreakpoint = 'xs' | 'sm' | 'md';
 
-export type FooterLogoProps = ComponentPropsWithRef<'img'> & {
+type ImgLogoProps = ComponentPropsWithRef<'img'> & {
+  /**Brekkepunkt når logoen skal skjules på mindre skjerm. */
+  hideBreakpoint?: HideBreakpoint;
+};
+
+interface ChildrenLogoProps {
   /**Brekkepunkt når logoen skal skjules på mindre skjerm. */
   hideBreakpoint?: HideBreakpoint;
   /**Custom logo som ikke er HTML `<img>`. Settes istedenfor `<img>` props. */
-  children?: ComponentPropsWithRef<'div'>['children'];
-};
+  children: ComponentPropsWithRef<'div'>['children'];
+}
+
+export type FooterLogoProps = ImgLogoProps | ChildrenLogoProps;
 
 export const FooterLogo = ({
   children,


### PR DESCRIPTION
## Beskrivelse

Ny prop: `children` for custom logoelement, som f.eks. Next sin `<Image>`. `<img>`-attributter har ingen effekt når den brukes.

## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [x] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
