### PR TITLE
ELSA1-743: rydder oppi type-overloads på tvers av komponenter

### DIFF
--- a/packages/dds-components/src/components/Accordion/AccordionHeader.tsx
+++ b/packages/dds-components/src/components/Accordion/AccordionHeader.tsx
@@ -1,5 +1,3 @@
-import { type ButtonHTMLAttributes } from 'react';
-
 import styles from './Accordion.module.css';
 import {
   type BaseComponentPropsWithChildren,
@@ -26,8 +24,7 @@ export type AccordionHeaderProps = Omit<
       typographyType?: StaticTypographyType;
       /**Angir om teksten skal være i "bold"-format. */
       bold?: boolean;
-    },
-    ButtonHTMLAttributes<HTMLButtonElement>
+    }
   >,
   'id'
 >;

--- a/packages/dds-components/src/components/Card/CardExpandable/CardExpandableHeader.tsx
+++ b/packages/dds-components/src/components/Card/CardExpandable/CardExpandableHeader.tsx
@@ -1,5 +1,4 @@
 import { type Properties, type Property } from 'csstype';
-import { type ButtonHTMLAttributes } from 'react';
 
 import styles from './CardExpandable.module.css';
 import {
@@ -26,8 +25,7 @@ export type CardExpandableHeaderProps = Omit<
       typographyType?: StaticTypographyType;
       /**Angir om teksten skal være i "bold"-format. */
       bold?: boolean;
-    },
-    ButtonHTMLAttributes<HTMLButtonElement>
+    }
   >,
   'id'
 >;

--- a/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectableGroup.tsx
+++ b/packages/dds-components/src/components/Card/CardSelectionControl/CardSelectableGroup.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes, useId } from 'react';
+import { useId } from 'react';
 
 import {
   CardSelectableContext,
@@ -50,8 +50,7 @@ export type CardSelectableGroupProps<T extends string | number> =
         value?: T | undefined;
         /**Default verdi - en `<CardSelectable>` med denne verdien blir forhåndsvalgt med uncontrolled state. */
         defaultValue?: T | undefined;
-      },
-    Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>
+      }
   >;
 
 export const CardSelectableGroup = <T extends string | number = string>({

--- a/packages/dds-components/src/components/Divider/Divider.tsx
+++ b/packages/dds-components/src/components/Divider/Divider.tsx
@@ -1,5 +1,3 @@
-import { type HTMLAttributes } from 'react';
-
 import styles from './Divider.module.css';
 import { type BaseComponentProps, getBaseHTMLProps } from '../../types';
 import { cn } from '../../utils';
@@ -13,8 +11,7 @@ export type DividerProps = BaseComponentProps<
      * @default "default"
      */
     color?: DividerColor;
-  },
-  Omit<HTMLAttributes<HTMLHRElement>, 'color'>
+  }
 >;
 
 export const Divider = ({

--- a/packages/dds-components/src/components/FavStar/FavStar.tsx
+++ b/packages/dds-components/src/components/FavStar/FavStar.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes, useId } from 'react';
+import { useId } from 'react';
 
 import styles from './FavStar.module.css';
 import { useControllableState } from '../../hooks/useControllableState';
@@ -38,8 +38,7 @@ export type FavStarProps = BaseComponentPropsWithChildren<
      * @default "medium"
      */
     size?: ComponentSize;
-  },
-  Omit<HTMLAttributes<HTMLElement>, 'onChange'>
+  }
 >;
 
 export const FavStar = ({

--- a/packages/dds-components/src/components/Pagination/Pagination.tsx
+++ b/packages/dds-components/src/components/Pagination/Pagination.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes, useState } from 'react';
+import { useState } from 'react';
 
 import styles from './Pagination.module.css';
 import { PaginationGenerator } from './paginationGenerator';
@@ -75,8 +75,7 @@ export type PaginationProps = BaseComponentProps<
     onSelectOptionChange?: (option: PaginationOption | null) => void;
     /**Brekkpunkt for små skjermer; den viser færre sideknapper og stacker delkomponentene. */
     smallScreenBreakpoint?: Breakpoint;
-  },
-  Omit<HTMLAttributes<HTMLElement>, 'onChange'>
+  }
 >;
 
 export const Pagination = ({

--- a/packages/dds-components/src/components/Search/Search.tsx
+++ b/packages/dds-components/src/components/Search/Search.tsx
@@ -29,15 +29,14 @@ import { renderLabel } from '../Typography/Label/Label.utils';
 import typographyStyles from '../Typography/typographyStyles.module.css';
 import { VisuallyHidden } from '../VisuallyHidden';
 
-export type SearchProps = Pick<InputProps, 'tip' | 'label'> & {
+export type SearchProps = Pick<InputProps, 'tip' | 'label' | 'width'> & {
   /**Størrelsen på komponenten. */
   componentSize?: SearchSize;
   /**Props for søkeknappen. */
   buttonProps?: SearchButtonProps;
   /**Om søkeikonet skal vises. */
   showIcon?: boolean;
-} & Pick<InputProps, 'width'> &
-  Omit<ComponentPropsWithRef<'input'>, 'width' | 'height'>;
+} & Omit<ComponentPropsWithRef<'input'>, 'width' | 'height'>;
 
 export const Search = ({
   componentSize = 'medium',

--- a/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.tsx
+++ b/packages/dds-components/src/components/SelectionControl/RadioButton/RadioButtonGroup.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, type HTMLAttributes, useId } from 'react';
+import { type ChangeEvent, useId } from 'react';
 
 import {
   RadioButtonGroupContext,
@@ -33,8 +33,7 @@ export type RadioButtonGroupProps<T extends string | number> =
       value?: T | undefined;
       /**Default verdi - en `<RadioButton>` med denne verdien blir forhåndsvalgt med uncontrolled state. */
       defaultValue?: T | undefined;
-    },
-    Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>
+    }
   >;
 
 export const RadioButtonGroup = <T extends string | number = string>({

--- a/packages/dds-components/src/components/Spinner/Spinner.tsx
+++ b/packages/dds-components/src/components/Spinner/Spinner.tsx
@@ -1,5 +1,5 @@
 import { type Property } from 'csstype';
-import { type HTMLAttributes, useId } from 'react';
+import { useId } from 'react';
 
 import styles from './Spinner.module.css';
 import { useTranslation } from '../../i18n';
@@ -22,8 +22,7 @@ export type SpinnerProps = BaseComponentProps<
      * @default "Innlasting pågår"
      */
     tooltip?: string;
-  },
-  Omit<HTMLAttributes<SVGSVGElement>, 'color'>
+  }
 >;
 
 export function Spinner(props: SpinnerProps) {

--- a/packages/dds-components/src/components/Tabs/Tab.tsx
+++ b/packages/dds-components/src/components/Tabs/Tab.tsx
@@ -48,8 +48,7 @@ export type TabProps = BaseComponentPropsWithChildren<
      * @default "1fr"
      */
     width?: CSS.Properties['width'];
-  } & PickedAttributes,
-  Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof PickedAttributes>
+  } & PickedAttributes
 >;
 
 export const Tab = ({

--- a/packages/dds-components/src/components/Tabs/Tabs.spec.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.spec.tsx
@@ -160,6 +160,22 @@ describe('<Tabs>', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it('calls Tabs onChange event', async () => {
+    const onChange = vi.fn();
+    render(
+      <Tabs onChange={onChange}>
+        <TabList>
+          <Tab />
+          <Tab />
+        </TabList>
+      </Tabs>,
+    );
+
+    const [tab2] = screen.getAllByRole('tab');
+    await userEvent.click(tab2);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
   it('tabs are connected to panels via aria-controls accessible name', () => {
     const id = 'id';
     const tab1Text = 'tab1';

--- a/packages/dds-components/src/components/Tabs/Tabs.spec.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.spec.tsx
@@ -171,7 +171,7 @@ describe('<Tabs>', () => {
       </Tabs>,
     );
 
-    const [tab2] = screen.getAllByRole('tab');
+    const tab2 = screen.getAllByRole('tab')[1];
     await userEvent.click(tab2);
     expect(onChange).toHaveBeenCalledTimes(1);
   });

--- a/packages/dds-components/src/components/Tabs/Tabs.tsx
+++ b/packages/dds-components/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import { type HTMLAttributes, useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 
 import { type AddTabButtonProps } from './AddTabButton';
 import { TabsContext } from './Tabs.context';
@@ -28,8 +28,7 @@ export type TabsProps = BaseComponentPropsWithChildren<
     tabContentDirection?: Direction;
     /** Props for "Legg til fane"-knapp. Støtter native HTML attributter og `width`. */
     addTabButtonProps?: Omit<AddTabButtonProps, 'index'>;
-  } & Pick<ResponsiveProps, 'width'>,
-  Omit<HTMLAttributes<HTMLDivElement>, 'onChange'>
+  } & Pick<ResponsiveProps, 'width'>
 >;
 
 export const Tabs = ({

--- a/packages/dds-components/src/components/Tooltip/Tooltip.tsx
+++ b/packages/dds-components/src/components/Tooltip/Tooltip.tsx
@@ -30,11 +30,6 @@ type AnchorElement = ReactElement<
   }
 >;
 
-type PickedHTMLAttributes = Pick<
-  HTMLAttributes<HTMLDivElement>,
-  'style' | 'onMouseLeave' | 'onMouseOver'
->;
-
 export type TooltipProps = BaseComponentProps<
   HTMLDivElement,
   {
@@ -54,8 +49,7 @@ export type TooltipProps = BaseComponentProps<
     tooltipId?: string;
     /**Om tooltip skal alltid være i DOM, eller bli rendret først når den skal vises. */
     keepMounted?: boolean;
-  } & PickedHTMLAttributes,
-  Omit<HTMLAttributes<HTMLDivElement>, 'children' | keyof PickedHTMLAttributes>
+  } & Pick<HTMLAttributes<HTMLDivElement>, 'onMouseLeave' | 'onMouseOver'>
 >;
 
 export const Tooltip = ({

--- a/packages/dds-components/src/components/Typography/Typography/Typography.tsx
+++ b/packages/dds-components/src/components/Typography/Typography/Typography.tsx
@@ -1,4 +1,4 @@
-import { type AnchorHTMLAttributes, type HTMLAttributes } from 'react';
+import { type HTMLAttributes } from 'react';
 
 import styles from './Typography.module.css';
 import {
@@ -31,8 +31,7 @@ type AnchorTypographyProps = BaseComponentPropsWithChildren<
 
     /**nativ `target`-prop ved `typographyType='a'`.  */
     target?: string;
-  },
-  AnchorHTMLAttributes<HTMLAnchorElement>
+  }
 >;
 
 type LabelTypographyProps = BaseComponentPropsWithChildren<

--- a/packages/dds-components/src/types/BaseComponentProps.ts
+++ b/packages/dds-components/src/types/BaseComponentProps.ts
@@ -29,6 +29,12 @@ type CommonComponentProps<
   ref?: TRef;
 };
 
+type HTMLAttributesFor<T extends Element> = T extends HTMLButtonElement
+  ? React.ButtonHTMLAttributes<T>
+  : T extends HTMLAnchorElement
+    ? React.AnchorHTMLAttributes<T>
+    : React.HTMLAttributes<T>;
+
 /**
  * Basetype for props som eksponeres til konsumenter av designsystemet.
  * - Rot: `id`, `className`, `style`, `TOtherProps`
@@ -43,8 +49,8 @@ type CommonComponentProps<
 export type BaseComponentProps<
   TElement extends Element,
   TOtherProps extends object = object,
-  THTMLAttributesProps extends HTMLAttributes<TElement> =
-    HTMLAttributes<TElement>,
+  THTMLAttributesProps extends HTMLAttributesFor<TElement> =
+    HTMLAttributesFor<TElement>,
 > = TOtherProps &
   CommonComponentProps<
     Omit<THTMLAttributesProps, keyof HTMLRootProps | keyof TOtherProps>,
@@ -84,7 +90,7 @@ export type PolymorphicBaseComponentProps<
 export type BaseComponentPropsWithChildren<
   T extends Element,
   TProps extends object = object,
-  THTMLProps extends HTMLAttributes<T> = HTMLAttributes<T>,
+  THTMLProps extends HTMLAttributesFor<T> = HTMLAttributesFor<T>,
 > = BaseComponentProps<
   T,
   TProps & {

--- a/packages/dds-components/src/types/BaseComponentProps.ts
+++ b/packages/dds-components/src/types/BaseComponentProps.ts
@@ -44,7 +44,9 @@ type HTMLAttributesFor<T extends Element> = T extends HTMLButtonElement
  *
  * @template TElement Element-type som genereres av komponenten.
  * @template TOtherProps Andre props komponenten skal eksponere til konsumenter.
- * @template THTMLAttributesProps Standard `HTMLAttributes<T>` men kan overstyres for f.eks knapper hvis man trenger en annen basetype for `htmlProps`.
+ * @template THTMLAttributesProps Standard `HTMLAttributes<T>`;
+ * settes til `ButtonHTMLAttributes<T>` hvis TElement er `HTMLButtonElement` og til `AnchorHTMLAttributes<T>` hvis TElement er `HTMLAnchorElement`.
+ * Kan overstyres hvis man trenger en annen basetype for `htmlProps`.
  */
 export type BaseComponentProps<
   TElement extends Element,


### PR DESCRIPTION
## Beskrivelse

Bakgrunn: 
En gamllem Omit-fiks i `BaseComponentProps.tsx` gjorde at hvis en prop blir satt på roten blir den ekskludert fra `htmlProps` prop ved bruk av `type BaseComponentProps(WithChildren)`. Man slipper dermed å bruke Omit på props våre komponenter har custom, men som overlapper med native HTML attributter, som obskur "`color`, og ofte customisert `onChange`. 

Løsning:
Fjerner dermed  manuelle type overloads via Omit fra props type i en rekke komponenter, bl.a. `CardSelectableGroupProps`, `DividerProps`, `FavStarProps`…

I samme slengen: 
Enkelte komponenter, som semantiske knapper og lenker, bruker ikke `HTMLAttributes` fomr sine HTML props, men f.eks. `ButtonHTMLAttributes` og `AnchorHTMLAttributes`. Oppdaterer `type BaseComponentProps(WithChildren)` slik at dette blir inferred, og fjerner customisering på dette i relevante komponenter (f.eks. `<AccordionHeader>`) .


## Sjekkliste

### Generelt

- [x] Lest [CONTRIBUTING.md](https://github.com/domstolene/designsystem/blob/main/CONTRIBUTING.md)
- [x] Fikk tildelt oppgave i [Elsa Utvikling Jira](https://domstol.atlassian.net/jira/software/c/projects/ELSA1/boards/357)

### PR

- [x] Tydelig beskrivelse av bidraget
- [ ] Hvis PR påvirker en eller flere bibliotek: release entry generert med [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md)

### Ny komponent

- [ ] Jeg legger til ny komponent og har med:
  - [ ] Demoer i `<KomponentNavn>.stories.tsx`
  - [ ] Teknisk dokumentasjon i `<KomponentNavn>.mdx`
  - [ ] Tester i `<KomponentNavn>.spec.tsx`
  - [ ] Styling i `<KomponentNavn>.module.css`
